### PR TITLE
fix: Fixed ec-container stretches beyond 100% width 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/components/ec-container/ec-container.vue
+++ b/src/components/ec-container/ec-container.vue
@@ -41,6 +41,7 @@ export default {
 
   &__content {
     flex: 1;
+    min-width: 0;
   }
 }
 </style>


### PR DESCRIPTION
... when the content is too big (e.g. table with many columns)

Every `flex: 1` should have `min-width: 0` because then the element respects the width of the parent and not the width of its children.

How to verify: 
1. go to trade finance view
2. switch the mobile view (e.g. Galaxy S5)
3. the content of the container is >500px because of the submitted requests table (it should be less than 360px). -> bug
4. apply the fix from this PR. -> should be back to normal and the table should be scrollable.