### PR TITLE
fix: Renamed publish and prepublish scripts to relase and prerelease.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "prestart": "npm run icons",
     "start": "start-storybook -s ./public,./src/assets -p 42475",
     "now-build": "npm run build-storybook",
-    "prepublish": "npm run lint && npm run test",
-    "publish": "npm version patch && npm publish && git push --follow-tags"
+    "prerelease": "npm run lint && npm run test",
+    "release": "npm version patch && npm publish && git push --follow-tags"
   },
   "dependencies": {
     "core-js": "2.6.5",


### PR DESCRIPTION
Recently, we added script into package.json to automate the publish process from local machine:
```
"prepublish": "npm run lint && npm run test",
"publish": "npm version patch && npm publish && git push --follow-tags"
```
Problem: the name `publish` is actually reserved alias, and running `npm publish` inside 'publish' script will re-run the command in infinite loop, publishing the package multiple times.

Check the documentation for publish in https://docs.npmjs.com/misc/scripts#description:
> publish, postpublish: Run AFTER the package is published.

Two solutions here:
1. change commands to this:
```
"prepublish": "npm run lint && npm run test && npm version patch",
"publish": "git push --follow-tags"
```
2. rename the commands to:
```
"prerelease": "npm run lint && npm run test",
"release": "npm version patch && npm publish && git push --follow-tags"
```

I've chosen the second, because it is more clear what those commands do and it explicitly says `npm publish` in it, so it's clear what are the intentions.