### PR TITLE
quickfix:update border color for ec-input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/components/ec-input-field/ec-input-field.vue
+++ b/src/components/ec-input-field/ec-input-field.vue
@@ -103,7 +103,7 @@ export default {
 
 $ec-input-field-text-color: $level-3-body-and-headings !default;
 $ec-input-field-primary-color: $level-4-tech-blue !default;
-$ec-input-field-border-color: $level-5-placeholders !default;
+$ec-input-field-border-color: $level-6-disabled-lines !default;
 $ec-input-field-background-disabled: $level-7-backgrounds !default;
 $ec-input-field-icon-area-size: 42px !default;
 $ec-input-field-icon-color: $ec-input-field-text-color !default;


### PR DESCRIPTION
Update the border color for the text input fields. 

Dropdown search and dropdown are already correct.