### PR TITLE
Remove outline from search input in dropdown search and fix the width of the navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ The library is in its initial phase, more components are added regularly.
 
 You can check the current status of the library [here](https://docs.google.com/spreadsheets/d/101NhAtDJ_6YLybdmWnhTvfem9yCtCeHJK5LtCZcX6Rk/edit#gid=0).
 
+Also check out the latest version deployed in [Storybook](https://chameleon.ebury.now.sh/).
+
 ## Installation
 
 Install @ebury/chameleon-components in your project with npm:
@@ -87,12 +89,13 @@ No classes ids or elements! CSS resets, box sizing etc.
 4. Elements -
 Only pure HTML elements like p, h1, h2, div etc.
 
-5. Objects
+5. Objects -
+Layouts and grids
 
 6. Components -
 Classes for specific UI components, most likely you want to add your classes in here.
 
-7. utilities -
+7. Utilities -
 Extremely specific styles that can override all the above
 
 ### Vue app

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.11",
+  "version": "0.1.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/components/ec-dropdown-search/ec-dropdown-search.vue
+++ b/src/components/ec-dropdown-search/ec-dropdown-search.vue
@@ -234,6 +234,7 @@ $ec-dropdown-search-maximum-number-of-items-visible: 5 !default; // search inclu
   &__search-input {
     @include body-text;
 
+    outline: 0;
     width: 100%;
     border: 0;
     padding: $item-horizontal-padding $item-vertical-padding;

--- a/src/components/ec-navigation/ec-navigation.vue
+++ b/src/components/ec-navigation/ec-navigation.vue
@@ -86,12 +86,13 @@ export default {
   overflow-y: auto;
   overflow-x: hidden;
 
-  &--is-collapsed {
-    width: 80px;
+  &--is-collapsable {
+    width: 256px;
+    transition: width 0.5s;
   }
 
-  &--is-collapsable {
-    transition: width 0.5s;
+  &--is-collapsed {
+    width: 80px;
   }
 
   &__branding {


### PR DESCRIPTION
To verify dropdown search:
1. Open any dropdown search story
2. Click the dropdown search element
3. The search input should not have any outline when gaining the focus.

To verify navigation width:
1. Open container with navigation story
2. Check the width of the navigation is 280px when isCollapsable knob is false
3. Check the width of the navigation is 256px when isCollapsable knob is true
4. Verify the navigation can be collapsed.