### PR TITLE
Passing z-index to from ec-dropdown to ec-popover

### DIFF
--- a/src/components/ec-dropdown-search/__snapshots__/ec-dropdown-search.spec.js.snap
+++ b/src/components/ec-dropdown-search/__snapshots__/ec-dropdown-search.spec.js.snap
@@ -92,6 +92,7 @@ exports[`EcDropdownSearch should add a tooltip for any disabled item 1`] = `
 exports[`EcDropdownSearch should disable the popover when disabled is set 1`] = `
 <ecpopover-stub
   class="ec-dropdown-search__trigger"
+  data-test="ec-popover-dropdown-search"
   disabled="true"
   level=""
   offset="8"
@@ -143,11 +144,11 @@ exports[`EcDropdownSearch should merge given popoverOptions 1`] = `
 - First value
 + Second value
 
-@@ -2,12 +2,12 @@
-    class=\\"ec-dropdown-search\\"
+@@ -3,12 +3,12 @@
   >
     <ecpopover-stub
       class=\\"ec-dropdown-search__trigger\\"
+      data-test=\\"ec-popover-dropdown-search\\"
       level=\\"\\"
 -     offset=\\"8\\"
 -     placement=\\"bottom\\"
@@ -165,7 +166,7 @@ exports[`EcDropdownSearch should merge given tooltipOptions and item.tooltip pro
 - First value
 + Second value
 
-@@ -38,12 +38,12 @@
+@@ -39,12 +39,12 @@
            
           <!---->
            
@@ -255,6 +256,7 @@ exports[`EcDropdownSearch should render as expected 1`] = `
 >
   <ecpopover-stub
     class="ec-dropdown-search__trigger"
+    data-test="ec-popover-dropdown-search"
     level=""
     offset="8"
     placement="bottom"
@@ -307,6 +309,7 @@ exports[`EcDropdownSearch should render given cta slot 1`] = `
 >
   <ecpopover-stub
     class="ec-dropdown-search__trigger"
+    data-test="ec-popover-dropdown-search"
     level=""
     offset="8"
     placement="bottom"
@@ -392,6 +395,7 @@ exports[`EcDropdownSearch should render given default slot 1`] = `
 >
   <ecpopover-stub
     class="ec-dropdown-search__trigger"
+    data-test="ec-popover-dropdown-search"
     level=""
     offset="8"
     placement="bottom"
@@ -449,6 +453,7 @@ exports[`EcDropdownSearch should render given item slot 1`] = `
 >
   <ecpopover-stub
     class="ec-dropdown-search__trigger"
+    data-test="ec-popover-dropdown-search"
     level=""
     offset="8"
     placement="bottom"
@@ -553,6 +558,7 @@ exports[`EcDropdownSearch should render given items slot 1`] = `
 >
   <ecpopover-stub
     class="ec-dropdown-search__trigger"
+    data-test="ec-popover-dropdown-search"
     level=""
     offset="8"
     placement="bottom"

--- a/src/components/ec-dropdown-search/ec-dropdown-search.spec.js
+++ b/src/components/ec-dropdown-search/ec-dropdown-search.spec.js
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import { mount, createLocalVue } from '@vue/test-utils';
 import EcDropdownSearch from './ec-dropdown-search.vue';
+import { withMockedConsole } from '../../../tests/utils/console';
 
 describe('EcDropdownSearch', () => {
   const MockedEcTooltipDirective = {
@@ -54,6 +55,27 @@ describe('EcDropdownSearch', () => {
   it('should render as expected', () => {
     const wrapper = mountDropdownSearch();
     expect(wrapper.element).toMatchSnapshot();
+  });
+
+  it.each([
+    ['modal', false],
+    ['tooltip', false],
+    ['notification', false],
+    ['level-1', false],
+    ['level-2', false],
+    ['level-3', false],
+    ['random', true],
+  ])('should validate if the level prop("%s") is on the allowed array of strings', (str, error) => {
+    if (error) {
+      withMockedConsole((errorSpy) => {
+        mountDropdownSearch({ items, level: str });
+        expect(errorSpy).toHaveBeenCalledTimes(1);
+        expect(errorSpy.mock.calls[0][0]).toContain('Invalid prop: custom validator check failed for prop "level"');
+      });
+    } else {
+      const wrapper = mountDropdownSearch({ items, level: str });
+      expect(wrapper.findByDataTest('ec-popover-dropdown-search').attributes('level')).toBe(str);
+    }
   });
 
   it('should render given default slot', () => {

--- a/src/components/ec-dropdown-search/ec-dropdown-search.vue
+++ b/src/components/ec-dropdown-search/ec-dropdown-search.vue
@@ -6,6 +6,7 @@
     <ec-popover
       ref="popover"
       class="ec-dropdown-search__trigger"
+      data-test="ec-popover-dropdown-search"
       v-bind="{
         open: isOpen,
         disabled: disabled,
@@ -13,6 +14,7 @@
         offset: 8,
         popoverInnerClass: 'ec-dropdown-search__popover',
         popperOptions,
+        level: level,
         ...popoverOptions,
       }"
       @hide="hide"
@@ -110,6 +112,12 @@ export default {
     placeholder: {
       type: String,
       default: 'Search...',
+    },
+    level: {
+      type: String,
+      validator(value) {
+        return ['notification', 'modal', 'tooltip', 'level-1', 'level-2', 'level-3'].includes(value);
+      },
     },
     isSearchEnabled: {
       type: Boolean,

--- a/src/components/ec-dropdown/__snapshots__/ec-dropdown.spec.js.snap
+++ b/src/components/ec-dropdown/__snapshots__/ec-dropdown.spec.js.snap
@@ -91,6 +91,7 @@ exports[`EcDropdown multiple value :props should get disabled when disabled prop
   <div
     class="ec-dropdown-search__trigger"
     data-popover-stub=""
+    data-test="ec-popover-dropdown-search"
     disabled="disabled"
     offset="8"
     placement="bottom"
@@ -106,7 +107,7 @@ exports[`EcDropdown multiple value :props should get disabled when disabled prop
         class="ec-input-field__input ec-input-field__input--has-icon"
         data-test="ec-dropdown__input"
         disabled="disabled"
-        id="ec-input-field-217"
+        id="ec-input-field-259"
         placeholder=""
         readonly="readonly"
         type="text"
@@ -150,7 +151,7 @@ exports[`EcDropdown multiple value :props should pass errorMessage prop to the t
 exports[`EcDropdown multiple value :props should pass label prop to the triggering input 1`] = `
 <label
   class="ec-input-field__label"
-  for="ec-input-field-179"
+  for="ec-input-field-221"
 >
   Random label
 </label>
@@ -160,7 +161,7 @@ exports[`EcDropdown multiple value :props should use placeholder prop 1`] = `
 <input
   class="ec-input-field__input ec-input-field__input--has-icon"
   data-test="ec-dropdown__input"
-  id="ec-input-field-204"
+  id="ec-input-field-246"
   placeholder="Random placeholder"
   readonly="readonly"
   type="text"
@@ -195,6 +196,7 @@ exports[`EcDropdown multiple value should render as expected 1`] = `
   <div
     class="ec-dropdown-search__trigger"
     data-popover-stub=""
+    data-test="ec-popover-dropdown-search"
     offset="8"
     placement="bottom"
     popoverinnerclass="ec-dropdown-search__popover"
@@ -208,7 +210,7 @@ exports[`EcDropdown multiple value should render as expected 1`] = `
       <input
         class="ec-input-field__input ec-input-field__input--has-icon"
         data-test="ec-dropdown__input"
-        id="ec-input-field-117"
+        id="ec-input-field-159"
         placeholder=""
         readonly="readonly"
         type="text"
@@ -266,7 +268,7 @@ exports[`EcDropdown multiple value should render checkbox for each item 1`] = `
     >
       <input
         class="ec-checkbox__input"
-        id="ec-checkbox-137"
+        id="ec-checkbox-179"
         type="checkbox"
       />
        
@@ -281,7 +283,7 @@ exports[`EcDropdown multiple value should render checkbox for each item 1`] = `
          
         <label
           class="ec-checkbox__label"
-          for="ec-checkbox-137"
+          for="ec-checkbox-179"
         >
           <div
             class="ec-dropdown__multiple-item-label"
@@ -303,7 +305,7 @@ exports[`EcDropdown multiple value should render checkbox for each item 1`] = `
     >
       <input
         class="ec-checkbox__input"
-        id="ec-checkbox-138"
+        id="ec-checkbox-180"
         type="checkbox"
       />
        
@@ -318,7 +320,7 @@ exports[`EcDropdown multiple value should render checkbox for each item 1`] = `
          
         <label
           class="ec-checkbox__label"
-          for="ec-checkbox-138"
+          for="ec-checkbox-180"
         >
           <div
             class="ec-dropdown__multiple-item-label"
@@ -340,7 +342,7 @@ exports[`EcDropdown multiple value should render checkbox for each item 1`] = `
     >
       <input
         class="ec-checkbox__input"
-        id="ec-checkbox-139"
+        id="ec-checkbox-181"
         type="checkbox"
       />
        
@@ -355,7 +357,7 @@ exports[`EcDropdown multiple value should render checkbox for each item 1`] = `
          
         <label
           class="ec-checkbox__label"
-          for="ec-checkbox-139"
+          for="ec-checkbox-181"
         >
           <div
             class="ec-dropdown__multiple-item-label"
@@ -378,7 +380,7 @@ exports[`EcDropdown multiple value should render checkbox for each item 1`] = `
       <input
         class="ec-checkbox__input"
         disabled="disabled"
-        id="ec-checkbox-140"
+        id="ec-checkbox-182"
         type="checkbox"
       />
        
@@ -393,7 +395,7 @@ exports[`EcDropdown multiple value should render checkbox for each item 1`] = `
          
         <label
           class="ec-checkbox__label"
-          for="ec-checkbox-140"
+          for="ec-checkbox-182"
         >
           <div
             class="ec-dropdown__multiple-item-label ec-dropdown__multiple-item-label--is-disabled"
@@ -415,7 +417,7 @@ exports[`EcDropdown multiple value should render checkbox for each item 1`] = `
     >
       <input
         class="ec-checkbox__input"
-        id="ec-checkbox-141"
+        id="ec-checkbox-183"
         type="checkbox"
       />
        
@@ -430,7 +432,7 @@ exports[`EcDropdown multiple value should render checkbox for each item 1`] = `
          
         <label
           class="ec-checkbox__label"
-          for="ec-checkbox-141"
+          for="ec-checkbox-183"
         >
           <div
             class="ec-dropdown__multiple-item-label"
@@ -451,27 +453,27 @@ exports[`EcDropdown multiple value should render preselected checkbox for each s
 - First value
 + Second value
 
-@@ -16,11 +16,11 @@
+@@ -17,11 +17,11 @@
         <!---->
          
         <input
           class=\\"ec-input-field__input ec-input-field__input--has-icon\\"
           data-test=\\"ec-dropdown__input\\"
--         id=\\"ec-input-field-146\\"
-+         id=\\"ec-input-field-157\\"
+-         id=\\"ec-input-field-188\\"
++         id=\\"ec-input-field-199\\"
           placeholder=\\"\\"
           readonly=\\"readonly\\"
           type=\\"text\\"
         />
          
-@@ -58,26 +58,34 @@
+@@ -59,26 +59,34 @@
             <div
               class=\\"ec-checkbox ec-dropdown__multiple-item\\"
             >
               <input
                 class=\\"ec-checkbox__input\\"
--               id=\\"ec-checkbox-148\\"
-+               id=\\"ec-checkbox-159\\"
+-               id=\\"ec-checkbox-190\\"
++               id=\\"ec-checkbox-201\\"
                 type=\\"checkbox\\"
               />
                
@@ -496,21 +498,21 @@ exports[`EcDropdown multiple value should render preselected checkbox for each s
                  
                 <label
                   class=\\"ec-checkbox__label\\"
--                 for=\\"ec-checkbox-148\\"
-+                 for=\\"ec-checkbox-159\\"
+-                 for=\\"ec-checkbox-190\\"
++                 for=\\"ec-checkbox-201\\"
                 >
                   <div
                     class=\\"ec-dropdown__multiple-item-label\\"
                   >
                     Item 1
-@@ -95,26 +103,34 @@
+@@ -96,26 +104,34 @@
             <div
               class=\\"ec-checkbox ec-dropdown__multiple-item\\"
             >
               <input
                 class=\\"ec-checkbox__input\\"
--               id=\\"ec-checkbox-149\\"
-+               id=\\"ec-checkbox-161\\"
+-               id=\\"ec-checkbox-191\\"
++               id=\\"ec-checkbox-203\\"
                 type=\\"checkbox\\"
               />
                
@@ -535,21 +537,21 @@ exports[`EcDropdown multiple value should render preselected checkbox for each s
                  
                 <label
                   class=\\"ec-checkbox__label\\"
--                 for=\\"ec-checkbox-149\\"
-+                 for=\\"ec-checkbox-161\\"
+-                 for=\\"ec-checkbox-191\\"
++                 for=\\"ec-checkbox-203\\"
                 >
                   <div
                     class=\\"ec-dropdown__multiple-item-label\\"
                   >
                     Item 2
-@@ -132,26 +148,34 @@
+@@ -133,26 +149,34 @@
             <div
               class=\\"ec-checkbox ec-dropdown__multiple-item\\"
             >
               <input
                 class=\\"ec-checkbox__input\\"
--               id=\\"ec-checkbox-150\\"
-+               id=\\"ec-checkbox-163\\"
+-               id=\\"ec-checkbox-192\\"
++               id=\\"ec-checkbox-205\\"
                 type=\\"checkbox\\"
               />
                
@@ -574,21 +576,21 @@ exports[`EcDropdown multiple value should render preselected checkbox for each s
                  
                 <label
                   class=\\"ec-checkbox__label\\"
--                 for=\\"ec-checkbox-150\\"
-+                 for=\\"ec-checkbox-163\\"
+-                 for=\\"ec-checkbox-192\\"
++                 for=\\"ec-checkbox-205\\"
                 >
                   <div
                     class=\\"ec-dropdown__multiple-item-label\\"
                   >
                     Item 3
-@@ -170,26 +194,34 @@
+@@ -171,26 +195,34 @@
               class=\\"ec-checkbox ec-dropdown__multiple-item\\"
             >
               <input
                 class=\\"ec-checkbox__input\\"
                 disabled=\\"disabled\\"
--               id=\\"ec-checkbox-151\\"
-+               id=\\"ec-checkbox-165\\"
+-               id=\\"ec-checkbox-193\\"
++               id=\\"ec-checkbox-207\\"
                 type=\\"checkbox\\"
               />
                
@@ -613,21 +615,21 @@ exports[`EcDropdown multiple value should render preselected checkbox for each s
                  
                 <label
                   class=\\"ec-checkbox__label\\"
--                 for=\\"ec-checkbox-151\\"
-+                 for=\\"ec-checkbox-165\\"
+-                 for=\\"ec-checkbox-193\\"
++                 for=\\"ec-checkbox-207\\"
                 >
                   <div
                     class=\\"ec-dropdown__multiple-item-label ec-dropdown__multiple-item-label--is-disabled\\"
                   >
                     Item 4
-@@ -207,26 +239,34 @@
+@@ -208,26 +240,34 @@
             <div
               class=\\"ec-checkbox ec-dropdown__multiple-item\\"
             >
               <input
                 class=\\"ec-checkbox__input\\"
--               id=\\"ec-checkbox-152\\"
-+               id=\\"ec-checkbox-167\\"
+-               id=\\"ec-checkbox-194\\"
++               id=\\"ec-checkbox-209\\"
                 type=\\"checkbox\\"
               />
                
@@ -652,8 +654,8 @@ exports[`EcDropdown multiple value should render preselected checkbox for each s
                  
                 <label
                   class=\\"ec-checkbox__label\\"
--                 for=\\"ec-checkbox-152\\"
-+                 for=\\"ec-checkbox-167\\"
+-                 for=\\"ec-checkbox-194\\"
++                 for=\\"ec-checkbox-209\\"
                 >
                   <div
                     class=\\"ec-dropdown__multiple-item-label\\"
@@ -665,7 +667,7 @@ exports[`EcDropdown multiple value should render readonly input as a trigger 1`]
 <input
   class="ec-input-field__input ec-input-field__input--has-icon"
   data-test="ec-dropdown__input"
-  id="ec-input-field-123"
+  id="ec-input-field-165"
   placeholder=""
   readonly="readonly"
   type="text"
@@ -763,6 +765,7 @@ exports[`EcDropdown single value :props should get disabled when disabled prop i
   <div
     class="ec-dropdown-search__trigger"
     data-popover-stub=""
+    data-test="ec-popover-dropdown-search"
     disabled="disabled"
     offset="8"
     placement="bottom"
@@ -778,7 +781,7 @@ exports[`EcDropdown single value :props should get disabled when disabled prop i
         class="ec-input-field__input ec-input-field__input--has-icon"
         data-test="ec-dropdown__input"
         disabled="disabled"
-        id="ec-input-field-66"
+        id="ec-input-field-108"
         placeholder=""
         readonly="readonly"
         type="text"
@@ -822,7 +825,7 @@ exports[`EcDropdown single value :props should pass errorMessage prop to the tri
 exports[`EcDropdown single value :props should pass label prop to the triggering input 1`] = `
 <label
   class="ec-input-field__label"
-  for="ec-input-field-28"
+  for="ec-input-field-70"
 >
   Random label
 </label>
@@ -832,7 +835,7 @@ exports[`EcDropdown single value :props should use placeholder prop 1`] = `
 <input
   class="ec-input-field__input ec-input-field__input--has-icon"
   data-test="ec-dropdown__input"
-  id="ec-input-field-53"
+  id="ec-input-field-95"
   placeholder="Random placeholder"
   readonly="readonly"
   type="text"
@@ -867,6 +870,7 @@ exports[`EcDropdown single value should render as expected 1`] = `
   <div
     class="ec-dropdown-search__trigger"
     data-popover-stub=""
+    data-test="ec-popover-dropdown-search"
     offset="8"
     placement="bottom"
     popoverinnerclass="ec-dropdown-search__popover"

--- a/src/components/ec-dropdown/ec-dropdown.spec.js
+++ b/src/components/ec-dropdown/ec-dropdown.spec.js
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import { mount, createLocalVue } from '@vue/test-utils';
 import EcDropdown from './ec-dropdown.vue';
+import { withMockedConsole } from '../../../tests/utils/console';
 
 describe('EcDropdown', () => {
   const MockedEcPopover = Vue.extend({
@@ -81,6 +82,30 @@ describe('EcDropdown', () => {
       it('should not render any label if prop is not given', () => {
         const wrapper = mountDropdownSingleValue({ label: '' });
         expect(wrapper.find('.ec-input-field__label').exists()).toBe(false);
+      });
+
+      it.each([
+        ['modal', false],
+        ['tooltip', false],
+        ['notification', false],
+        ['level-1', false],
+        ['level-2', false],
+        ['level-3', false],
+        ['random', true],
+      ])('should validate if the level prop("%s") is on the allowed array of strings', (str, error) => {
+        if (error) {
+          withMockedConsole((errorSpy) => {
+            mountDropdown({ items, level: str });
+            expect(errorSpy).toHaveBeenCalledTimes(2);
+            // this is the test for the dropdown
+            expect(errorSpy.mock.calls[0][0]).toContain('Invalid prop: custom validator check failed for prop "level"');
+            // this is the test for the
+            expect(errorSpy.mock.calls[1][0]).toContain('Invalid prop: custom validator check failed for prop "level"');
+          });
+        } else {
+          const wrapper = mountDropdown({ items, level: str });
+          expect(wrapper.findByDataTest('ec-popover-dropdown-search').attributes('level')).toBe(str);
+        }
       });
 
       it('should pass label prop to the triggering input', () => {

--- a/src/components/ec-dropdown/ec-dropdown.vue
+++ b/src/components/ec-dropdown/ec-dropdown.vue
@@ -9,6 +9,7 @@
     data-test="ec-dropdown"
     :keep-open="multiple"
     :disabled="disabled"
+    :level="level"
     @change="onSelected"
   >
     <ec-input-field
@@ -92,6 +93,12 @@ export default {
     label: {
       type: String,
       default: '',
+    },
+    level: {
+      type: String,
+      validator(value) {
+        return ['notification', 'modal', 'tooltip', 'level-1', 'level-2', 'level-3'].includes(value);
+      },
     },
     errorMessage: {
       type: String,


### PR DESCRIPTION
Pairing with @jaimeperezpedra on this.

While working on add supplier modal discovered that ec-dropdown not showing on modal.
We need to pass the level as a prop to the ec-dropdown--> ec-dropdowns-search--> ec-popover

Thoughts about this solution?

