### PR TITLE
Quickfix ec-loading z-index

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.64",
+  "version": "0.1.65",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/components/ec-loading/ec-loading.vue
+++ b/src/components/ec-loading/ec-loading.vue
@@ -51,6 +51,7 @@ export default {
 </script>
 
 <style lang="scss">
+@import '../../scss/settings/z-index';
 @import '../../scss/settings/colors/index';
 
 .ec-loading {
@@ -63,6 +64,7 @@ export default {
     display: flex;
     justify-content: center;
     align-items: center;
+    z-index: $z-index-loading;
 
     &--is-transparent {
       background: rgba($white, 0.5);

--- a/src/scss/settings/_z-index.scss
+++ b/src/scss/settings/_z-index.scss
@@ -1,4 +1,5 @@
 $z-index-notification: 300;
+$z-index-loading: 250;
 $z-index-modal: 200;
 $z-index-tooltip: 100;
 $z-index-level-1: 10;


### PR DESCRIPTION
On some cases the loading spinner is not visible. In order to work properly we need to add z-index to ensure that will be on top of every other element (except notifications).