### PR TITLE
Expose eslintrc in the package

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,12 +12,12 @@ module.exports = {
     'max-len': 'off',
     'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
+    'no-param-reassign': ['error', { props: false }],
     'no-restricted-syntax': 'off',
+    'no-use-before-define': 'off',
+
     'import/prefer-default-export': 'off',
-    'vue/require-default-prop': 'off',
-    'vue/multiline-html-element-content-newline': 'off',
-    'vue/singleline-html-element-content-newline': 'off',
-    'vue/component-name-in-template-casing': ['error', 'kebab-case'],
+
     'vue/attributes-order': ['error', {
       order: [
         'GLOBAL',
@@ -29,10 +29,14 @@ module.exports = {
         'TWO_WAY_BINDING',
         'OTHER_DIRECTIVES',
         'OTHER_ATTR',
-        'EVENTS',
         'CONTENT',
+        'EVENTS',
       ],
     }],
+    'vue/component-name-in-template-casing': ['error', 'kebab-case'],
+    'vue/multiline-html-element-content-newline': 'off',
+    'vue/require-default-prop': 'off',
+    'vue/singleline-html-element-content-newline': 'off',
   },
   parserOptions: {
     parser: 'babel-eslint',
@@ -45,13 +49,16 @@ module.exports = {
       env: {
         jest: true,
       },
+      rules: {
+        'global-require': 'off',
+      },
     },
     {
       files: [
         '**/*.story.js',
       ],
       rules: {
-        'import/no-extraneous-dependencies': 0,
+        'import/no-extraneous-dependencies': 'off',
         'vue/require-prop-types': 'off',
       },
     },

--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,6 @@
 .browserslistrc
 .editorconfig
 .eslintignore
-.eslintrc.js
 .out
 .storybook
 babel.config.js

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -24,7 +24,6 @@ module.exports = async ({ config }) => {
     use: ['style-loader', 'css-loader', 'sass-loader'],
     include: path.resolve(__dirname, '../'),
   });
-  // eslint-disable-next-line no-param-reassign
   config.resolve.alias = {
     ...config.resolve.alias,
     '@': path.resolve(__dirname, '..', 'src'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.21",
+  "version": "0.1.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.21",
+  "version": "0.1.23",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/components/ec-container/ec-container.story.js
+++ b/src/components/ec-container/ec-container.story.js
@@ -48,12 +48,10 @@ stories
               const boundaryPadding = 24;
               const width = this.$refs.userInfo.$el.offsetWidth - (2 * boundaryPadding);
               const left = this.$refs.userInfo.$el.offsetLeft + boundaryPadding;
-              /* eslint-disable no-param-reassign */
               data.styles.width = width;
               data.offsets.popper.width = width;
               data.offsets.popper.left = left;
               data.offsets.popper.right = left + width + boundaryPadding;
-              /* eslint-enable */
             }
 
             return data;

--- a/src/components/ec-dropdown-search/ec-dropdown-search.vue
+++ b/src/components/ec-dropdown-search/ec-dropdown-search.vue
@@ -134,7 +134,6 @@ export default {
             enabled: true,
             order: 840,
             fn: /* istanbul ignore next */ (data) => {
-              // eslint-disable-next-line no-param-reassign
               data.styles.width = this.$refs.popperWidthReference.offsetWidth;
               return data;
             },

--- a/src/components/ec-toaster/ec-toaster-touch.js
+++ b/src/components/ec-toaster/ec-toaster-touch.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 export default {
   bind(el, binding, vnode) {
     let startX;

--- a/src/directives/ec-focus-trap/ec-focus-trap.js
+++ b/src/directives/ec-focus-trap/ec-focus-trap.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import focusTrap from 'focus-trap';
 
 export default {


### PR DESCRIPTION
This is preparation for moving EBO code to new folder. We can reuse eslintrc.js and stylelintrc.js in EBO, because of the extend functionality of eslint and stylelint, e.g.
```
// eslintrc.js in EBO
module.exports = {
  extends: [ '@ebury/chameleon-components/.eslintrc.js' ]
}
```

Once we have the monorepo, we can move these rc files into separate packages, publish them and extend EBO and chameleon-components from it.

To verify:
- check the eslintrc.js and stylelintrc.js files are in published package.
- verify there are no errors when running lint task