### PR TITLE
feat(ONL-4295): Adding back button to EcPanel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.71",
+  "version": "0.1.72",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.72",
+  "version": "0.1.71",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.71",
+  "version": "0.1.72",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.72",
+  "version": "0.1.71",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/components/ec-panel/__snapshots__/ec-panel.spec.js.snap
+++ b/src/components/ec-panel/__snapshots__/ec-panel.spec.js.snap
@@ -74,7 +74,7 @@ exports[`EcPanel #slots #main - should render main slot section if slot is passe
 </aside>
 `;
 
-exports[`EcPanel :props :goBackEnabled - should not render the back button within the panel when is false 1`] = `
+exports[`EcPanel :props :isBackEnabled - should not render the back button within the panel when is false 1`] = `
 <aside
   class="ec-panel"
 >
@@ -108,7 +108,7 @@ exports[`EcPanel :props :goBackEnabled - should not render the back button withi
 </aside>
 `;
 
-exports[`EcPanel :props :goBackEnabled - should render the back button within the panel when is true 1`] = `
+exports[`EcPanel :props :isBackEnabled - should render the back button within the panel when is true 1`] = `
 <aside
   class="ec-panel"
 >

--- a/src/components/ec-panel/__snapshots__/ec-panel.spec.js.snap
+++ b/src/components/ec-panel/__snapshots__/ec-panel.spec.js.snap
@@ -10,13 +10,15 @@ exports[`EcPanel #slots #header - should render header slot section if slot is p
     <div
       class="ec-panel__header-icons"
     >
+      <!---->
+       
       <a
         aria-label="Close panel"
-        class="ec-panel__close"
+        class="ec-panel__header-action ec-panel__header-action--close"
         href="#"
       >
         <svg
-          class="ec-panel__close-icon ec-icon"
+          class="ec-panel__header-icon ec-icon"
           height="24"
           width="24"
         >
@@ -45,13 +47,15 @@ exports[`EcPanel #slots #main - should render main slot section if slot is passe
     <div
       class="ec-panel__header-icons"
     >
+      <!---->
+       
       <a
         aria-label="Close panel"
-        class="ec-panel__close"
+        class="ec-panel__header-action ec-panel__header-action--close"
         href="#"
       >
         <svg
-          class="ec-panel__close-icon ec-icon"
+          class="ec-panel__header-icon ec-icon"
           height="24"
           width="24"
         >
@@ -70,6 +74,88 @@ exports[`EcPanel #slots #main - should render main slot section if slot is passe
 </aside>
 `;
 
+exports[`EcPanel :props :goBackEnabled - should not render the back button within the panel when is false 1`] = `
+<aside
+  class="ec-panel"
+>
+  <div
+    class="ec-panel__header"
+  >
+    <div
+      class="ec-panel__header-icons"
+    >
+      <!---->
+       
+      <a
+        aria-label="Close panel"
+        class="ec-panel__header-action ec-panel__header-action--close"
+        href="#"
+      >
+        <svg
+          class="ec-panel__header-icon ec-icon"
+          height="24"
+          width="24"
+        >
+          <use
+            xlink:href="#ec-simple-close"
+          />
+        </svg>
+      </a>
+    </div>
+     
+  </div>
+   
+</aside>
+`;
+
+exports[`EcPanel :props :goBackEnabled - should render the back button within the panel when is true 1`] = `
+<aside
+  class="ec-panel"
+>
+  <div
+    class="ec-panel__header"
+  >
+    <div
+      class="ec-panel__header-icons"
+    >
+      <a
+        aria-label="Go back"
+        class="ec-panel__header-action ec-panel__header-action--back"
+        href="#"
+      >
+        <svg
+          class="ec-panel__header-icon ec-icon"
+          height="24"
+          width="24"
+        >
+          <use
+            xlink:href="#ec-simple-chevron-left"
+          />
+        </svg>
+      </a>
+       
+      <a
+        aria-label="Close panel"
+        class="ec-panel__header-action ec-panel__header-action--close"
+        href="#"
+      >
+        <svg
+          class="ec-panel__header-icon ec-icon"
+          height="24"
+          width="24"
+        >
+          <use
+            xlink:href="#ec-simple-close"
+          />
+        </svg>
+      </a>
+    </div>
+     
+  </div>
+   
+</aside>
+`;
+
 exports[`EcPanel :props :show - should not render the panel when is false 1`] = `<!---->`;
 
 exports[`EcPanel :props :show - should render the panel when is true 1`] = `
@@ -82,13 +168,15 @@ exports[`EcPanel :props :show - should render the panel when is true 1`] = `
     <div
       class="ec-panel__header-icons"
     >
+      <!---->
+       
       <a
         aria-label="Close panel"
-        class="ec-panel__close"
+        class="ec-panel__header-action ec-panel__header-action--close"
         href="#"
       >
         <svg
-          class="ec-panel__close-icon ec-icon"
+          class="ec-panel__header-icon ec-icon"
           height="24"
           width="24"
         >
@@ -116,13 +204,15 @@ exports[`EcPanel v-model should render the panel when we pass to model true 1`] 
     <div
       class="ec-panel__header-icons"
     >
+      <!---->
+       
       <a
         aria-label="Close panel"
-        class="ec-panel__close"
+        class="ec-panel__header-action ec-panel__header-action--close"
         href="#"
       >
         <svg
-          class="ec-panel__close-icon ec-icon"
+          class="ec-panel__header-icon ec-icon"
           height="24"
           width="24"
         >

--- a/src/components/ec-panel/__snapshots__/ec-panel.spec.js.snap
+++ b/src/components/ec-panel/__snapshots__/ec-panel.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`EcPanel #slots #header - should render header slot section if slot is passed 1`] = `
 <aside
   class="ec-panel"
+  data-test="ec-panel"
 >
   <div
     class="ec-panel__header"
@@ -15,6 +16,7 @@ exports[`EcPanel #slots #header - should render header slot section if slot is p
       <a
         aria-label="Close panel"
         class="ec-panel__header-action ec-panel__header-action--close"
+        data-test="ec-panel__header-action--close"
         href="#"
       >
         <svg
@@ -40,6 +42,7 @@ exports[`EcPanel #slots #header - should render header slot section if slot is p
 exports[`EcPanel #slots #main - should render main slot section if slot is passed 1`] = `
 <aside
   class="ec-panel"
+  data-test="ec-panel"
 >
   <div
     class="ec-panel__header"
@@ -52,6 +55,7 @@ exports[`EcPanel #slots #main - should render main slot section if slot is passe
       <a
         aria-label="Close panel"
         class="ec-panel__header-action ec-panel__header-action--close"
+        data-test="ec-panel__header-action--close"
         href="#"
       >
         <svg
@@ -74,9 +78,12 @@ exports[`EcPanel #slots #main - should render main slot section if slot is passe
 </aside>
 `;
 
-exports[`EcPanel :props :isBackEnabled - should not render the back button within the panel when is false 1`] = `
+exports[`EcPanel :props :show - should not render the panel when is false 1`] = `<!---->`;
+
+exports[`EcPanel :props :show - should render the panel when is true 1`] = `
 <aside
   class="ec-panel"
+  data-test="ec-panel"
 >
   <div
     class="ec-panel__header"
@@ -89,6 +96,7 @@ exports[`EcPanel :props :isBackEnabled - should not render the back button withi
       <a
         aria-label="Close panel"
         class="ec-panel__header-action ec-panel__header-action--close"
+        data-test="ec-panel__header-action--close"
         href="#"
       >
         <svg
@@ -108,9 +116,46 @@ exports[`EcPanel :props :isBackEnabled - should not render the back button withi
 </aside>
 `;
 
-exports[`EcPanel :props :isBackEnabled - should render the back button within the panel when is true 1`] = `
+exports[`EcPanel @events @back should not render back button when event handler attribute is not present 1`] = `
 <aside
   class="ec-panel"
+  data-test="ec-panel"
+>
+  <div
+    class="ec-panel__header"
+  >
+    <div
+      class="ec-panel__header-icons"
+    >
+      <!---->
+       
+      <a
+        aria-label="Close panel"
+        class="ec-panel__header-action ec-panel__header-action--close"
+        data-test="ec-panel__header-action--close"
+        href="#"
+      >
+        <svg
+          class="ec-panel__header-icon ec-icon"
+          height="24"
+          width="24"
+        >
+          <use
+            xlink:href="#ec-simple-close"
+          />
+        </svg>
+      </a>
+    </div>
+     
+  </div>
+   
+</aside>
+`;
+
+exports[`EcPanel @events @back should render back button when event handler attribute is present 1`] = `
+<aside
+  class="ec-panel"
+  data-test="ec-panel"
 >
   <div
     class="ec-panel__header"
@@ -121,6 +166,7 @@ exports[`EcPanel :props :isBackEnabled - should render the back button within th
       <a
         aria-label="Go back"
         class="ec-panel__header-action ec-panel__header-action--back"
+        data-test="ec-panel__header-action--back"
         href="#"
       >
         <svg
@@ -137,42 +183,7 @@ exports[`EcPanel :props :isBackEnabled - should render the back button within th
       <a
         aria-label="Close panel"
         class="ec-panel__header-action ec-panel__header-action--close"
-        href="#"
-      >
-        <svg
-          class="ec-panel__header-icon ec-icon"
-          height="24"
-          width="24"
-        >
-          <use
-            xlink:href="#ec-simple-close"
-          />
-        </svg>
-      </a>
-    </div>
-     
-  </div>
-   
-</aside>
-`;
-
-exports[`EcPanel :props :show - should not render the panel when is false 1`] = `<!---->`;
-
-exports[`EcPanel :props :show - should render the panel when is true 1`] = `
-<aside
-  class="ec-panel"
->
-  <div
-    class="ec-panel__header"
-  >
-    <div
-      class="ec-panel__header-icons"
-    >
-      <!---->
-       
-      <a
-        aria-label="Close panel"
-        class="ec-panel__header-action ec-panel__header-action--close"
+        data-test="ec-panel__header-action--close"
         href="#"
       >
         <svg
@@ -197,6 +208,7 @@ exports[`EcPanel v-model should not render the panel when we pass to model false
 exports[`EcPanel v-model should render the panel when we pass to model true 1`] = `
 <aside
   class="ec-panel"
+  data-test="ec-panel"
 >
   <div
     class="ec-panel__header"
@@ -209,6 +221,7 @@ exports[`EcPanel v-model should render the panel when we pass to model true 1`] 
       <a
         aria-label="Close panel"
         class="ec-panel__header-action ec-panel__header-action--close"
+        data-test="ec-panel__header-action--close"
         href="#"
       >
         <svg

--- a/src/components/ec-panel/ec-panel.spec.js
+++ b/src/components/ec-panel/ec-panel.spec.js
@@ -39,15 +39,15 @@ describe('EcPanel', () => {
       expect(wrapper.element).toMatchSnapshot();
     });
 
-    it(':goBackEnabled - should render the back button within the panel when is true', () => {
-      const wrapper = mountPanel({ show: true, goBackEnabled: true });
+    it(':isBackEnabled - should render the back button within the panel when is true', () => {
+      const wrapper = mountPanel({ show: true, isBackEnabled: true });
 
       expect(wrapper.find('.ec-panel__header-action--back').exists()).toBe(true);
       expect(wrapper.element).toMatchSnapshot();
     });
 
-    it(':goBackEnabled - should not render the back button within the panel when is false', () => {
-      const wrapper = mountPanel({ show: true, goBackEnabled: false });
+    it(':isBackEnabled - should not render the back button within the panel when is false', () => {
+      const wrapper = mountPanel({ show: true, isBackEnabled: false });
 
       expect(wrapper.find('.ec-panel__header-action--back').exists()).toBe(false);
       expect(wrapper.element).toMatchSnapshot();
@@ -64,7 +64,7 @@ describe('EcPanel', () => {
     });
 
     it('@back - should emit both "show-panel" and "back" events when the simple-chevron-left icon is clicked', () => {
-      const wrapper = mountPanel({ show: true, goBackEnabled: true });
+      const wrapper = mountPanel({ show: true, isBackEnabled: true });
       wrapper.find('.ec-panel__header-action--back').trigger('click');
 
       expect(wrapper.emitted('show-panel').length).toBe(1);

--- a/src/components/ec-panel/ec-panel.spec.js
+++ b/src/components/ec-panel/ec-panel.spec.js
@@ -38,20 +38,6 @@ describe('EcPanel', () => {
       expect(wrapper.find('.ec-panel').exists()).toBe(false);
       expect(wrapper.element).toMatchSnapshot();
     });
-
-    it(':isBackEnabled - should render the back button within the panel when is true', () => {
-      const wrapper = mountPanel({ show: true, isBackEnabled: true });
-
-      expect(wrapper.find('.ec-panel__header-action--back').exists()).toBe(true);
-      expect(wrapper.element).toMatchSnapshot();
-    });
-
-    it(':isBackEnabled - should not render the back button within the panel when is false', () => {
-      const wrapper = mountPanel({ show: true, isBackEnabled: false });
-
-      expect(wrapper.find('.ec-panel__header-action--back').exists()).toBe(false);
-      expect(wrapper.element).toMatchSnapshot();
-    });
   });
 
   describe('@events', () => {
@@ -63,12 +49,66 @@ describe('EcPanel', () => {
       expect(wrapper.emitted('close').length).toBe(1);
     });
 
-    it('@back - should emit both "show-panel" and "back" events when the simple-chevron-left icon is clicked', () => {
-      const wrapper = mountPanel({ show: true, isBackEnabled: true });
-      wrapper.find('.ec-panel__header-action--back').trigger('click');
+    describe('@back', () => {
+      it('should render back button when event handler attribute is present', () => {
+        const wrapper = mountPanelAsTemplate(
+          '<ec-panel v-model="show" @back="anyGivenCallback"></ec-panel>',
+          {},
+          {
+            data() {
+              return {
+                show: true,
+              };
+            },
+            methods: {
+              anyGivenCallback: jest.fn(),
+            },
+          },
+        );
 
-      expect(wrapper.emitted('show-panel').length).toBe(1);
-      expect(wrapper.emitted('back').length).toBe(1);
+        expect(wrapper.find('.ec-panel__header-action--back').exists()).toBeTruthy();
+        expect(wrapper.element).toMatchSnapshot();
+      });
+
+      it('should not render back button when event handler attribute is not present', () => {
+        const wrapper = mountPanelAsTemplate(
+          '<ec-panel v-model="show"></ec-panel>',
+          {},
+          {
+            data() {
+              return {
+                show: true,
+              };
+            },
+          },
+        );
+
+        expect(wrapper.find('.ec-panel__header-action--back').exists()).toBeFalsy();
+        expect(wrapper.element).toMatchSnapshot();
+      });
+
+      it('should emit a "back" event when the simple-chevron-left icon is clicked', () => {
+        const anyGivenCallback = jest.fn();
+        const wrapper = mountPanelAsTemplate(
+          '<ec-panel v-model="show" @back="anyGivenCallback"></ec-panel>',
+          {},
+          {
+            data() {
+              return {
+                show: true,
+              };
+            },
+            methods: {
+              anyGivenCallback,
+            },
+          },
+        );
+
+        wrapper.find('.ec-panel__header-action--back').trigger('click');
+
+        expect(anyGivenCallback).toHaveBeenCalled();
+        expect(wrapper.find('.ec-panel').exists()).toBeFalsy();
+      });
     });
   });
 

--- a/src/components/ec-panel/ec-panel.spec.js
+++ b/src/components/ec-panel/ec-panel.spec.js
@@ -38,14 +38,37 @@ describe('EcPanel', () => {
       expect(wrapper.find('.ec-panel').exists()).toBe(false);
       expect(wrapper.element).toMatchSnapshot();
     });
+
+    it(':goBackEnabled - should render the back button within the panel when is true', () => {
+      const wrapper = mountPanel({ show: true, goBackEnabled: true });
+
+      expect(wrapper.find('.ec-panel__header-action--back').exists()).toBe(true);
+      expect(wrapper.element).toMatchSnapshot();
+    });
+
+    it(':goBackEnabled - should not render the back button within the panel when is false', () => {
+      const wrapper = mountPanel({ show: true, goBackEnabled: false });
+
+      expect(wrapper.find('.ec-panel__header-action--back').exists()).toBe(false);
+      expect(wrapper.element).toMatchSnapshot();
+    });
   });
 
   describe('@events', () => {
-    it('@close - should emit a "close" event when the simple-close icon is clicked', () => {
+    it('@close - should emit both "show-panel" and "close" events when the simple-close icon is clicked', () => {
       const wrapper = mountPanel({ show: true });
-      wrapper.find('.ec-panel__close').trigger('click');
+      wrapper.find('.ec-panel__header-action--close').trigger('click');
 
+      expect(wrapper.emitted('show-panel').length).toBe(1);
       expect(wrapper.emitted('close').length).toBe(1);
+    });
+
+    it('@back - should emit both "show-panel" and "back" events when the simple-chevron-left icon is clicked', () => {
+      const wrapper = mountPanel({ show: true, goBackEnabled: true });
+      wrapper.find('.ec-panel__header-action--back').trigger('click');
+
+      expect(wrapper.emitted('show-panel').length).toBe(1);
+      expect(wrapper.emitted('back').length).toBe(1);
     });
   });
 
@@ -92,7 +115,7 @@ describe('EcPanel', () => {
       expect(wrapper.find('.ec-panel').exists()).toBe(true);
       expect(wrapper.element).toMatchSnapshot();
 
-      wrapper.find('.ec-panel__close').trigger('click');
+      wrapper.find('.ec-panel__header-action--close').trigger('click');
       expect(wrapper.vm.show).toBe(false);
       expect(wrapper.element).toMatchSnapshot();
     });

--- a/src/components/ec-panel/ec-panel.story.js
+++ b/src/components/ec-panel/ec-panel.story.js
@@ -1,5 +1,7 @@
-import { storiesOf } from '@storybook/vue';
+
+import { action } from '@storybook/addon-actions';
 import { boolean } from '@storybook/addon-knobs';
+import { storiesOf } from '@storybook/vue';
 import EcPanel from './ec-panel.vue';
 
 storiesOf('Panel', module)
@@ -12,21 +14,12 @@ storiesOf('Panel', module)
       withOverflowingContent: {
         default: boolean('With overflowing content', true),
       },
-      displayingBackButton: {
-        default: boolean('With back button visible', false),
-      },
     },
     watch: {
       showFromProps: {
         immediate: true,
         handler(newValue) {
           this.show = newValue;
-        },
-      },
-      displayingBackButton: {
-        immediate: true,
-        handler(newValue) {
-          this.isBackEnabled = newValue;
         },
       },
     },
@@ -36,11 +29,16 @@ storiesOf('Panel', module)
         isBackEnabled: true,
       };
     },
+    methods: {
+      clickBackButton() {
+        action('Back button clicked')();
+      },
+    },
     template: `
       <div style="width: 100vw; height: 100vh; position: fixed; top: 0; left: 0;">
         <div v-for="i in 5">Lorem, ipsum dolor sit amet consectetur adipisicing elit. Eum nobis obcaecati optio magnam, porro inventore? Suscipit sit atque a! Ullam provident quidem recusandae, itaque error labore porro inventore? Suscipit sit atque a! Ullam provident quidem recusandae, itaque error labore</div>
 
-        <ec-panel v-model="show" :is-back-enabled="isBackEnabled">
+        <ec-panel v-model="show" @back="clickBackButton()">
           <template #header>
             <h2 class="ec-mb--24">Lorem, ipsum dolor sit amet</h2>
           </template>

--- a/src/components/ec-panel/ec-panel.story.js
+++ b/src/components/ec-panel/ec-panel.story.js
@@ -13,7 +13,7 @@ storiesOf('Panel', module)
         default: boolean('With overflowing content', true),
       },
       displayingBackButton: {
-        default: boolean('With the back button visible', false),
+        default: boolean('With back button visible', false),
       },
     },
     watch: {
@@ -26,21 +26,21 @@ storiesOf('Panel', module)
       displayingBackButton: {
         immediate: true,
         handler(newValue) {
-          this.goBackEnabled = newValue;
+          this.isBackEnabled = newValue;
         },
       },
     },
     data() {
       return {
         show: true,
-        goBackEnabled: true,
+        isBackEnabled: true,
       };
     },
     template: `
       <div style="width: 100vw; height: 100vh; position: fixed; top: 0; left: 0;">
         <div v-for="i in 5">Lorem, ipsum dolor sit amet consectetur adipisicing elit. Eum nobis obcaecati optio magnam, porro inventore? Suscipit sit atque a! Ullam provident quidem recusandae, itaque error labore porro inventore? Suscipit sit atque a! Ullam provident quidem recusandae, itaque error labore</div>
 
-        <ec-panel v-model="show" :go-back-enabled="goBackEnabled">
+        <ec-panel v-model="show" :is-back-enabled="isBackEnabled">
           <template #header>
             <h2 class="ec-mb--24">Lorem, ipsum dolor sit amet</h2>
           </template>

--- a/src/components/ec-panel/ec-panel.story.js
+++ b/src/components/ec-panel/ec-panel.story.js
@@ -12,6 +12,9 @@ storiesOf('Panel', module)
       withOverflowingContent: {
         default: boolean('With overflowing content', true),
       },
+      displayingBackButton: {
+        default: boolean('With the back button visible', false),
+      },
     },
     watch: {
       showFromProps: {
@@ -20,17 +23,24 @@ storiesOf('Panel', module)
           this.show = newValue;
         },
       },
+      displayingBackButton: {
+        immediate: true,
+        handler(newValue) {
+          this.goBackEnabled = newValue;
+        },
+      },
     },
     data() {
       return {
         show: true,
+        goBackEnabled: true,
       };
     },
     template: `
       <div style="width: 100vw; height: 100vh; position: fixed; top: 0; left: 0;">
         <div v-for="i in 5">Lorem, ipsum dolor sit amet consectetur adipisicing elit. Eum nobis obcaecati optio magnam, porro inventore? Suscipit sit atque a! Ullam provident quidem recusandae, itaque error labore porro inventore? Suscipit sit atque a! Ullam provident quidem recusandae, itaque error labore</div>
 
-        <ec-panel v-model="show">
+        <ec-panel v-model="show" :go-back-enabled="goBackEnabled">
           <template #header>
             <h2 class="ec-mb--24">Lorem, ipsum dolor sit amet</h2>
           </template>

--- a/src/components/ec-panel/ec-panel.vue
+++ b/src/components/ec-panel/ec-panel.vue
@@ -2,6 +2,7 @@
   <aside
     v-if="show"
     class="ec-panel"
+    data-test="ec-panel"
   >
     <div class="ec-panel__header">
       <div class="ec-panel__header-icons">
@@ -10,6 +11,7 @@
           aria-label="Go back"
           class="ec-panel__header-action ec-panel__header-action--back"
           href="#"
+          data-test="ec-panel__header-action--back"
           @click.stop.prevent="goBack"
         >
           <ec-icon
@@ -22,6 +24,7 @@
           aria-label="Close panel"
           class="ec-panel__header-action ec-panel__header-action--close"
           href="#"
+          data-test="ec-panel__header-action--close"
           @click.stop.prevent="closePanel"
         >
           <ec-icon
@@ -56,9 +59,10 @@ export default {
       type: Boolean,
       default: false,
     },
-    isBackEnabled: {
-      type: Boolean,
-      default: false,
+  },
+  computed: {
+    isBackEnabled() {
+      return this.$listeners.back;
     },
   },
   methods: {

--- a/src/components/ec-panel/ec-panel.vue
+++ b/src/components/ec-panel/ec-panel.vue
@@ -6,13 +6,26 @@
     <div class="ec-panel__header">
       <div class="ec-panel__header-icons">
         <a
-          aria-label="Close panel"
-          class="ec-panel__close"
+          v-if="goBackEnabled"
+          aria-label="Go back"
+          class="ec-panel__header-action ec-panel__header-action--back"
           href="#"
-          @click.stop.prevent="$emit('close', false)"
+          @click.stop.prevent="goBack"
         >
           <ec-icon
-            class="ec-panel__close-icon"
+            class="ec-panel__header-icon"
+            name="simple-chevron-left"
+            :size="24"
+          />
+        </a>
+        <a
+          aria-label="Close panel"
+          class="ec-panel__header-action ec-panel__header-action--close"
+          href="#"
+          @click.stop.prevent="closePanel"
+        >
+          <ec-icon
+            class="ec-panel__header-icon"
             name="simple-close"
             :size="24"
           />
@@ -36,15 +49,28 @@ export default {
   },
   model: {
     prop: 'show',
-    event: 'close',
+    event: 'show-panel',
   },
   props: {
     show: {
       type: Boolean,
       default: false,
     },
+    goBackEnabled: {
+      type: Boolean,
+      default: false,
+    },
   },
-
+  methods: {
+    goBack() {
+      this.$emit('show-panel', false);
+      this.$emit('back');
+    },
+    closePanel() {
+      this.$emit('show-panel', false);
+      this.$emit('close');
+    },
+  },
 };
 </script>
 
@@ -52,8 +78,8 @@ export default {
 @import '../../scss/settings/index';
 @import '../../scss/tools/index';
 
-$ec-panel-close-btn-fill: $level-4-interactive-elements !default;
-$ec-panel-close-btn-fill-hover: $level-4-tech-blue !default;
+$ec-panel-header-btn-fill: $level-4-interactive-elements !default;
+$ec-panel-header-btn-fill-hover: $level-4-tech-blue !default;
 $ec-panel-background-color: $white !default;
 
 .ec-panel {
@@ -80,22 +106,29 @@ $ec-panel-background-color: $white !default;
     flex-direction: row;
   }
 
-  &__close {
-    margin-left: auto;
+  &__header-icon {
+    fill: currentColor;
+    display: inline-block;
+    vertical-align: top;
+  }
+
+  &__header-action {
     cursor: pointer;
-    color: $ec-panel-close-btn-fill;
+    color: $ec-panel-header-btn-fill;
 
     @include color-transition;
 
     &:hover {
-      color: $ec-panel-close-btn-fill-hover;
+      color: $ec-panel-header-btn-fill-hover;
     }
-  }
 
-  &__close-icon {
-    fill: currentColor;
-    display: inline-block;
-    vertical-align: top;
+    &--back {
+      margin-right: auto;
+    }
+
+    &--close {
+      margin-left: auto;
+    }
   }
 }
 

--- a/src/components/ec-panel/ec-panel.vue
+++ b/src/components/ec-panel/ec-panel.vue
@@ -6,7 +6,7 @@
     <div class="ec-panel__header">
       <div class="ec-panel__header-icons">
         <a
-          v-if="goBackEnabled"
+          v-if="isBackEnabled"
           aria-label="Go back"
           class="ec-panel__header-action ec-panel__header-action--back"
           href="#"
@@ -56,7 +56,7 @@ export default {
       type: Boolean,
       default: false,
     },
-    goBackEnabled: {
+    isBackEnabled: {
       type: Boolean,
       default: false,
     },


### PR DESCRIPTION
- This story is for adding to the EcPanel the possibility of displaying (is optional) a new button in the top-left corner, with a left arrow icon.

- This button just will emit an event to point out that user wants to go back to a previous panel.

- To display it in Storybook, go to Panel basic component, and mark "With the back button visible" in the Knobs tab. 

![image](https://user-images.githubusercontent.com/4802418/76618677-6de4d800-6529-11ea-9397-92912df846f1.png)
