### PR TITLE
fix refs on the buttons of the modal 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.58",
+  "version": "0.1.59",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.58",
+  "version": "0.1.59",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/components/ec-modal/ec-modal.story.js
+++ b/src/components/ec-modal/ec-modal.story.js
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/vue';
-import { boolean, object } from '@storybook/addon-knobs';
+import { boolean } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import EcTooltip from '../../directives/ec-tooltip/ec-tooltip';
 import EcIcon from '../ec-icon';
@@ -41,7 +41,7 @@ stories
         default: boolean('Is Loading Positive Button', false),
       },
       isNegativeLoading: {
-        default: object('Is Loading Negative Button', false),
+        default: boolean('Is Loading Negative Button', false),
       },
     },
     watch: {
@@ -78,8 +78,8 @@ stories
         <ec-modal
           v-if="!isLarge"
           :large = "isLarge"
-          :isClosable="isClosable"
-          :isLoading="{ positive: isPositiveLoading, negative: isNegativeLoading }"
+          :is-closable="isClosable"
+          :is-loading="{ positive: isPositiveLoading, negative: isNegativeLoading }"
           @negative = "rejected()"
           @positive = "accepted()"
           @close = "onClose()"

--- a/src/components/ec-modal/ec-modal.vue
+++ b/src/components/ec-modal/ec-modal.vue
@@ -42,13 +42,13 @@
           </div>
 
           <ec-loading
-            ref="negativeButton"
             v-if="hasNegativeButton()"
             class="ec-modal__btn-loading ec-modal__btn-loading--right"
             :show="isLoadingNegativeButton"
             :transparent="!isLoadingNegativeButton"
           >
             <button
+              ref="negativeButton"
               class="ec-btn ec-btn--md ec-btn--secondary ec-btn--rounded ec-modal__negative-btn "
               @click="negativeAction()"
             >
@@ -57,13 +57,13 @@
           </ec-loading>
 
           <ec-loading
-            ref="primaryButton"
             v-if="hasPrimaryButton()"
             class="ec-modal__btn-loading"
             :show="isLoadingPositiveButton"
             :transparent="!isLoadingPositiveButton"
           >
             <button
+              ref="primaryButton"
               :class="{'ec-modal__positive-btn--right': !hasNegativeButton()}"
               class="ec-btn ec-btn--md ec-btn--primary ec-btn--rounded ec-modal__positive-btn"
               @click="positiveAction()"


### PR DESCRIPTION
Fix refs on the buttons of the modal because was throwing an error o the focus trap.

This was the error:
![image](https://user-images.githubusercontent.com/29793161/74349749-9653a800-4dac-11ea-98eb-046c519141a1.png)
