### PR TITLE
Focus style for active navigation-link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/components/ec-container/ec-container.story.js
+++ b/src/components/ec-container/ec-container.story.js
@@ -97,7 +97,9 @@ stories
         default: object('menuLinks', [
           { text: 'Link 1', iconName: 'simple-trade', url: '/my-url' },
           { text: 'Link 2', iconName: 'simple-trade-finance', url: '/my-url' },
-          { text: 'Link 3', iconName: 'simple-dashboard', url: '/my-url' },
+          {
+            text: 'Link 3', iconName: 'simple-dashboard', url: '/my-url', isActive: true,
+          },
           { text: 'Link 4', iconName: 'simple-help', url: '/my-url' },
           { text: 'Link 5', iconName: 'simple-calendar', url: '/my-url' },
         ]),
@@ -150,11 +152,11 @@ stories
           </template>
 
           <template #menu>
-            <ec-menu :links="menuLinks" :is-collapsed="isCollapsable && isCollapsed" />
+            <ec-menu :links="menuLinks" :is-collapsed="isCollapsable && isCollapsed" @click.native.stop.prevent />
           </template>
 
           <template #footer-menu>
-            <ec-menu :links="footerLinks" :is-collapsed="isCollapsable && isCollapsed" :horizontal="!isCollapsable || (isCollapsable && !isCollapsed)" />
+            <ec-menu :links="footerLinks" :is-collapsed="isCollapsable && isCollapsed" :horizontal="!isCollapsable || (isCollapsable && !isCollapsed)" @click.native.stop.prevent />
           </template>
 
           <template #copyright v-if="!isCollapsable || !isCollapsed">

--- a/src/components/ec-navigation-link/ec-navigation-link.vue
+++ b/src/components/ec-navigation-link/ec-navigation-link.vue
@@ -161,10 +161,15 @@ $ec-navigation-link-text-color-hover: $level-4-tech-blue !default;
 
   &--is-active {
     background-color: $level-4-tech-blue;
-  }
 
-  &--is-active:hover {
-    color: $ec-navigation-link-text-color;
+    &:hover,
+    &:focus {
+      color: $ec-navigation-link-text-color;
+    }
+
+    &:focus {
+      background-color: rgba($level-4-tech-blue, 0.9);
+    }
   }
 }
 </style>


### PR DESCRIPTION
* Added :focus style for active navigation-link.
* Added active state example to the container story for better visibility.

Currently, the :focus style changes the color of the item to blue, so the text is not visible. We need to keep the white `color` of the text but change the `background-color`.

To verify:
- Open Storybook > Layout > Container > with navigation story
- Check the active navigation item focus using Tab key
- The text should stay white, the background-color should change.