### PR TITLE
Sass fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17577,12 +17577,12 @@
       }
     },
     "sass": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.18.0.tgz",
-      "integrity": "sha512-Mc579V+BhH693tqt+lvph+gmRqmC6BjtsEVsjkW1944DEA5a0wPuCi781hL3fY4EDuqZnEVPbu42CZRywwE97g==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.23.3.tgz",
+      "integrity": "sha512-1DKRZxJMOh4Bme16AbWTyYeJAjTlrvw2+fWshHHaepeJfGq2soFZTnt0YhWit+bohtDu4LdyPoEj6VFD4APHog==",
       "dev": true,
       "requires": {
-        "chokidar": "^2.0.0"
+        "chokidar": ">=2.0.0 <4.0.0"
       }
     },
     "sass-loader": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@ebury/chameleon-components",
   "version": "0.1.9",
   "main": "src/main.js",
-  "sideEffects": "false",
+  "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",
   "license": "UNLICENSED",
   "scripts": {
@@ -51,7 +51,7 @@
     "eslint-plugin-vue": "5.2.3",
     "lint-staged": "9.4.2",
     "mutation-observer": "1.0.3",
-    "sass": "1.18.0",
+    "sass": "1.23.3",
     "sass-loader": "7.1.0",
     "snapshot-diff": "0.5.2",
     "storybook-vue-router": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/scss/components/_v-tooltip.scss
+++ b/src/scss/components/_v-tooltip.scss
@@ -43,7 +43,7 @@ $ec-tooltip-width-value: 5px;
       border-right-color: transparent;
       border-bottom-color: transparent;
       bottom: -$ec-tooltip-width-value;
-      left: calc(50% - $ec-tooltip-width-value);
+      left: calc(50% - #{$ec-tooltip-width-value});
       margin-top: 0;
       margin-bottom: 0;
     }
@@ -59,7 +59,7 @@ $ec-tooltip-width-value: 5px;
       border-right-color: transparent;
       border-top-color: transparent;
       top: -$ec-tooltip-width-value;
-      left: calc(50% - $ec-tooltip-width-value);
+      left: calc(50% - #{$ec-tooltip-width-value});
       margin-top: 0;
       margin-bottom: 0;
     }
@@ -75,7 +75,7 @@ $ec-tooltip-width-value: 5px;
       border-top-color: transparent;
       border-bottom-color: transparent;
       left: -$ec-tooltip-width-value;
-      top: calc(50% - $ec-tooltip-width-value);
+      top: calc(50% - #{$ec-tooltip-width-value});
       margin-left: 0;
       margin-right: 0;
     }
@@ -91,7 +91,7 @@ $ec-tooltip-width-value: 5px;
       border-right-color: transparent;
       border-bottom-color: transparent;
       right: -$ec-tooltip-width-value;
-      top: calc(50% - $ec-tooltip-width-value);
+      top: calc(50% - #{$ec-tooltip-width-value});
       margin-left: 0;
       margin-right: 0;
     }


### PR DESCRIPTION
latest version of sass spec requires the calc() arguments to be interpolated.

EBO uses `sass@1.23.3` which require all variables in `calc()` being interpolated. see https://sass-lang.com/documentation/syntax/special-functions#calc-element-progid-and-expression.

I have updated `sass` package here and fixed all occurrences.