### PR TITLE
ONL-4270: currencies without decimals

### DIFF
--- a/src/components/ec-amount-input/ec-amount-input.spec.js
+++ b/src/components/ec-amount-input/ec-amount-input.spec.js
@@ -161,5 +161,29 @@ describe('EcAmountInput', () => {
     expect(wrapper.vm.valueAmount).toBe(1111);
     expect(wrapper.find('input').element.value).toBe('1,111');
   });
+
+  it('should allow typing only a negative sign into input', async () => {
+    const wrapper = mountAmountInput();
+    wrapper.find('input').setValue('-');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('input').element.value).toBe('-');
+  });
+
+  it('should allow typing only a negative sign into input when there is v-model', async () => {
+    const wrapper = mountAmountInputAsTemplate(
+      '<ec-amount-input v-model="valueAmount" locale="en" />', {
+        data() {
+          return {
+            valueAmount: null,
+          };
+        },
+      },
+    );
+
+    wrapper.find('input').setValue('-');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('input').element.value).toBe('-');
+    expect(wrapper.vm.valueAmount).toBeNaN();
+  });
 });
 

--- a/src/components/ec-amount-input/ec-amount-input.spec.js
+++ b/src/components/ec-amount-input/ec-amount-input.spec.js
@@ -124,5 +124,42 @@ describe('EcAmountInput', () => {
     await wrapper.vm.$nextTick();
     expect(wrapper.find('input').element.value).toBe('1,111.11');
   });
+
+  it('should format the number for currency without decimals', async () => {
+    const wrapper = mountAmountInputAsTemplate(
+      '<ec-amount-input v-model="valueAmount" locale="en" currency="JPY" />', {
+        data() {
+          return {
+            valueAmount: null,
+          };
+        },
+      },
+    );
+    expect(wrapper.find('input').element.value).toBe('');
+    wrapper.setData({ valueAmount: '1111.11' });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find('input').element.value).toBe('1,111');
+  });
+
+  it('should remove existing decimals if currency changes to one without decimals', async () => {
+    const wrapper = mountAmountInputAsTemplate(
+      '<ec-amount-input v-model="valueAmount" locale="en" :currency="currency" />', {
+        data() {
+          return {
+            currency: 'GBP',
+            valueAmount: null,
+          };
+        },
+      },
+    );
+    wrapper.setData({ valueAmount: 1111.11 });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.valueAmount).toBe(1111.11);
+    expect(wrapper.find('input').element.value).toBe('1,111.11');
+    wrapper.setData({ currency: 'JPY' });
+    await wrapper.vm.$nextTick();
+    expect(wrapper.vm.valueAmount).toBe(1111);
+    expect(wrapper.find('input').element.value).toBe('1,111');
+  });
 });
 

--- a/src/components/ec-amount-input/ec-amount-input.story.js
+++ b/src/components/ec-amount-input/ec-amount-input.story.js
@@ -1,5 +1,5 @@
 import { storiesOf } from '@storybook/vue';
-import { select, boolean } from '@storybook/addon-knobs';
+import { select, boolean, text } from '@storybook/addon-knobs';
 import EcAmountInput from './ec-amount-input.vue';
 
 const stories = storiesOf('Input Amount', module);
@@ -17,9 +17,14 @@ stories
         default: boolean('Is Masked', false),
       },
       locale: {
-        default: select('Locale', ['en', 'es', 'de-ch'], 'en'),
+        default: select('Locale', ['en', 'es', 'de-ch', 'jp'], 'en'),
       },
-
+      currency: {
+        default: select('Currency', ['GBP', 'EUR', 'JPY', 'INR', 'USD', 'CAD'], 'GBP'),
+      },
+      label: {
+        default: text('Label', 'Amount input'),
+      },
     },
     template: `
     <div class="ec-ml--24 ec-mr--24">
@@ -27,12 +32,12 @@ stories
         <div class="ec-grid__row">
           <div class="ec-col-12">
             <div class="ec-m--24">
-              <ec-amount-input v-bind="$props" label="Amount input" v-model="value" />
+              <ec-amount-input v-bind="$props" v-model="value" />
             </div>
             <div class="ec-m--24">The input value: {{ value }} (type: {{ typeof value }})</div>
           </div>
         </div>
       </div>
-    </div>       
+    </div>
   `,
   }));

--- a/src/components/ec-amount-input/ec-amount-input.vue
+++ b/src/components/ec-amount-input/ec-amount-input.vue
@@ -76,8 +76,10 @@ export default {
             return;
           }
 
-          const formatted = format(newValue, this.getFormattingOptions());
-          this.formattedValue = formatted;
+          if (!Number.isNaN(newValue) && this.formattedValue !== '-') {
+            const formatted = format(newValue, this.getFormattingOptions());
+            this.formattedValue = formatted;
+          }
           this.unformattedValue = newValue;
         }
       },

--- a/src/components/ec-amount-input/ec-amount-input.vue
+++ b/src/components/ec-amount-input/ec-amount-input.vue
@@ -34,6 +34,9 @@ export default {
       type: String,
       default: 'en',
     },
+    currency: {
+      type: String,
+    },
   },
   data() {
     return {
@@ -43,8 +46,11 @@ export default {
   },
   computed: {
     precision() {
-      // we use GBP only because Intl requires it in constructor, but we don't use it in the implementation, so it can be hard coded.
-      const options = new Intl.NumberFormat(this.locale, { style: 'currency', currency: 'GBP' }).resolvedOptions();
+      // Precision may vary because of locale and currency
+      // If currency is not given, use only locale and pass non existent currency, e.g. EN -> 2
+      // If currency is present, we might get different result, e.g. precision for EN with GBP is 2,
+      // but EN with JPY is 0.
+      const options = new Intl.NumberFormat(this.locale, { style: 'currency', currency: this.currency || 'XYZ' }).resolvedOptions();
       return options.maximumFractionDigits;
     },
     groupingSeparator() {
@@ -75,6 +81,11 @@ export default {
           this.unformattedValue = newValue;
         }
       },
+    },
+    currency() {
+      const formatted = format(this.value, this.getFormattingOptions());
+      this.formattedValue = formatted;
+      this.unformattedValue = +(unFormat(formatted, this.groupingSeparator, this.decimalSeparator));
     },
     locale() {
       const formatted = new Intl.NumberFormat(this.locale, { type: 'decimal', maximumFractionDigits: this.precision }).format(this.unformattedValue);

--- a/src/directives/ec-amount/utils.js
+++ b/src/directives/ec-amount/utils.js
@@ -9,7 +9,7 @@ function format(input, opt = defaults) {
     input = input.toString();
   }
 
-  const negative = input.includes('-') ? '-' : '';
+  const negative = input.startsWith('-') ? '-' : '';
 
   input = sanitizeInput(input, opt.decimalSeparator);
   if (opt.precision > 0) {

--- a/src/directives/ec-amount/utils.js
+++ b/src/directives/ec-amount/utils.js
@@ -12,7 +12,11 @@ function format(input, opt = defaults) {
   const negative = input.includes('-') ? '-' : '';
 
   input = sanitizeInput(input, opt.decimalSeparator);
-  input = keepOnlyOneDecimalSeparator(input, opt.decimalSeparator);
+  if (opt.precision > 0) {
+    input = keepOnlyOneDecimalSeparator(input, opt.decimalSeparator);
+  } else {
+    input = removeDecimal(input, opt.decimalSeparator);
+  }
   const parts = input.split(opt.decimalSeparator);
   let integer = parseToStr(parts[0]);
   let decimal = parts[1];
@@ -40,6 +44,11 @@ function keepOnlyOneDecimalSeparator(number, decimalSeparator) {
     return split[0] + decimalSeparator + split.slice(1).join('');
   }
   return number;
+}
+
+function removeDecimal(number, decimalSeparator) {
+  const split = number.split(decimalSeparator);
+  return split[0];
 }
 
 function unFormat(input, groupingSeparator, decimalSeparator) {

--- a/src/directives/ec-amount/utils.spec.js
+++ b/src/directives/ec-amount/utils.spec.js
@@ -57,11 +57,23 @@ describe('EcAmount - utils', () => {
       [0.11, '0', optionsWithoutDecimals],
       [-1.11, '-1', optionsWithoutDecimals],
     ])('should format the value %s into a %s without decimal', (value, valueFormatted, options) => {
-      if (options !== undefined) {
-        expect(format(value, options)).toBe(valueFormatted);
-      } else {
-        expect(format(value)).toBe(valueFormatted);
-      }
+      expect(format(value, options)).toBe(valueFormatted);
+    });
+
+    it.each([
+      ['-', '-', defaultOptions],
+      ['--', '-', defaultOptions],
+      ['-1', '-1', defaultOptions],
+      ['-.', '-.', defaultOptions],
+      ['-.1', '-.1', defaultOptions],
+      ['--1', '-1', defaultOptions],
+      ['-1111.11', '-1,111.11', defaultOptions],
+      [-1, '-1', defaultOptions],
+      [-1111.11, '-1,111.11', defaultOptions],
+      ['1-', '1', defaultOptions],
+      ['1-1', '11', defaultOptions],
+    ])('should format negative sign in the value %s into a %s', (value, valueFormatted, options) => {
+      expect(format(value, options)).toBe(valueFormatted);
     });
   });
 

--- a/src/directives/ec-amount/utils.spec.js
+++ b/src/directives/ec-amount/utils.spec.js
@@ -5,6 +5,12 @@ const defaultOptions = {
   decimalSeparator: '.',
   precision: 2,
 };
+
+const optionsWithoutDecimals = {
+  ...defaultOptions,
+  precision: 0,
+};
+
 describe('EcAmount - utils', () => {
   describe('format', () => {
     it.each([
@@ -33,6 +39,24 @@ describe('EcAmount - utils', () => {
       [1111111, '1`111`111', { ...defaultOptions, groupingSeparator: '`' }],
       ['1111111`11', '1,111,111`11', { ...defaultOptions, decimalSeparator: '`' }],
     ])('should format the value %s into a %s', (value, valueFormatted, options) => {
+      if (options !== undefined) {
+        expect(format(value, options)).toBe(valueFormatted);
+      } else {
+        expect(format(value)).toBe(valueFormatted);
+      }
+    });
+
+    it.each([
+      ['', '', optionsWithoutDecimals],
+      ['abc', '', optionsWithoutDecimals],
+      ['.', '', optionsWithoutDecimals],
+      ['111.51', '111', optionsWithoutDecimals],
+      ['1111.11', '1,111', optionsWithoutDecimals],
+      ['11.11.11', '11', optionsWithoutDecimals],
+      [1.11, '1', optionsWithoutDecimals],
+      [0.11, '0', optionsWithoutDecimals],
+      [-1.11, '-1', optionsWithoutDecimals],
+    ])('should format the value %s into a %s without decimal', (value, valueFormatted, options) => {
       if (options !== undefined) {
         expect(format(value, options)).toBe(valueFormatted);
       } else {


### PR DESCRIPTION
Two things have been fixed:

1. Amount input now properly handles currencies without decimals and doesn't allow typing decimal separator.
2. Negative sign in amount input was causing weird behaviours, e.g. you could type `-` in the middle of a number; or you have to press `-` twice in empty input to get at least one `-` in the input.