### PR TITLE
ONL-3966 Reverse status and warning status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/components/ec-user-info/ec-user-info.vue
+++ b/src/components/ec-user-info/ec-user-info.vue
@@ -113,6 +113,7 @@ $ec-user-info-avatar-size: 48px !default;
 
     .ec-user-info--is-collapsable & {
       text-align: left;
+      align-self: center;
     }
   }
 }

--- a/src/scss/components/ec-btn/_ec-btn.scss
+++ b/src/scss/components/ec-btn/_ec-btn.scss
@@ -9,6 +9,8 @@ $ec-btn-success-color: $color-success !default;
 $ec-btn-success-color-hover: $color-success-hover !default;
 $ec-btn-error-color: $color-error !default;
 $ec-btn-error-color-hover: $color-error-hover !default;
+$ec-btn-warning-color: $color-warning !default;
+$ec-btn-warning-color-hover: $color-warning-hover !default;
 $ec-btn-disabled-color: $level-6-disabled-lines !default;
 
 .ec-btn {
@@ -110,11 +112,31 @@ $ec-btn-disabled-color: $level-6-disabled-lines !default;
     }
   }
 
+  &--secondary-reverse {
+    color: $ec-btn-secondary-color;
+    background-color: $ec-btn-color;
+
+    &:hover {
+      color: $ec-btn-color;
+      background-color: $ec-btn-secondary-color;
+    }
+  }
+
   &--success {
     background-color: $ec-btn-success-color;
 
     &:hover {
       background-color: $ec-btn-success-color-hover;
+    }
+  }
+
+  &--success-reverse {
+    color: $ec-btn-success-color;
+    background-color: $ec-btn-color;
+
+    &:hover {
+      color: $ec-btn-color;
+      background-color: $ec-btn-success-color;
     }
   }
 
@@ -126,18 +148,55 @@ $ec-btn-disabled-color: $level-6-disabled-lines !default;
     }
   }
 
+  &--error-reverse {
+    color: $ec-btn-error-color;
+    background-color: $ec-btn-color;
+
+    &:hover {
+      color: $ec-btn-color;
+      background-color: $ec-btn-error-color;
+    }
+  }
+
+  &--warning {
+    background-color: $ec-btn-warning-color;
+
+    &:hover {
+      background-color: $ec-btn-warning-color-hover;
+    }
+  }
+
+  &--warning-reverse {
+    color: $ec-btn-warning-color;
+    background-color: $ec-btn-color;
+
+    &:hover {
+      color: $ec-btn-color;
+      background-color: $ec-btn-warning-color;
+    }
+  }
+
   &--outline {
     border: 1px;
     border-style: solid;
     background-color: transparent;
 
-    &.ec-btn--primary,
-    &.ec-btn--primary-reverse {
+    &.ec-btn--primary {
       color: $ec-btn-primary-color;
       border-color: $ec-btn-primary-color;
 
       &:hover {
         background-color: $ec-btn-primary-color;
+      }
+    }
+
+    &.ec-btn--primary-reverse {
+      color: $ec-btn-color;
+      border-color: $ec-btn-color;
+
+      &:hover {
+        color: $ec-btn-primary-color;
+        background-color: $ec-btn-color;
       }
     }
 
@@ -150,6 +209,16 @@ $ec-btn-disabled-color: $level-6-disabled-lines !default;
       }
     }
 
+    &.ec-btn--secondary-reverse {
+      color: $ec-btn-color;
+      border-color: $ec-btn-color;
+
+      &:hover {
+        color: $ec-btn-secondary-color;
+        background-color: $ec-btn-color;
+      }
+    }
+
     &.ec-btn--success {
       color: $ec-btn-success-color;
       border-color: $ec-btn-success-color;
@@ -159,12 +228,51 @@ $ec-btn-disabled-color: $level-6-disabled-lines !default;
       }
     }
 
+    &.ec-btn--success-reverse {
+      color: $ec-btn-color;
+      border-color: $ec-btn-color;
+
+      &:hover {
+        color: $ec-btn-success-color;
+        background-color: $ec-btn-color;
+      }
+    }
+
     &.ec-btn--error {
       color: $ec-btn-error-color;
       border-color: $ec-btn-error-color;
 
       &:hover {
         background-color: $ec-btn-error-color;
+      }
+    }
+
+    &.ec-btn--error-reverse {
+      color: $ec-btn-color;
+      border-color: $ec-btn-color;
+
+      &:hover {
+        color: $ec-btn-error-color;
+        background-color: $ec-btn-color;
+      }
+    }
+
+    &.ec-btn--warning {
+      color: $ec-btn-warning-color;
+      border-color: $ec-btn-warning-color;
+
+      &:hover {
+        background-color: $ec-btn-warning-color;
+      }
+    }
+
+    &.ec-btn--warning-reverse {
+      color: $ec-btn-color;
+      border-color: $ec-btn-color;
+
+      &:hover {
+        color: $ec-btn-warning-color;
+        background-color: $ec-btn-color;
       }
     }
 

--- a/src/scss/components/ec-btn/_ec-btn.scss
+++ b/src/scss/components/ec-btn/_ec-btn.scss
@@ -16,6 +16,7 @@ $ec-btn-disabled-color: $level-6-disabled-lines !default;
 .ec-btn {
   @include btn;
 
+  outline: 0;
   white-space: nowrap;
   overflow: hidden;
   fill: currentColor;

--- a/src/scss/components/ec-btn/_ec-btn.scss
+++ b/src/scss/components/ec-btn/_ec-btn.scss
@@ -59,6 +59,7 @@ $ec-btn-disabled-color: $level-6-disabled-lines !default;
   }
 
   &--icon-only {
+    width: auto;
     border-radius: 50%;
 
     &.ec-btn--sm {

--- a/src/scss/components/ec-btn/_ec-btn.scss
+++ b/src/scss/components/ec-btn/_ec-btn.scss
@@ -74,6 +74,7 @@ $ec-btn-disabled-color: $level-6-disabled-lines !default;
 
   &:disabled {
     background-color: $ec-btn-disabled-color;
+    color: $ec-btn-color;
     cursor: default;
     pointer-events: none;
   }
@@ -93,6 +94,11 @@ $ec-btn-disabled-color: $level-6-disabled-lines !default;
     &:hover {
       color: $ec-btn-color;
       background-color: $ec-btn-primary-color;
+    }
+
+    &:disabled {
+      background-color: $ec-btn-color;
+      color: $level-5-placeholders;
     }
   }
 

--- a/src/scss/components/ec-btn/_ec-btn.scss
+++ b/src/scss/components/ec-btn/_ec-btn.scss
@@ -98,11 +98,6 @@ $ec-btn-disabled-color: $level-6-disabled-lines !default;
       color: $ec-btn-color;
       background-color: $ec-btn-primary-color;
     }
-
-    &:disabled {
-      background-color: $ec-btn-color;
-      color: $level-5-placeholders;
-    }
   }
 
   &--secondary {

--- a/src/scss/components/ec-btn/ec-btn.story.js
+++ b/src/scss/components/ec-btn/ec-btn.story.js
@@ -125,6 +125,7 @@ stories
         <button class="ec-btn ec-btn--md ec-btn--secondary ec-m--8">Secondary</button>
         <button class="ec-btn ec-btn--sm ec-btn--success ec-m--8">Success</button>
         <button class="ec-btn ec-btn--sm ec-btn--error ec-m--8">Error</button>
+        <button class="ec-btn ec-btn--sm ec-btn--warning ec-m--8">Warning</button>
         <button class="ec-btn ec-btn--sm ec-m--8" disabled>Disabled</button>
 
         <h3 class="ec-m--8">Solid Rounded Buttons</h3>
@@ -132,13 +133,23 @@ stories
         <button class="ec-btn ec-btn--md ec-btn--rounded ec-btn--secondary ec-m--8">Secondary</button>
         <button class="ec-btn ec-btn--sm ec-btn--rounded ec-btn--success ec-m--8">Success</button>
         <button class="ec-btn ec-btn--sm ec-btn--rounded ec-btn--error ec-m--8">Error</button>
+        <button class="ec-btn ec-btn--sm ec-btn--rounded ec-btn--warning ec-m--8">Warning</button>
         <button class="ec-btn ec-btn--sm ec-btn--rounded ec-m--8" disabled>Disabled</button>
+
+        <h3 class="ec-m--8">Rounded Buttons Reverse</h3>
+        <button class="ec-btn ec-btn--md ec-btn--rounded  ec-btn--primary-reverse ec-m--8">Primary</button>
+        <button class="ec-btn ec-btn--md ec-btn--rounded  ec-btn--secondary-reverse ec-m--8">Secondary</button>
+        <button class="ec-btn ec-btn--sm ec-btn--rounded  ec-btn--success-reverse ec-m--8">Success</button>
+        <button class="ec-btn ec-btn--sm ec-btn--rounded  ec-btn--error-reverse ec-m--8">Error</button>
+        <button class="ec-btn ec-btn--sm ec-btn--rounded  ec-btn--warning-reverse ec-m--8">Warning</button>
+        <button class="ec-btn ec-btn--sm ec-btn--rounded  ec-m--8" disabled>Disabled</button>
 
         <h3 class="ec-m--8">Outline Buttons</h3>
         <button class="ec-btn ec-btn--md ec-btn--outline ec-btn--primary ec-m--8">Primary</button>
         <button class="ec-btn ec-btn--md ec-btn--outline ec-btn--secondary ec-m--8">Secondary</button>
         <button class="ec-btn ec-btn--sm ec-btn--outline ec-btn--success ec-m--8">Success</button>
         <button class="ec-btn ec-btn--sm ec-btn--outline ec-btn--error ec-m--8">Error</button>
+        <button class="ec-btn ec-btn--sm ec-btn--outline ec-btn--warning ec-m--8">Warning</button>
         <button class="ec-btn ec-btn--sm ec-m--8 ec-btn--outline" disabled>Disabled</button>
 
         <h3 class="ec-m--8">Outline Rounded Buttons</h3>
@@ -146,6 +157,15 @@ stories
         <button class="ec-btn ec-btn--md ec-btn--rounded ec-btn--outline ec-btn--secondary ec-m--8">Secondary</button>
         <button class="ec-btn ec-btn--sm ec-btn--rounded ec-btn--outline ec-btn--success ec-m--8">Success</button>
         <button class="ec-btn ec-btn--sm ec-btn--rounded ec-btn--outline ec-btn--error ec-m--8">Error</button>
+        <button class="ec-btn ec-btn--sm ec-btn--rounded ec-btn--outline ec-btn--warning ec-m--8">Warning</button>
+        <button class="ec-btn ec-btn--sm ec-btn--rounded ec-btn--outline ec-m--8" disabled>Disabled</button>
+
+        <h3 class="ec-m--8">Outline Rounded Buttons Reverse</h3>
+        <button class="ec-btn ec-btn--md ec-btn--rounded ec-btn--outline ec-btn--primary-reverse ec-m--8">Primary</button>
+        <button class="ec-btn ec-btn--md ec-btn--rounded ec-btn--outline ec-btn--secondary-reverse ec-m--8">Secondary</button>
+        <button class="ec-btn ec-btn--sm ec-btn--rounded ec-btn--outline ec-btn--success-reverse ec-m--8">Success</button>
+        <button class="ec-btn ec-btn--sm ec-btn--rounded ec-btn--outline ec-btn--error-reverse ec-m--8">Error</button>
+        <button class="ec-btn ec-btn--sm ec-btn--rounded ec-btn--outline ec-btn--warning-reverse ec-m--8">Warning</button>
         <button class="ec-btn ec-btn--sm ec-btn--rounded ec-btn--outline ec-m--8" disabled>Disabled</button>
       </div>
     `,

--- a/src/scss/components/ec-btn/ec-btn.story.js
+++ b/src/scss/components/ec-btn/ec-btn.story.js
@@ -37,7 +37,18 @@ stories
         default: select('Size', ['ec-btn--sm', 'ec-btn--md'], 'ec-btn--sm'),
       },
       color: {
-        default: select('Color', ['ec-btn--primary', 'ec-btn--primary-reverse', 'ec-btn--secondary', 'ec-btn--success', 'ec-btn--error'], 'ec-btn--primary'),
+        default: select('Color', [
+          'ec-btn--primary',
+          'ec-btn--primary-reverse',
+          'ec-btn--secondary',
+          'ec-btn--secondary-reverse',
+          'ec-btn--success',
+          'ec-btn--success-reverse',
+          'ec-btn--error',
+          'ec-btn--error-reverse',
+          'ec-btn--warning',
+          'ec-btn--warning-reverse',
+        ], 'ec-btn--primary'),
       },
     },
     computed: {

--- a/src/scss/components/ec-btn/ec-btn.story.js
+++ b/src/scss/components/ec-btn/ec-btn.story.js
@@ -138,14 +138,6 @@ function generateAllForElement(element) {
     data() {
       return {
         element,
-        buttons: [
-          {
-            title: 'Solid Buttons',
-            data: [
-              { classes: '', text: 'Primary' },
-            ],
-          },
-        ],
         types: ['primary', 'secondary', 'success', 'error', 'warning'],
         disabled: [false, true],
         rounded: [false, true],

--- a/src/scss/components/ec-btn/ec-btn.story.js
+++ b/src/scss/components/ec-btn/ec-btn.story.js
@@ -1,11 +1,14 @@
+/* eslint-disable no-use-before-define */
+/* eslint-disable no-plusplus */
 import { storiesOf } from '@storybook/vue';
-import {
-  boolean, number, select, text,
-} from '@storybook/addon-knobs';
+import { boolean, select, text } from '@storybook/addon-knobs';
 import StoryRouter from 'storybook-vue-router';
 import EcIcon from '@/components/ec-icon';
 
 const stories = storiesOf('Button', module);
+
+const darkTheme = { name: 'dark', value: 'rgb(46,54,56)', default: true };
+const lightTheme = { name: 'light', value: '#fff', default: true };
 
 stories
   .addDecorator(StoryRouter())
@@ -116,112 +119,128 @@ stories
       </div>
     `,
   }))
-  .add('all', () => ({
-    template: `
-      <div class="ec-m--20">
+  .add('all buttons (dark)', generateAllForElement('button'), {
+    backgrounds: [darkTheme],
+  })
+  .add('all buttons (light)', generateAllForElement('button'), {
+    backgrounds: [lightTheme],
+  })
+  .add('all anchors (dark)', generateAllForElement('a'), {
+    backgrounds: [darkTheme],
+  })
+  .add('all anchors (light)', generateAllForElement('a'), {
+    backgrounds: [lightTheme],
+  });
 
-        <h3 class="ec-m--8">Solid Buttons</h3>
-        <button class="ec-btn ec-btn--md ec-btn--primary ec-m--8">Primary</button>
-        <button class="ec-btn ec-btn--md ec-btn--secondary ec-m--8">Secondary</button>
-        <button class="ec-btn ec-btn--sm ec-btn--success ec-m--8">Success</button>
-        <button class="ec-btn ec-btn--sm ec-btn--error ec-m--8">Error</button>
-        <button class="ec-btn ec-btn--sm ec-btn--warning ec-m--8">Warning</button>
-        <button class="ec-btn ec-btn--sm ec-m--8" disabled>Disabled</button>
-
-        <h3 class="ec-m--8">Solid Rounded Buttons</h3>
-        <button class="ec-btn ec-btn--md ec-btn--rounded ec-btn--primary ec-m--8">Primary</button>
-        <button class="ec-btn ec-btn--md ec-btn--rounded ec-btn--secondary ec-m--8">Secondary</button>
-        <button class="ec-btn ec-btn--sm ec-btn--rounded ec-btn--success ec-m--8">Success</button>
-        <button class="ec-btn ec-btn--sm ec-btn--rounded ec-btn--error ec-m--8">Error</button>
-        <button class="ec-btn ec-btn--sm ec-btn--rounded ec-btn--warning ec-m--8">Warning</button>
-        <button class="ec-btn ec-btn--sm ec-btn--rounded ec-m--8" disabled>Disabled</button>
-
-        <h3 class="ec-m--8">Rounded Buttons Reverse</h3>
-        <button class="ec-btn ec-btn--md ec-btn--rounded  ec-btn--primary-reverse ec-m--8">Primary</button>
-        <button class="ec-btn ec-btn--md ec-btn--rounded  ec-btn--secondary-reverse ec-m--8">Secondary</button>
-        <button class="ec-btn ec-btn--sm ec-btn--rounded  ec-btn--success-reverse ec-m--8">Success</button>
-        <button class="ec-btn ec-btn--sm ec-btn--rounded  ec-btn--error-reverse ec-m--8">Error</button>
-        <button class="ec-btn ec-btn--sm ec-btn--rounded  ec-btn--warning-reverse ec-m--8">Warning</button>
-        <button class="ec-btn ec-btn--sm ec-btn--rounded  ec-m--8" disabled>Disabled</button>
-
-        <h3 class="ec-m--8">Outline Buttons</h3>
-        <button class="ec-btn ec-btn--md ec-btn--outline ec-btn--primary ec-m--8">Primary</button>
-        <button class="ec-btn ec-btn--md ec-btn--outline ec-btn--secondary ec-m--8">Secondary</button>
-        <button class="ec-btn ec-btn--sm ec-btn--outline ec-btn--success ec-m--8">Success</button>
-        <button class="ec-btn ec-btn--sm ec-btn--outline ec-btn--error ec-m--8">Error</button>
-        <button class="ec-btn ec-btn--sm ec-btn--outline ec-btn--warning ec-m--8">Warning</button>
-        <button class="ec-btn ec-btn--sm ec-m--8 ec-btn--outline" disabled>Disabled</button>
-
-        <h3 class="ec-m--8">Outline Rounded Buttons</h3>
-        <button class="ec-btn ec-btn--md ec-btn--rounded ec-btn--outline ec-btn--primary ec-m--8">Primary</button>
-        <button class="ec-btn ec-btn--md ec-btn--rounded ec-btn--outline ec-btn--secondary ec-m--8">Secondary</button>
-        <button class="ec-btn ec-btn--sm ec-btn--rounded ec-btn--outline ec-btn--success ec-m--8">Success</button>
-        <button class="ec-btn ec-btn--sm ec-btn--rounded ec-btn--outline ec-btn--error ec-m--8">Error</button>
-        <button class="ec-btn ec-btn--sm ec-btn--rounded ec-btn--outline ec-btn--warning ec-m--8">Warning</button>
-        <button class="ec-btn ec-btn--sm ec-btn--rounded ec-btn--outline ec-m--8" disabled>Disabled</button>
-
-        <h3 class="ec-m--8">Outline Rounded Buttons Reverse</h3>
-        <button class="ec-btn ec-btn--md ec-btn--rounded ec-btn--outline ec-btn--primary-reverse ec-m--8">Primary</button>
-        <button class="ec-btn ec-btn--md ec-btn--rounded ec-btn--outline ec-btn--secondary-reverse ec-m--8">Secondary</button>
-        <button class="ec-btn ec-btn--sm ec-btn--rounded ec-btn--outline ec-btn--success-reverse ec-m--8">Success</button>
-        <button class="ec-btn ec-btn--sm ec-btn--rounded ec-btn--outline ec-btn--error-reverse ec-m--8">Error</button>
-        <button class="ec-btn ec-btn--sm ec-btn--rounded ec-btn--outline ec-btn--warning-reverse ec-m--8">Warning</button>
-        <button class="ec-btn ec-btn--sm ec-btn--rounded ec-btn--outline ec-m--8" disabled>Disabled</button>
-      </div>
-    `,
-  }))
-  .add('icon buttons', () => ({
+function generateAllForElement(element) {
+  return () => ({
     components: { EcIcon },
-    props: {
-      iconName: {
-        default: select('Icon name', ['simple-check', 'simple-add', 'simple-dashboard', 'simple-sign-out'], 'simple-add'),
-      },
-      iconSize: {
-        default: number('Icon size', 20),
-      },
-      buttonSize: {
-        default: select('Size', ['ec-btn--sm', 'ec-btn--md'], 'ec-btn--sm'),
-      },
+    data() {
+      return {
+        element,
+        buttons: [
+          {
+            title: 'Solid Buttons',
+            data: [
+              { classes: '', text: 'Primary' },
+            ],
+          },
+        ],
+        types: ['primary', 'secondary', 'success', 'error', 'warning'],
+        disabled: [false, true],
+        rounded: [false, true],
+        outline: [false, true],
+        reverse: [false, true],
+        hasIcon: [false, true],
+        hasIconOnly: [false, true],
+        fullWidth: [false, true],
+        sizes: ['sm', 'md'],
+      };
     },
     computed: {
-      classNames() {
-        return [
-          this.buttonSize,
-        ];
+      blocks() {
+        function cartesian(...args) {
+          const result = [];
+          const max = args.length - 1;
+          function helper(arr, i) {
+            for (let j = 0, l = args[i].length; j < l; j++) {
+              const a = arr.slice(0);
+              a.push(args[i][j]);
+              if (i === max) {
+                result.push(a);
+              } else {
+                helper(a, i + 1);
+              }
+            }
+          }
+          helper([], 0);
+          return result;
+        }
+
+        // generate all possible combinations of props
+        let combinations;
+        if (this.element !== 'a') {
+          combinations = cartesian(this.rounded, this.outline, this.reverse, this.hasIcon, this.hasIconOnly, this.fullWidth, this.sizes, this.disabled);
+        } else {
+          combinations = cartesian(this.rounded, this.outline, this.reverse, this.hasIcon, this.hasIconOnly, this.fullWidth, this.sizes);
+        }
+
+        // each row in the story will represent one combination, and each row will show all button types.
+        return combinations.map(([rounded, outline, reverse, hasIcon, hasIconOnly, fullWidth, size, disabled]) => {
+          const buttons = this.types.map((type) => {
+            const buttonText = type;
+            const classes = {
+              'ec-btn': true,
+              'ec-btn--icon-only': hasIconOnly,
+              'ec-btn--full-width': fullWidth,
+              'ec-btn--rounded': rounded,
+              'ec-btn--outline': outline,
+              [`ec-btn--${type}-reverse`]: reverse,
+              [`ec-btn--${type}`]: !reverse,
+              [`ec-btn--${size}`]: true,
+            };
+
+            return {
+              classes, text: buttonText, hasIcon, hasIconOnly, disabled,
+            };
+          });
+
+          return {
+            buttons,
+            title: [
+              `${size === 'md' ? 'Medium' : 'Small'}`,
+              `${hasIconOnly ? 'icon-only' : ''}`,
+              `${hasIcon ? 'icon' : ''}`,
+              `${outline ? 'outline' : ''}`,
+              `${reverse ? 'reverse' : ''}`,
+              `${fullWidth ? 'full width' : ''}`,
+              `${rounded ? 'rounded' : ''}`,
+              `${disabled ? 'disabled' : ''}`,
+            ].join(' '),
+          };
+        });
       },
     },
     template: `
         <div class="ec-m--20">
-          <button
-            :class="classNames"
-            class="ec-btn ec-btn--primary ec-btn--icon-only">
-            <ec-icon :name="iconName" :size="iconSize" />
-          </button>
-          <button
-            :class="classNames"
-            class="ec-btn ec-btn--primary-reverse ec-btn--icon-only">
-            <ec-icon :name="iconName" :size="iconSize" />
-          </button>
-          <button
-            :class="classNames"
-            class="ec-btn ec-btn--secondary ec-btn--icon-only">
-            <ec-icon :name="iconName" :size="iconSize" />
-          </button>
-          <button
-            :class="classNames"
-            class="ec-btn ec-btn--success ec-btn--icon-only">
-            <ec-icon :name="iconName" :size="iconSize" />
-          </button>
-          <button
-            :class="classNames"
-            class="ec-btn ec-btn--error ec-btn--icon-only">
-            <ec-icon :name="iconName" :size="iconSize" />
-          </button>
-          <button
-          :class="classNames"
-            class="ec-btn ec-btn--icon-only" disabled>
-            <ec-icon :name="iconName" :size="iconSize" />
-          </button>
+        <template v-for="(block, blockIndex) in blocks">
+          <h3 :key="blockIndex" class="ec-m--8" style="color:tomato">{{block.title}}</h3>
+          <component :is="element" v-for="(button, buttonIndex) in block.buttons" :key="blockIndex + '-' + buttonIndex"
+           :class="button.classes"
+           class="ec-m--8"
+           :disabled="button.disabled"
+           >
+            <template v-if="button.hasIconOnly">
+              <ec-icon name="simple-check" :size="24" />
+            </template>
+            <template v-else>
+              <ec-icon v-if="button.hasIcon" class="ec-mr--8" name="simple-check" :size="24" />
+              {{ button.text }}
+            </template>
+           </component>
+        </template>
         </div>
+         
       `,
-  }));
+  });
+}


### PR DESCRIPTION
To test this PR you need to go to the button component and test a new status here is the list of that:

- Primary-reverse with Outline.
- Secondary-reverse
- Secondary-reverse with Outline
- Success-reverse
- Success-reverse with Outline
- Error-reverse
- Error-reverse with Outline
- Warning
- Warning-reverse
- Warning-reverse with Outline

The Frontify needs to be updating to compare with that, I just ask for that change.

Here is the image with all the buttons, you can check it with the [here](https://chameleon-git-onl-3966-reverse-buttons.ebury.now.sh/?path=/story/button--all-buttons-dark)
![image](https://user-images.githubusercontent.com/29793161/68684040-b4b4c800-055f-11ea-8118-ebd79b0f72b6.png)

