### PR TITLE
Onl 4002 align to the right and max width

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.79",
+  "version": "0.1.80",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.79",
+  "version": "0.1.80",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.78",
+  "version": "0.1.79",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/components/ec-smart-table/__snapshots__/ec-smart-table.spec.js.snap
+++ b/src/components/ec-smart-table/__snapshots__/ec-smart-table.spec.js.snap
@@ -59,7 +59,9 @@ exports[`EcSmartTable sorting multi sort should allow sorting multiple columns: 
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Test 1
         
@@ -100,7 +102,9 @@ exports[`EcSmartTable sorting multi sort should allow sorting multiple columns: 
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Test 2
         
@@ -119,7 +123,9 @@ exports[`EcSmartTable sorting multi sort should allow sorting multiple columns: 
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Test 3
         
@@ -170,7 +176,9 @@ exports[`EcSmartTable sorting multi sort should allow sorting multiple columns: 
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Test 1
         
@@ -211,7 +219,9 @@ exports[`EcSmartTable sorting multi sort should allow sorting multiple columns: 
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Test 2
         
@@ -230,7 +240,9 @@ exports[`EcSmartTable sorting multi sort should allow sorting multiple columns: 
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Test 3
         
@@ -281,7 +293,9 @@ exports[`EcSmartTable sorting multi sort should allow sorting multiple columns: 
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Test 1
         
@@ -322,7 +336,9 @@ exports[`EcSmartTable sorting multi sort should allow sorting multiple columns: 
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Test 2
         
@@ -341,7 +357,9 @@ exports[`EcSmartTable sorting multi sort should allow sorting multiple columns: 
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Test 3
         
@@ -383,7 +401,9 @@ exports[`EcSmartTable sorting multi sort should sort column: ASC -> DESC 1`] = `
   <span
     class="ec-table-head__cell-wrapper"
   >
-    <span>
+    <span
+      class=""
+    >
       
           Test 1
         
@@ -427,7 +447,9 @@ exports[`EcSmartTable sorting multi sort should sort column: ASC 1`] = `
   <span
     class="ec-table-head__cell-wrapper"
   >
-    <span>
+    <span
+      class=""
+    >
       
           Test 1
         
@@ -471,7 +493,9 @@ exports[`EcSmartTable sorting multi sort should sort column: DESC -> not sorted 
   <span
     class="ec-table-head__cell-wrapper"
   >
-    <span>
+    <span
+      class=""
+    >
       
           Test 1
         
@@ -511,7 +535,9 @@ exports[`EcSmartTable sorting multi sort should sort column: not sorted -> ASC 1
   <span
     class="ec-table-head__cell-wrapper"
   >
-    <span>
+    <span
+      class=""
+    >
       
           Test 1
         
@@ -560,7 +586,9 @@ exports[`EcSmartTable sorting should render sortable columns 1`] = `
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Test 1
         
@@ -597,7 +625,9 @@ exports[`EcSmartTable sorting should render sortable columns 1`] = `
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Test 2
         
@@ -616,7 +646,9 @@ exports[`EcSmartTable sorting should render sortable columns 1`] = `
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Test 3
         
@@ -663,7 +695,9 @@ exports[`EcSmartTable sorting should render sorted columns 1`] = `
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Test 1
         
@@ -704,7 +738,9 @@ exports[`EcSmartTable sorting should render sorted columns 1`] = `
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Test 2
         
@@ -723,7 +759,9 @@ exports[`EcSmartTable sorting should render sorted columns 1`] = `
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Test 3
         
@@ -774,7 +812,9 @@ exports[`EcSmartTable sorting single sort should allow sorting only one column: 
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Test 1
         
@@ -815,7 +855,9 @@ exports[`EcSmartTable sorting single sort should allow sorting only one column: 
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Test 2
         
@@ -834,7 +876,9 @@ exports[`EcSmartTable sorting single sort should allow sorting only one column: 
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Test 3
         
@@ -881,7 +925,9 @@ exports[`EcSmartTable sorting single sort should allow sorting only one column: 
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Test 1
         
@@ -918,7 +964,9 @@ exports[`EcSmartTable sorting single sort should allow sorting only one column: 
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Test 2
         
@@ -937,7 +985,9 @@ exports[`EcSmartTable sorting single sort should allow sorting only one column: 
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Test 3
         
@@ -988,7 +1038,9 @@ exports[`EcSmartTable sorting single sort should allow sorting only one column: 
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Test 1
         
@@ -1029,7 +1081,9 @@ exports[`EcSmartTable sorting single sort should allow sorting only one column: 
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Test 2
         
@@ -1048,7 +1102,9 @@ exports[`EcSmartTable sorting single sort should allow sorting only one column: 
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Test 3
         
@@ -1090,7 +1146,9 @@ exports[`EcSmartTable sorting single sort should sort column: ASC -> DESC 1`] = 
   <span
     class="ec-table-head__cell-wrapper"
   >
-    <span>
+    <span
+      class=""
+    >
       
           Test 1
         
@@ -1134,7 +1192,9 @@ exports[`EcSmartTable sorting single sort should sort column: ASC 1`] = `
   <span
     class="ec-table-head__cell-wrapper"
   >
-    <span>
+    <span
+      class=""
+    >
       
           Test 1
         
@@ -1178,7 +1238,9 @@ exports[`EcSmartTable sorting single sort should sort column: DESC -> not sorted
   <span
     class="ec-table-head__cell-wrapper"
   >
-    <span>
+    <span
+      class=""
+    >
       
           Test 1
         
@@ -1218,7 +1280,9 @@ exports[`EcSmartTable sorting single sort should sort column: not sorted -> ASC 
   <span
     class="ec-table-head__cell-wrapper"
   >
-    <span>
+    <span
+      class=""
+    >
       
           Test 1
         

--- a/src/components/ec-table-head/__snapshots__/ec-table-head.spec.js.snap
+++ b/src/components/ec-table-head/__snapshots__/ec-table-head.spec.js.snap
@@ -502,7 +502,7 @@ exports[`EcTableHead should render with max-width and ellipsis on the column tha
         class="ec-table-head__cell-wrapper"
       >
         <span
-          class="ec-table-head__cell-text--is-ellipsis"
+          class="ec-table-head__cell-text--has-max-width"
         >
           
           Column B

--- a/src/components/ec-table-head/__snapshots__/ec-table-head.spec.js.snap
+++ b/src/components/ec-table-head/__snapshots__/ec-table-head.spec.js.snap
@@ -28,13 +28,13 @@ exports[`EcTableHead should have a column align to center if its type is icon 1`
       </span>
     </th>
     <th
-      class="ec-table-head__cell ec-table-head__cell--text-center"
+      class="ec-table-head__cell"
       colspan="2"
       data-test="ec-table-head__cell ec-table-head__cell--1"
       scope="col"
     >
       <span
-        class="ec-table-head__cell-wrapper ec-table-head__cell-wrapper--text-center"
+        class="ec-table-head__cell-wrapper ec-table-head__cell-wrapper--is-type-icon"
       >
         <span
           class=""
@@ -108,7 +108,7 @@ exports[`EcTableHead should have a column align to the right if its type is curr
       scope="col"
     >
       <span
-        class="ec-table-head__cell-wrapper ec-table-head__cell-wrapper--text-right"
+        class="ec-table-head__cell-wrapper ec-table-head__cell-wrapper--is-type-currency"
       >
         <span
           class=""
@@ -502,7 +502,7 @@ exports[`EcTableHead should render with max-width and ellipsis on the column tha
         class="ec-table-head__cell-wrapper"
       >
         <span
-          class="ec-table-head__cell-text--ellipsis"
+          class="ec-table-head__cell-text--is-ellipsis"
         >
           
           Column B

--- a/src/components/ec-table-head/__snapshots__/ec-table-head.spec.js.snap
+++ b/src/components/ec-table-head/__snapshots__/ec-table-head.spec.js.snap
@@ -1,5 +1,153 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EcTableHead should have a column align to center if its type is icon 1`] = `
+<thead
+  class="ec-table-head"
+  data-test="ec-table-head"
+>
+  <tr>
+    <th
+      class="ec-table-head__cell"
+      data-test="ec-table-head__cell ec-table-head__cell--0"
+      scope="col"
+    >
+      <span
+        class="ec-table-head__cell-wrapper"
+      >
+        <span
+          class=""
+        >
+          
+          Column A
+        
+        </span>
+         
+        <!---->
+         
+        <!---->
+      </span>
+    </th>
+    <th
+      class="ec-table-head__cell ec-table-head__cell--text-center"
+      colspan="2"
+      data-test="ec-table-head__cell ec-table-head__cell--1"
+      scope="col"
+    >
+      <span
+        class="ec-table-head__cell-wrapper ec-table-head__cell-wrapper--text-center"
+      >
+        <span
+          class=""
+        >
+          
+          Column B
+        
+        </span>
+         
+        <!---->
+         
+        <!---->
+      </span>
+    </th>
+    <th
+      class="ec-table-head__cell"
+      data-test="ec-table-head__cell ec-table-head__cell--2"
+      scope="col"
+    >
+      <span
+        class="ec-table-head__cell-wrapper"
+      >
+        <span
+          class=""
+        >
+          
+          Column C
+        
+        </span>
+         
+        <!---->
+         
+        <!---->
+      </span>
+    </th>
+  </tr>
+</thead>
+`;
+
+exports[`EcTableHead should have a column align to the right if its type is currency 1`] = `
+<thead
+  class="ec-table-head"
+  data-test="ec-table-head"
+>
+  <tr>
+    <th
+      class="ec-table-head__cell"
+      data-test="ec-table-head__cell ec-table-head__cell--0"
+      scope="col"
+    >
+      <span
+        class="ec-table-head__cell-wrapper"
+      >
+        <span
+          class=""
+        >
+          
+          Column A
+        
+        </span>
+         
+        <!---->
+         
+        <!---->
+      </span>
+    </th>
+    <th
+      class="ec-table-head__cell"
+      colspan="2"
+      data-test="ec-table-head__cell ec-table-head__cell--1"
+      scope="col"
+    >
+      <span
+        class="ec-table-head__cell-wrapper ec-table-head__cell-wrapper--text-right"
+      >
+        <span
+          class=""
+        >
+          
+          Column B
+        
+        </span>
+         
+        <!---->
+         
+        <!---->
+      </span>
+    </th>
+    <th
+      class="ec-table-head__cell"
+      data-test="ec-table-head__cell ec-table-head__cell--2"
+      scope="col"
+    >
+      <span
+        class="ec-table-head__cell-wrapper"
+      >
+        <span
+          class=""
+        >
+          
+          Column C
+        
+        </span>
+         
+        <!---->
+         
+        <!---->
+      </span>
+    </th>
+  </tr>
+</thead>
+`;
+
 exports[`EcTableHead should not render if no columns are supplied 1`] = `<!---->`;
 
 exports[`EcTableHead should render as expected 1`] = `
@@ -16,7 +164,9 @@ exports[`EcTableHead should render as expected 1`] = `
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Column A
         
@@ -36,7 +186,9 @@ exports[`EcTableHead should render as expected 1`] = `
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Column B
         
@@ -55,7 +207,9 @@ exports[`EcTableHead should render as expected 1`] = `
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Column C
         
@@ -84,7 +238,9 @@ exports[`EcTableHead should render info icon with a tooltip as expected 1`] = `
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Column A
         
@@ -114,7 +270,9 @@ exports[`EcTableHead should render info icon with a tooltip as expected 1`] = `
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Column B
         
@@ -143,7 +301,9 @@ exports[`EcTableHead should render info icon with a tooltip as expected 1`] = `
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Column C
         
@@ -182,7 +342,9 @@ exports[`EcTableHead should render sorting as expected 1`] = `
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Column A
         
@@ -224,7 +386,9 @@ exports[`EcTableHead should render sorting as expected 1`] = `
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Column B
         
@@ -265,7 +429,9 @@ exports[`EcTableHead should render sorting as expected 1`] = `
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Column C
         
@@ -292,6 +458,81 @@ exports[`EcTableHead should render sorting as expected 1`] = `
            
           <!---->
         </a>
+      </span>
+    </th>
+  </tr>
+</thead>
+`;
+
+exports[`EcTableHead should render with max-width and ellipsis on the column that has the prop given 1`] = `
+<thead
+  class="ec-table-head"
+  data-test="ec-table-head"
+>
+  <tr>
+    <th
+      class="ec-table-head__cell"
+      data-test="ec-table-head__cell ec-table-head__cell--0"
+      scope="col"
+    >
+      <span
+        class="ec-table-head__cell-wrapper"
+      >
+        <span
+          class=""
+        >
+          
+          Column A
+        
+        </span>
+         
+        <!---->
+         
+        <!---->
+      </span>
+    </th>
+    <th
+      class="ec-table-head__cell"
+      colspan="2"
+      data-test="ec-table-head__cell ec-table-head__cell--1"
+      scope="col"
+      style="max-width: 250px;"
+    >
+      <span
+        class="ec-table-head__cell-wrapper"
+      >
+        <span
+          class="ec-table-head__cell-text--ellipsis"
+        >
+          
+          Column B
+        
+        </span>
+         
+        <!---->
+         
+        <!---->
+      </span>
+    </th>
+    <th
+      class="ec-table-head__cell"
+      data-test="ec-table-head__cell ec-table-head__cell--2"
+      scope="col"
+    >
+      <span
+        class="ec-table-head__cell-wrapper"
+      >
+        <span
+          class=""
+        >
+          
+          Column C
+        
+        </span>
+         
+        <!---->
+         
+        <!---->
       </span>
     </th>
   </tr>

--- a/src/components/ec-table-head/ec-table-head.spec.js
+++ b/src/components/ec-table-head/ec-table-head.spec.js
@@ -40,7 +40,7 @@ describe('EcTableHead', () => {
     });
   });
 
-  it('should have class ec-table-head__cell--text-center if type of content is icon', () => {
+  it('should have a column align to center if its type is icon', () => {
     const wrapper = mountEcTableHead({
       columns: columns.map(column => ({
         ...column,
@@ -48,8 +48,18 @@ describe('EcTableHead', () => {
       })),
     });
 
-    expect(wrapper.findByDataTest('ec-table-head__cell--0').classes('ec-table-head__cell--text-center')).toBe(false);
-    expect(wrapper.findByDataTest('ec-table-head__cell--1').classes('ec-table-head__cell--text-center')).toBe(true);
+    expect(wrapper.element).toMatchSnapshot();
+  });
+
+  it('should have a column align to the right if its type is currency', () => {
+    const wrapper = mountEcTableHead({
+      columns: columns.map(column => ({
+        ...column,
+        type: column.name === 'column-b' ? 'currency' : null,
+      })),
+    });
+
+    expect(wrapper.element).toMatchSnapshot();
   });
 
   it('should not render if no columns are supplied', () => {
@@ -113,5 +123,16 @@ describe('EcTableHead', () => {
 
     expect(wrapper.findByDataTest('ec-table-head__cell--1').attributes('style')).toBe('min-width: 250px;');
     expect(wrapper.findByDataTest('ec-table-head__cell--0').attributes('style')).toBe(undefined);
+  });
+
+  it('should render with max-width and ellipsis on the column that has the prop given', () => {
+    const wrapper = mountEcTableHead({
+      columns: columns.map(column => ({
+        ...column,
+        maxWidth: column.name === 'column-b' ? '250px' : null,
+      })),
+    });
+
+    expect(wrapper.element).toMatchSnapshot();
   });
 });

--- a/src/components/ec-table-head/ec-table-head.vue
+++ b/src/components/ec-table-head/ec-table-head.vue
@@ -15,7 +15,10 @@
         :colspan="column.span"
         scope="col"
       >
-        <span class="ec-table-head__cell-wrapper">
+        <span
+          class="ec-table-head__cell-wrapper"
+          :class="{'ec-table-head__cell-wrapper--justify-end': column.align === 'right'}"
+        >
           <span>
             {{ column.title }}
           </span>
@@ -79,7 +82,23 @@ export default {
       this.$emit('sort', column.name);
     },
     getWidthStyle(column) {
-      return column && column.minWidth ? { minWidth: column.minWidth } : null;
+      let widthStyle = {};
+      if (column && column.minWidth) {
+        widthStyle = {
+          ...widthStyle,
+          minWidth: column.minWidth,
+        };
+      }
+      if (column && column.maxWidth) {
+        widthStyle = {
+          ...widthStyle,
+          maxWidth: column.maxWidth,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        };
+      }
+      return Object.keys(widthStyle).length ? widthStyle : null;
     },
     getStickyColumnClass(colIndex, columns) {
       if (this.stickyColumn === 'left' && colIndex === 0) {
@@ -101,6 +120,10 @@ export default {
   &__cell-wrapper {
     display: flex;
     align-items: center;
+
+    &--justify-end {
+      justify-content: flex-end;
+    }
   }
 
   &__icon {

--- a/src/components/ec-table-head/ec-table-head.vue
+++ b/src/components/ec-table-head/ec-table-head.vue
@@ -22,7 +22,7 @@
             'ec-table-head__cell-wrapper--is-type-currency': column.type === 'currency',
           }"
         >
-          <span :class="{'ec-table-head__cell-text--is-ellipsis': column.maxWidth}">
+          <span :class="{'ec-table-head__cell-text--has-max-width': column.maxWidth}">
             {{ column.title }}
           </span>
           <ec-icon
@@ -85,20 +85,10 @@ export default {
       this.$emit('sort', column.name);
     },
     getWidthStyle(column) {
-      let widthStyle = {};
-      if (column && column.minWidth) {
-        widthStyle = {
-          ...widthStyle,
-          minWidth: column.minWidth,
-        };
+      if (column && (column.maxWidth || column.minWidth)) {
+        return { maxWidth: column.maxWidth, minWidth: column.minWidth };
       }
-      if (column && column.maxWidth) {
-        widthStyle = {
-          ...widthStyle,
-          maxWidth: column.maxWidth,
-        };
-      }
-      return Object.keys(widthStyle).length ? widthStyle : null;
+      return null;
     },
     getStickyColumnClass(colIndex, columns) {
       if (this.stickyColumn === 'left' && colIndex === 0) {
@@ -165,7 +155,7 @@ export default {
     }
   }
 
-  &__cell-text--is-ellipsis {
+  &__cell-text--has-max-width {
     @include ellipsis;
   }
 }

--- a/src/components/ec-table-head/ec-table-head.vue
+++ b/src/components/ec-table-head/ec-table-head.vue
@@ -17,9 +17,12 @@
       >
         <span
           class="ec-table-head__cell-wrapper"
-          :class="{'ec-table-head__cell-wrapper--justify-end': column.align === 'right'}"
+          :class="{
+            'ec-table-head__cell-wrapper--text-center': column.type === 'icon',
+            'ec-table-head__cell-wrapper--text-right': column.type === 'currency',
+          }"
         >
-          <span>
+          <span :class="{'ec-table-head__cell-text--ellipsis': column.maxWidth}">
             {{ column.title }}
           </span>
           <ec-icon
@@ -93,9 +96,6 @@ export default {
         widthStyle = {
           ...widthStyle,
           maxWidth: column.maxWidth,
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
         };
       }
       return Object.keys(widthStyle).length ? widthStyle : null;
@@ -121,7 +121,11 @@ export default {
     display: flex;
     align-items: center;
 
-    &--justify-end {
+    &--text-center {
+      justify-content: center;
+    }
+
+    &--text-right {
       justify-content: flex-end;
     }
   }
@@ -163,6 +167,10 @@ export default {
     &--text-center {
       text-align: center;
     }
+  }
+
+  &__cell-text--ellipsis {
+    @include ellipsis;
   }
 }
 </style>

--- a/src/components/ec-table-head/ec-table-head.vue
+++ b/src/components/ec-table-head/ec-table-head.vue
@@ -11,18 +11,18 @@
         :style="getWidthStyle(column)"
         :data-test="`ec-table-head__cell ec-table-head__cell--${colIndex}`"
         class="ec-table-head__cell"
-        :class="[ getStickyColumnClass(colIndex, columns), {'ec-table-head__cell--text-center': column.type === 'icon'}]"
+        :class="getStickyColumnClass(colIndex, columns)"
         :colspan="column.span"
         scope="col"
       >
         <span
           class="ec-table-head__cell-wrapper"
           :class="{
-            'ec-table-head__cell-wrapper--text-center': column.type === 'icon',
-            'ec-table-head__cell-wrapper--text-right': column.type === 'currency',
+            'ec-table-head__cell-wrapper--is-type-icon': column.type === 'icon',
+            'ec-table-head__cell-wrapper--is-type-currency': column.type === 'currency',
           }"
         >
-          <span :class="{'ec-table-head__cell-text--ellipsis': column.maxWidth}">
+          <span :class="{'ec-table-head__cell-text--is-ellipsis': column.maxWidth}">
             {{ column.title }}
           </span>
           <ec-icon
@@ -121,11 +121,11 @@ export default {
     display: flex;
     align-items: center;
 
-    &--text-center {
+    &--is-type-icon {
       justify-content: center;
     }
 
-    &--text-right {
+    &--is-type-currency {
       justify-content: flex-end;
     }
   }
@@ -163,13 +163,9 @@ export default {
     &:last-child {
       padding-right: 16px;
     }
-
-    &--text-center {
-      text-align: center;
-    }
   }
 
-  &__cell-text--ellipsis {
+  &__cell-text--is-ellipsis {
     @include ellipsis;
   }
 }

--- a/src/components/ec-table/__snapshots__/ec-table.spec.js.snap
+++ b/src/components/ec-table/__snapshots__/ec-table.spec.js.snap
@@ -1154,7 +1154,7 @@ exports[`EcTable should render the style with the max-width on each cell of the 
               class="ec-table-head__cell-wrapper"
             >
               <span
-                class="ec-table-head__cell-text--is-ellipsis"
+                class="ec-table-head__cell-text--has-max-width"
               >
                 
           Lorem
@@ -1196,7 +1196,7 @@ exports[`EcTable should render the style with the max-width on each cell of the 
           data-test="ec-table__row ec-table__row--0"
         >
           <td
-            class="ec-table__cell ec-table__cell--is-ellipsis"
+            class="ec-table__cell ec-table__cell--has-max-width"
             data-test="ec-table__cell ec-table__cell--0"
             style="max-width: 250px;"
           >
@@ -1214,7 +1214,7 @@ exports[`EcTable should render the style with the max-width on each cell of the 
           data-test="ec-table__row ec-table__row--1"
         >
           <td
-            class="ec-table__cell ec-table__cell--is-ellipsis"
+            class="ec-table__cell ec-table__cell--has-max-width"
             data-test="ec-table__cell ec-table__cell--0"
             style="max-width: 250px;"
           >

--- a/src/components/ec-table/__snapshots__/ec-table.spec.js.snap
+++ b/src/components/ec-table/__snapshots__/ec-table.spec.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EcTable should have a column align to right if its type is currency 1`] = `
+exports[`EcTable should have a column align to center if its type is icon 1`] = `
 <div>
   <!---->
    
@@ -43,7 +43,7 @@ exports[`EcTable should have a column align to right if its type is currency 1`]
             scope="col"
           >
             <span
-              class="ec-table-head__cell-wrapper ec-table-head__cell-wrapper--text-right"
+              class="ec-table-head__cell-wrapper ec-table-head__cell-wrapper--is-type-icon"
             >
               <span
                 class=""
@@ -73,7 +73,7 @@ exports[`EcTable should have a column align to right if its type is currency 1`]
             foo
           </td>
           <td
-            class="ec-table__cell ec-table__cell--text-right"
+            class="ec-table__cell ec-table__cell--is-type-icon"
             data-test="ec-table__cell ec-table__cell--1"
           >
             bar
@@ -90,7 +90,7 @@ exports[`EcTable should have a column align to right if its type is currency 1`]
             widgets
           </td>
           <td
-            class="ec-table__cell ec-table__cell--text-right"
+            class="ec-table__cell ec-table__cell--is-type-icon"
             data-test="ec-table__cell ec-table__cell--1"
           >
             doodads
@@ -104,7 +104,7 @@ exports[`EcTable should have a column align to right if its type is currency 1`]
 </div>
 `;
 
-exports[`EcTable should have class ec-table-cell--text-center if type of column is icon 1`] = `
+exports[`EcTable should have a column align to the right if its type is currency 1`] = `
 <div>
   <!---->
    
@@ -142,12 +142,12 @@ exports[`EcTable should have class ec-table-cell--text-center if type of column 
             </span>
           </th>
           <th
-            class="ec-table-head__cell ec-table-head__cell--text-center"
+            class="ec-table-head__cell"
             data-test="ec-table-head__cell ec-table-head__cell--1"
             scope="col"
           >
             <span
-              class="ec-table-head__cell-wrapper ec-table-head__cell-wrapper--text-center"
+              class="ec-table-head__cell-wrapper ec-table-head__cell-wrapper--is-type-currency"
             >
               <span
                 class=""
@@ -177,7 +177,7 @@ exports[`EcTable should have class ec-table-cell--text-center if type of column 
             foo
           </td>
           <td
-            class="ec-table__cell ec-table__cell--text-center"
+            class="ec-table__cell ec-table__cell--is-type-currency"
             data-test="ec-table__cell ec-table__cell--1"
           >
             bar
@@ -194,7 +194,7 @@ exports[`EcTable should have class ec-table-cell--text-center if type of column 
             widgets
           </td>
           <td
-            class="ec-table__cell ec-table__cell--text-center"
+            class="ec-table__cell ec-table__cell--is-type-currency"
             data-test="ec-table__cell ec-table__cell--1"
           >
             doodads
@@ -1154,7 +1154,7 @@ exports[`EcTable should render the style with the max-width on each cell of the 
               class="ec-table-head__cell-wrapper"
             >
               <span
-                class="ec-table-head__cell-text--ellipsis"
+                class="ec-table-head__cell-text--is-ellipsis"
               >
                 
           Lorem
@@ -1196,7 +1196,7 @@ exports[`EcTable should render the style with the max-width on each cell of the 
           data-test="ec-table__row ec-table__row--0"
         >
           <td
-            class="ec-table__cell ec-table__cell--ellipsis"
+            class="ec-table__cell ec-table__cell--is-ellipsis"
             data-test="ec-table__cell ec-table__cell--0"
             style="max-width: 250px;"
           >
@@ -1214,7 +1214,7 @@ exports[`EcTable should render the style with the max-width on each cell of the 
           data-test="ec-table__row ec-table__row--1"
         >
           <td
-            class="ec-table__cell ec-table__cell--ellipsis"
+            class="ec-table__cell ec-table__cell--is-ellipsis"
             data-test="ec-table__cell ec-table__cell--0"
             style="max-width: 250px;"
           >

--- a/src/components/ec-table/__snapshots__/ec-table.spec.js.snap
+++ b/src/components/ec-table/__snapshots__/ec-table.spec.js.snap
@@ -1,5 +1,109 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EcTable should have a column align to right if its type is currency 1`] = `
+<div>
+  <!---->
+   
+  <div
+    class="ec-table-scroll-container"
+    data-test="ec-table-scroll-container"
+  >
+    <table
+      class="ec-table"
+    >
+      <thead
+        class="ec-table-head"
+        data-test="ec-table-head"
+      >
+        <tr>
+          <th
+            class="ec-table-head__cell"
+            data-test="ec-table-head__cell ec-table-head__cell--0"
+            scope="col"
+          >
+            <span
+              class="ec-table-head__cell-wrapper"
+            >
+              <span
+                class=""
+              >
+                
+          Lorem
+        
+              </span>
+               
+              <!---->
+               
+              <!---->
+            </span>
+          </th>
+          <th
+            class="ec-table-head__cell"
+            data-test="ec-table-head__cell ec-table-head__cell--1"
+            scope="col"
+          >
+            <span
+              class="ec-table-head__cell-wrapper ec-table-head__cell-wrapper--text-right"
+            >
+              <span
+                class=""
+              >
+                
+          Ipsum
+        
+              </span>
+               
+              <!---->
+               
+              <!---->
+            </span>
+          </th>
+        </tr>
+      </thead>
+       
+      <tbody>
+        <tr
+          class=""
+          data-test="ec-table__row ec-table__row--0"
+        >
+          <td
+            class="ec-table__cell"
+            data-test="ec-table__cell ec-table__cell--0"
+          >
+            foo
+          </td>
+          <td
+            class="ec-table__cell ec-table__cell--text-right"
+            data-test="ec-table__cell ec-table__cell--1"
+          >
+            bar
+          </td>
+        </tr>
+        <tr
+          class=""
+          data-test="ec-table__row ec-table__row--1"
+        >
+          <td
+            class="ec-table__cell"
+            data-test="ec-table__cell ec-table__cell--0"
+          >
+            widgets
+          </td>
+          <td
+            class="ec-table__cell ec-table__cell--text-right"
+            data-test="ec-table__cell ec-table__cell--1"
+          >
+            doodads
+          </td>
+        </tr>
+      </tbody>
+       
+      <!---->
+    </table>
+  </div>
+</div>
+`;
+
 exports[`EcTable should have class ec-table-cell--text-center if type of column is icon 1`] = `
 <div>
   <!---->
@@ -24,7 +128,9 @@ exports[`EcTable should have class ec-table-cell--text-center if type of column 
             <span
               class="ec-table-head__cell-wrapper"
             >
-              <span>
+              <span
+                class=""
+              >
                 
           Lorem
         
@@ -41,9 +147,11 @@ exports[`EcTable should have class ec-table-cell--text-center if type of column 
             scope="col"
           >
             <span
-              class="ec-table-head__cell-wrapper"
+              class="ec-table-head__cell-wrapper ec-table-head__cell-wrapper--text-center"
             >
-              <span>
+              <span
+                class=""
+              >
                 
           Ipsum
         
@@ -130,7 +238,9 @@ exports[`EcTable should render as expected if provided with data and columns 1`]
             <span
               class="ec-table-head__cell-wrapper"
             >
-              <span>
+              <span
+                class=""
+              >
                 
           Lorem
         
@@ -149,7 +259,9 @@ exports[`EcTable should render as expected if provided with data and columns 1`]
             <span
               class="ec-table-head__cell-wrapper"
             >
-              <span>
+              <span
+                class=""
+              >
                 
           Ipsum
         
@@ -230,7 +342,9 @@ exports[`EcTable should render as expected if provided with data and columns, wi
             <span
               class="ec-table-head__cell-wrapper"
             >
-              <span>
+              <span
+                class=""
+              >
                 
           Lorem
         
@@ -249,7 +363,9 @@ exports[`EcTable should render as expected if provided with data and columns, wi
             <span
               class="ec-table-head__cell-wrapper"
             >
-              <span>
+              <span
+                class=""
+              >
                 
           Ipsum
         
@@ -530,7 +646,9 @@ exports[`EcTable should render as expected if provided with rows and columns, wi
             <span
               class="ec-table-head__cell-wrapper"
             >
-              <span>
+              <span
+                class=""
+              >
                 
           Lorem
         
@@ -549,7 +667,9 @@ exports[`EcTable should render as expected if provided with rows and columns, wi
             <span
               class="ec-table-head__cell-wrapper"
             >
-              <span>
+              <span
+                class=""
+              >
                 
           Ipsum
         
@@ -669,7 +789,9 @@ exports[`EcTable should render as expected if provided with rows and columns, wi
             <span
               class="ec-table-head__cell-wrapper"
             >
-              <span>
+              <span
+                class=""
+              >
                 
           Lorem
         
@@ -688,7 +810,9 @@ exports[`EcTable should render as expected if provided with rows and columns, wi
             <span
               class="ec-table-head__cell-wrapper"
             >
-              <span>
+              <span
+                class=""
+              >
                 
           Ipsum
         
@@ -779,106 +903,6 @@ exports[`EcTable should render as expected if provided with rows and columns, wi
 </div>
 `;
 
-exports[`EcTable should render has expected if a column is defined to align to the right 1`] = `
-<div>
-  <!---->
-   
-  <div
-    class="ec-table-scroll-container"
-    data-test="ec-table-scroll-container"
-  >
-    <table
-      class="ec-table"
-    >
-      <thead
-        class="ec-table-head"
-        data-test="ec-table-head"
-      >
-        <tr>
-          <th
-            class="ec-table-head__cell"
-            data-test="ec-table-head__cell ec-table-head__cell--0"
-            scope="col"
-          >
-            <span
-              class="ec-table-head__cell-wrapper ec-table-head__cell-wrapper--justify-end"
-            >
-              <span>
-                
-          Lorem
-        
-              </span>
-               
-              <!---->
-               
-              <!---->
-            </span>
-          </th>
-          <th
-            class="ec-table-head__cell"
-            data-test="ec-table-head__cell ec-table-head__cell--1"
-            scope="col"
-          >
-            <span
-              class="ec-table-head__cell-wrapper"
-            >
-              <span>
-                
-          Ipsum
-        
-              </span>
-               
-              <!---->
-               
-              <!---->
-            </span>
-          </th>
-        </tr>
-      </thead>
-       
-      <tbody>
-        <tr
-          class=""
-          data-test="ec-table__row ec-table__row--0"
-        >
-          <td
-            class="ec-table__cell ec-table__cell--text-right"
-            data-test="ec-table__cell ec-table__cell--0"
-          >
-            foo
-          </td>
-          <td
-            class="ec-table__cell"
-            data-test="ec-table__cell ec-table__cell--1"
-          >
-            bar
-          </td>
-        </tr>
-        <tr
-          class=""
-          data-test="ec-table__row ec-table__row--1"
-        >
-          <td
-            class="ec-table__cell ec-table__cell--text-right"
-            data-test="ec-table__cell ec-table__cell--0"
-          >
-            widgets
-          </td>
-          <td
-            class="ec-table__cell"
-            data-test="ec-table__cell ec-table__cell--1"
-          >
-            doodads
-          </td>
-        </tr>
-      </tbody>
-       
-      <!---->
-    </table>
-  </div>
-</div>
-`;
-
 exports[`EcTable should render slots as expected 1`] = `
 <div>
   <!---->
@@ -903,7 +927,9 @@ exports[`EcTable should render slots as expected 1`] = `
             <span
               class="ec-table-head__cell-wrapper"
             >
-              <span>
+              <span
+                class=""
+              >
                 
           Lorem
         
@@ -922,7 +948,9 @@ exports[`EcTable should render slots as expected 1`] = `
             <span
               class="ec-table-head__cell-wrapper"
             >
-              <span>
+              <span
+                class=""
+              >
                 
           Ipsum
         
@@ -1018,7 +1046,9 @@ exports[`EcTable should render sorting as expected 1`] = `
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Lorem
         
@@ -1059,7 +1089,9 @@ exports[`EcTable should render sorting as expected 1`] = `
       <span
         class="ec-table-head__cell-wrapper"
       >
-        <span>
+        <span
+          class=""
+        >
           
           Ipsum
         
@@ -1094,4 +1126,111 @@ exports[`EcTable should render sorting as expected 1`] = `
     </th>
   </tr>
 </thead>
+`;
+
+exports[`EcTable should render the style with the max-width on each cell of the column that have the prop given 1`] = `
+<div>
+  <!---->
+   
+  <div
+    class="ec-table-scroll-container"
+    data-test="ec-table-scroll-container"
+  >
+    <table
+      class="ec-table"
+    >
+      <thead
+        class="ec-table-head"
+        data-test="ec-table-head"
+      >
+        <tr>
+          <th
+            class="ec-table-head__cell"
+            data-test="ec-table-head__cell ec-table-head__cell--0"
+            scope="col"
+            style="max-width: 250px;"
+          >
+            <span
+              class="ec-table-head__cell-wrapper"
+            >
+              <span
+                class="ec-table-head__cell-text--ellipsis"
+              >
+                
+          Lorem
+        
+              </span>
+               
+              <!---->
+               
+              <!---->
+            </span>
+          </th>
+          <th
+            class="ec-table-head__cell"
+            data-test="ec-table-head__cell ec-table-head__cell--1"
+            scope="col"
+          >
+            <span
+              class="ec-table-head__cell-wrapper"
+            >
+              <span
+                class=""
+              >
+                
+          Ipsum
+        
+              </span>
+               
+              <!---->
+               
+              <!---->
+            </span>
+          </th>
+        </tr>
+      </thead>
+       
+      <tbody>
+        <tr
+          class=""
+          data-test="ec-table__row ec-table__row--0"
+        >
+          <td
+            class="ec-table__cell ec-table__cell--ellipsis"
+            data-test="ec-table__cell ec-table__cell--0"
+            style="max-width: 250px;"
+          >
+            foo
+          </td>
+          <td
+            class="ec-table__cell"
+            data-test="ec-table__cell ec-table__cell--1"
+          >
+            bar
+          </td>
+        </tr>
+        <tr
+          class=""
+          data-test="ec-table__row ec-table__row--1"
+        >
+          <td
+            class="ec-table__cell ec-table__cell--ellipsis"
+            data-test="ec-table__cell ec-table__cell--0"
+            style="max-width: 250px;"
+          >
+            widgets
+          </td>
+          <td
+            class="ec-table__cell"
+            data-test="ec-table__cell ec-table__cell--1"
+          >
+            doodads
+          </td>
+        </tr>
+      </tbody>
+       
+      <!---->
+    </table>
+  </div>
+</div>
 `;

--- a/src/components/ec-table/__snapshots__/ec-table.spec.js.snap
+++ b/src/components/ec-table/__snapshots__/ec-table.spec.js.snap
@@ -779,6 +779,106 @@ exports[`EcTable should render as expected if provided with rows and columns, wi
 </div>
 `;
 
+exports[`EcTable should render has expected if a column is defined to align to the right 1`] = `
+<div>
+  <!---->
+   
+  <div
+    class="ec-table-scroll-container"
+    data-test="ec-table-scroll-container"
+  >
+    <table
+      class="ec-table"
+    >
+      <thead
+        class="ec-table-head"
+        data-test="ec-table-head"
+      >
+        <tr>
+          <th
+            class="ec-table-head__cell"
+            data-test="ec-table-head__cell ec-table-head__cell--0"
+            scope="col"
+          >
+            <span
+              class="ec-table-head__cell-wrapper ec-table-head__cell-wrapper--justify-end"
+            >
+              <span>
+                
+          Lorem
+        
+              </span>
+               
+              <!---->
+               
+              <!---->
+            </span>
+          </th>
+          <th
+            class="ec-table-head__cell"
+            data-test="ec-table-head__cell ec-table-head__cell--1"
+            scope="col"
+          >
+            <span
+              class="ec-table-head__cell-wrapper"
+            >
+              <span>
+                
+          Ipsum
+        
+              </span>
+               
+              <!---->
+               
+              <!---->
+            </span>
+          </th>
+        </tr>
+      </thead>
+       
+      <tbody>
+        <tr
+          class=""
+          data-test="ec-table__row ec-table__row--0"
+        >
+          <td
+            class="ec-table__cell ec-table__cell--text-right"
+            data-test="ec-table__cell ec-table__cell--0"
+          >
+            foo
+          </td>
+          <td
+            class="ec-table__cell"
+            data-test="ec-table__cell ec-table__cell--1"
+          >
+            bar
+          </td>
+        </tr>
+        <tr
+          class=""
+          data-test="ec-table__row ec-table__row--1"
+        >
+          <td
+            class="ec-table__cell ec-table__cell--text-right"
+            data-test="ec-table__cell ec-table__cell--0"
+          >
+            widgets
+          </td>
+          <td
+            class="ec-table__cell"
+            data-test="ec-table__cell ec-table__cell--1"
+          >
+            doodads
+          </td>
+        </tr>
+      </tbody>
+       
+      <!---->
+    </table>
+  </div>
+</div>
+`;
+
 exports[`EcTable should render slots as expected 1`] = `
 <div>
   <!---->

--- a/src/components/ec-table/ec-table.spec.js
+++ b/src/components/ec-table/ec-table.spec.js
@@ -325,4 +325,40 @@ describe('EcTable', () => {
     expect(wrapperArray.length).toBe(columns.length);
     wrapperArray.wrappers.forEach(wrapperItem => expect(wrapperItem.attributes('style')).toBe('min-width: 250px;'));
   });
+
+  it('should render the style with the max-width on each cell of the column that have the prop given', () => {
+    const columns = [
+      {
+        name: 'lorem',
+        title: 'Lorem',
+        maxWidth: '250px',
+      },
+      {
+        name: 'ipsum',
+        title: 'Ipsum',
+      },
+    ];
+    const wrapper = mountTable({ columns });
+    const wrapperArray = wrapper.findAllByDataTest('ec-table__cell--0');
+    expect(wrapperArray.length).toBe(columns.length);
+    wrapperArray.wrappers.forEach(wrapperItem => expect(wrapperItem.attributes('style')).toBe('max-width: 250px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;'));
+  });
+
+  it('should render has expected if a column is defined to align to the right', () => {
+    const wrapper = mountTable({
+      columns: [
+        {
+          name: 'lorem',
+          title: 'Lorem',
+          align: 'right',
+        },
+        {
+          name: 'ipsum',
+          title: 'Ipsum',
+        },
+      ],
+    });
+
+    expect(wrapper.element).toMatchSnapshot();
+  });
 });

--- a/src/components/ec-table/ec-table.spec.js
+++ b/src/components/ec-table/ec-table.spec.js
@@ -104,7 +104,7 @@ describe('EcTable', () => {
     expect(wrapper.element).toMatchSnapshot();
   });
 
-  it('should have class ec-table-cell--text-center if type of column is icon', () => {
+  it('should have a column align to center if its type is icon', () => {
     const wrapper = mountTableAsTemplate(
       '<ec-table :columns="columns" :data="data"/>',
       {},
@@ -131,13 +131,10 @@ describe('EcTable', () => {
       },
     );
 
-    expect(wrapper.findByDataTest('ec-table__cell--0').classes('ec-table__cell--text-center')).toBe(false);
-    expect(wrapper.findByDataTest('ec-table__cell--1').classes('ec-table__cell--text-center')).toBe(true);
-
     expect(wrapper.element).toMatchSnapshot();
   });
 
-  it('should have a column align to right if its type is currency', () => {
+  it('should have a column align to the right if its type is currency', () => {
     const wrapper = mountTableAsTemplate(
       '<ec-table :columns="columns" :data="data"/>',
       {},

--- a/src/components/ec-table/ec-table.spec.js
+++ b/src/components/ec-table/ec-table.spec.js
@@ -137,6 +137,36 @@ describe('EcTable', () => {
     expect(wrapper.element).toMatchSnapshot();
   });
 
+  it('should have a column align to right if its type is currency', () => {
+    const wrapper = mountTableAsTemplate(
+      '<ec-table :columns="columns" :data="data"/>',
+      {},
+      {
+        data() {
+          return {
+            columns: [
+              {
+                name: 'lorem',
+                title: 'Lorem',
+              },
+              {
+                name: 'ipsum',
+                title: 'Ipsum',
+                type: 'currency',
+              },
+            ],
+            data: [
+              ['foo', 'bar'],
+              ['widgets', 'doodads'],
+            ],
+          };
+        },
+      },
+    );
+
+    expect(wrapper.element).toMatchSnapshot();
+  });
+
   it('the tr should have class ec-table-row--is-clickable if we set the listener on row-click', async () => {
     const onRowClick = jest.fn();
     const wrapper = mountTable(
@@ -339,25 +369,6 @@ describe('EcTable', () => {
       },
     ];
     const wrapper = mountTable({ columns });
-    const wrapperArray = wrapper.findAllByDataTest('ec-table__cell--0');
-    expect(wrapperArray.length).toBe(columns.length);
-    wrapperArray.wrappers.forEach(wrapperItem => expect(wrapperItem.attributes('style')).toBe('max-width: 250px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;'));
-  });
-
-  it('should render has expected if a column is defined to align to the right', () => {
-    const wrapper = mountTable({
-      columns: [
-        {
-          name: 'lorem',
-          title: 'Lorem',
-          align: 'right',
-        },
-        {
-          name: 'ipsum',
-          title: 'Ipsum',
-        },
-      ],
-    });
 
     expect(wrapper.element).toMatchSnapshot();
   });

--- a/src/components/ec-table/ec-table.story.js
+++ b/src/components/ec-table/ec-table.story.js
@@ -57,17 +57,17 @@ const sorts = [
 const data = [
   [
     'Lorem',
+    'EUR 100',
     'ipsum',
     'dolor',
-    'sit',
-    'amet, consectetur adipiscing elit. Vestibulum eget ultricies turpis',
+    'sit amet, consectetur adipiscing elit. Vestibulum eget ultricies turpis',
   ],
   [
     'foo',
+    'GBP 200',
     'bar',
     'baz',
     'qux',
-    'quux',
   ],
 ];
 

--- a/src/components/ec-table/ec-table.story.js
+++ b/src/components/ec-table/ec-table.story.js
@@ -23,7 +23,7 @@ const columns = [
     title: 'Original amount',
     sortable: true,
     tooltip: 'This is info test',
-    align: 'right',
+    type: 'currency',
   },
   {
     name: 'repayment-date',
@@ -37,8 +37,8 @@ const columns = [
     tooltip: 'This is info test',
   },
   {
-    name: 'text-long',
-    title: 'Text long',
+    name: 'long-text',
+    title: 'Text too long to display',
     maxWidth: '120px',
   },
 ];

--- a/src/components/ec-table/ec-table.story.js
+++ b/src/components/ec-table/ec-table.story.js
@@ -23,6 +23,7 @@ const columns = [
     title: 'Original amount',
     sortable: true,
     tooltip: 'This is info test',
+    align: 'right',
   },
   {
     name: 'repayment-date',
@@ -34,6 +35,11 @@ const columns = [
     title: 'Status',
     type: 'icon',
     tooltip: 'This is info test',
+  },
+  {
+    name: 'text-long',
+    title: 'Text long',
+    maxWidth: '120px',
   },
 ];
 
@@ -54,12 +60,14 @@ const data = [
     'ipsum',
     'dolor',
     'sit',
+    'amet, consectetur adipiscing elit. Vestibulum eget ultricies turpis',
   ],
   [
     'foo',
     'bar',
     'baz',
-    'sit',
+    'qux',
+    'quux',
   ],
 ];
 

--- a/src/components/ec-table/ec-table.vue
+++ b/src/components/ec-table/ec-table.vue
@@ -38,7 +38,7 @@
                 {
                   'ec-table__cell--is-type-icon': columns[colIndex] && columns[colIndex].type === 'icon',
                   'ec-table__cell--is-type-currency': columns[colIndex] && columns[colIndex].type === 'currency',
-                  'ec-table__cell--is-ellipsis': columns[colIndex] && columns[colIndex].maxWidth,
+                  'ec-table__cell--has-max-width': columns[colIndex] && columns[colIndex].maxWidth,
                 }]"
             >
               <slot
@@ -123,20 +123,10 @@ export default {
       this.$emit('sort', columnName);
     },
     getColumnWidth(column) {
-      let widthStyle = {};
-      if (column && column.minWidth) {
-        widthStyle = {
-          ...widthStyle,
-          minWidth: column.minWidth,
-        };
+      if (column && (column.maxWidth || column.minWidth)) {
+        return { maxWidth: column.maxWidth, minWidth: column.minWidth };
       }
-      if (column && column.maxWidth) {
-        widthStyle = {
-          ...widthStyle,
-          maxWidth: column.maxWidth,
-        };
-      }
-      return Object.keys(widthStyle).length ? widthStyle : null;
+      return null;
     },
     getStickyColumnClass(colIndex, columns) {
       if (this.stickyColumn === 'left' && colIndex === 0) {
@@ -223,7 +213,7 @@ export default {
       }
     }
 
-    &--is-ellipsis {
+    &--has-max-width {
       @include ellipsis;
     }
   }

--- a/src/components/ec-table/ec-table.vue
+++ b/src/components/ec-table/ec-table.vue
@@ -35,7 +35,10 @@
               class="ec-table__cell"
               :class="[
                 getStickyColumnClass(colIndex, columns),
-                { 'ec-table__cell--text-center': columns[colIndex] && columns[colIndex].type === 'icon' }]"
+                {
+                  'ec-table__cell--text-center': columns[colIndex] && columns[colIndex].type === 'icon',
+                  'ec-table__cell--text-right': columns[colIndex] && columns[colIndex].align === 'right',
+                }]"
             >
               <slot
                 :name="getSlotName(colIndex)"
@@ -119,7 +122,23 @@ export default {
       this.$emit('sort', columnName);
     },
     getColumnWidth(column) {
-      return column && column.minWidth ? { minWidth: column.minWidth } : null;
+      let widthStyle = {};
+      if (column && column.minWidth) {
+        widthStyle = {
+          ...widthStyle,
+          minWidth: column.minWidth,
+        };
+      }
+      if (column && column.maxWidth) {
+        widthStyle = {
+          ...widthStyle,
+          maxWidth: column.maxWidth,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        };
+      }
+      return Object.keys(widthStyle).length ? widthStyle : null;
     },
     getStickyColumnClass(colIndex, columns) {
       if (this.stickyColumn === 'left' && colIndex === 0) {
@@ -180,6 +199,10 @@ export default {
 
     &--text-center {
       text-align: center;
+    }
+
+    &--text-right {
+      text-align: right;
     }
 
     &--sticky-left {

--- a/src/components/ec-table/ec-table.vue
+++ b/src/components/ec-table/ec-table.vue
@@ -37,7 +37,8 @@
                 getStickyColumnClass(colIndex, columns),
                 {
                   'ec-table__cell--text-center': columns[colIndex] && columns[colIndex].type === 'icon',
-                  'ec-table__cell--text-right': columns[colIndex] && columns[colIndex].align === 'right',
+                  'ec-table__cell--text-right': columns[colIndex] && columns[colIndex].type === 'currency',
+                  'ec-table__cell--ellipsis': columns[colIndex] && columns[colIndex].maxWidth,
                 }]"
             >
               <slot
@@ -133,9 +134,6 @@ export default {
         widthStyle = {
           ...widthStyle,
           maxWidth: column.maxWidth,
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
         };
       }
       return Object.keys(widthStyle).length ? widthStyle : null;
@@ -223,6 +221,10 @@ export default {
       .ec-table__row--is-clickable:hover & {
         background: $level-6;
       }
+    }
+
+    &--ellipsis {
+      @include ellipsis;
     }
   }
 }

--- a/src/components/ec-table/ec-table.vue
+++ b/src/components/ec-table/ec-table.vue
@@ -36,9 +36,9 @@
               :class="[
                 getStickyColumnClass(colIndex, columns),
                 {
-                  'ec-table__cell--text-center': columns[colIndex] && columns[colIndex].type === 'icon',
-                  'ec-table__cell--text-right': columns[colIndex] && columns[colIndex].type === 'currency',
-                  'ec-table__cell--ellipsis': columns[colIndex] && columns[colIndex].maxWidth,
+                  'ec-table__cell--is-type-icon': columns[colIndex] && columns[colIndex].type === 'icon',
+                  'ec-table__cell--is-type-currency': columns[colIndex] && columns[colIndex].type === 'currency',
+                  'ec-table__cell--is-ellipsis': columns[colIndex] && columns[colIndex].maxWidth,
                 }]"
             >
               <slot
@@ -195,11 +195,11 @@ export default {
 
     @include body-text;
 
-    &--text-center {
+    &--is-type-icon {
       text-align: center;
     }
 
-    &--text-right {
+    &--is-type-currency {
       text-align: right;
     }
 
@@ -223,7 +223,7 @@ export default {
       }
     }
 
-    &--ellipsis {
+    &--is-ellipsis {
       @include ellipsis;
     }
   }


### PR DESCRIPTION
I would like to add a couple of new features to the _EcTable_ component.

- To be able to align columns to the right (by default they are all aligned to the left, except the ones containing an icon that are centered).
- To be able to define a _maxWidth_ of column. If the text inside the cell requires more space than the column offers, use the _ellipsis_. 