### PR TITLE
feat(4293) add action-list scss component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.68",
+  "version": "0.1.69",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/scss/components/_index.scss
+++ b/src/scss/components/_index.scss
@@ -1,3 +1,4 @@
+@import 'ec-action-list/ec-action-list';
 @import 'ec-btn/ec-btn';
 @import 'ec-card/ec-card';
 @import 'ec-grid/ec-grid';

--- a/src/scss/components/ec-action-list/_ec-action-list-group.scss
+++ b/src/scss/components/ec-action-list/_ec-action-list-group.scss
@@ -1,0 +1,7 @@
+.ec-action-list-group {
+  display: flex;
+
+  &--column {
+    flex-direction: column;
+  }
+}

--- a/src/scss/components/ec-action-list/_ec-action-list-item.scss
+++ b/src/scss/components/ec-action-list/_ec-action-list-item.scss
@@ -1,0 +1,13 @@
+.ec-action-list-item {
+  @include shape-border-radius;
+  @include border-level-6;
+
+  padding: 16px;
+  margin: 4px;
+  cursor: pointer;
+
+  &:hover,
+  &:active {
+    background-color: $level-7-backgrounds;
+  }
+}

--- a/src/scss/components/ec-action-list/_ec-action-list.scss
+++ b/src/scss/components/ec-action-list/_ec-action-list.scss
@@ -1,0 +1,2 @@
+@import 'ec-action-list-group';
+@import 'ec-action-list-item';

--- a/src/scss/components/ec-action-list/ec-action-list.story.js
+++ b/src/scss/components/ec-action-list/ec-action-list.story.js
@@ -1,0 +1,49 @@
+import { storiesOf } from '@storybook/vue';
+
+const stories = storiesOf('Action List', module);
+
+stories
+  .add('vertical', () => ({
+    template: `
+    <div style="display: flex; height: 100vh; margin: 10px">
+      <div style="margin: auto; width: 33vw;">
+        <div class="ec-action-list-group ec-action-list-group--column">
+          <div class="ec-action-list-item">
+            <div>Action title</div>
+            <div style="color: #86989c;">Lorem ipsum dolor consectutur</div>
+          </div>
+          <div class="ec-action-list-item">
+            <div>Action title</div>
+            <div style="color: #86989c;">Lorem ipsum dolor consectutur</div>
+          </div>
+          <div class="ec-action-list-item">
+            <div>Action title</div>
+            <div style="color: #86989c;">Lorem ipsum dolor consectutur</div>
+          </div>
+        </div>
+      </div>
+    </div>
+      `,
+  }))
+  .add('horizontal', () => ({
+    template: `
+    <div style="display: flex; height: 100vh; margin: 10px">
+      <div style="margin: auto; width: 66vw;">
+        <div class="ec-action-list-group">
+          <div class="ec-action-list-item">
+            <div>Action title</div>
+            <div style="color: #86989c;">Lorem ipsum dolor consectutut</div>
+          </div>
+          <div class="ec-action-list-item">
+            <div>Action title</div>
+            <div style="color: #86989c;">Lorem ipsum dolor consectutut</div>
+          </div>
+          <div class="ec-action-list-item">
+            <div>Action title</div>
+            <div style="color: #86989c;">Lorem ipsum dolor consectutut</div>
+          </div>
+        </div>
+      </div>
+    </div>
+      `,
+  }));

--- a/src/scss/tools/_borders.scss
+++ b/src/scss/tools/_borders.scss
@@ -9,3 +9,7 @@
 @mixin button-border-radius {
   border-radius: 50px;
 }
+
+@mixin border-level-6 {
+  border: 1px solid $level-6-disabled-lines;
+}


### PR DESCRIPTION
This will be used to build the Download statements panel in the new stack. I decided to add it as a scss component because we will use it also to build the available actions inside the account details panel.

**Download Staments**
![Screenshot_20200309_111919](https://user-images.githubusercontent.com/1553182/76204015-e5e49280-61f7-11ea-862f-5bbdb3fac7de.png)

**Account Panel**
![Screenshot_20200309_111828](https://user-images.githubusercontent.com/1553182/76204029-eaa94680-61f7-11ea-87ac-ba7f575628c9.png)


