### PR TITLE
ONL-4168: feat: Reworked how currency input displays disabled currencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.83",
+  "version": "0.1.84",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/components/ec-currency-input/__snapshots__/ec-currency-input.spec.js.snap
+++ b/src/components/ec-currency-input/__snapshots__/ec-currency-input.spec.js.snap
@@ -100,16 +100,13 @@ exports[`EcCurrencyInput :props should render a loading state when currenciesLoa
 </ecpopover-stub>
 `;
 
-exports[`EcCurrencyInput :props should render the component with the dropdown disabled when isCurrenciesDisabled is set true 1`] = `
-<input
-  class="ec-input-field__input ec-input-field__input--is-in-group-right ec-input-field__input--has-icon"
-  data-test="ec-currency-input__currencies ec-dropdown__input ec-input-field__input"
-  disabled="disabled"
-  id="ec-currency-input-field-73"
-  placeholder=""
-  readonly="readonly"
-  type="text"
-/>
+exports[`EcCurrencyInput :props should render the component with the dropdown part disabled when isCurrenciesDisabled is set true 1`] = `
+<div
+  class="ec-currency-input__currencies ec-currency-input__currencies--is-disabled"
+  data-test="ec-currency-input__currencies"
+>
+  EUR
+</div>
 `;
 
 exports[`EcCurrencyInput :props should render the component with the input disabled when isAmountDisabled is set true 1`] = `
@@ -117,7 +114,7 @@ exports[`EcCurrencyInput :props should render the component with the input disab
   class="ec-input-field__input ec-input-field__input--is-in-group-left"
   data-test="ec-currency-input__amount ec-amount-input ec-input-field__input"
   disabled="disabled"
-  id="ec-input-field-91"
+  id="ec-input-field-85"
   type="text"
 />
 `;

--- a/src/components/ec-currency-input/ec-currency-input.spec.js
+++ b/src/components/ec-currency-input/ec-currency-input.spec.js
@@ -84,8 +84,8 @@ describe('EcCurrencyInput', () => {
       expect(wrapper.findByDataTest('ec-popover-dropdown-search').element).toMatchSnapshot();
     });
 
-    it('should render the component with the dropdown disabled when isCurrenciesDisabled is set true', () => {
-      const wrapper = mountCurrencyInput({ isCurrenciesDisabled: true });
+    it('should render the component with the dropdown part disabled when isCurrenciesDisabled is set true', () => {
+      const wrapper = mountCurrencyInput({ isCurrenciesDisabled: true, value: { currency: 'EUR' } });
 
       expect(wrapper.findByDataTest('ec-currency-input__currencies').element).toMatchSnapshot();
     });
@@ -148,6 +148,21 @@ describe('EcCurrencyInput', () => {
       expect(wrapper.vm.value.currency).toEqual(currencies[0]);
       selectItem(wrapper, 1);
       expect(wrapper.vm.value.currency).toEqual(currencies[1]);
+    });
+
+    it('should preselect the currency item in the dropdown and the amount in the input from the v-model', () => {
+      const wrapper = mountCurrencyInputAsTemplate(
+        '<ec-currency-input :currencies="currencies" v-model="value" />',
+        {},
+        {
+          data() {
+            return { currencies, value: { currency: currencies[1], amount: 1234.56 } };
+          },
+        },
+      );
+
+      expect(wrapper.findByDataTest('ec-currency-input__currencies').element.value).toBe(currencies[1]);
+      expect(wrapper.findByDataTest('ec-currency-input__amount').element.value).toBe('1,234.56');
     });
 
     it('should use the v-model with the amount and emit the changes', async () => {

--- a/src/components/ec-currency-input/ec-currency-input.story.js
+++ b/src/components/ec-currency-input/ec-currency-input.story.js
@@ -26,8 +26,8 @@ stories
       locale: {
         default: select('locale', ['en', 'es', 'de-ch', 'jp'], 'en'),
       },
-      currenciesLoading: {
-        default: boolean('currencies loading', false),
+      currenciesAreLoading: {
+        default: boolean('currencies are loading', false),
       },
       isAmountDisabled: {
         default: boolean('amount disabled', false),
@@ -49,5 +49,3 @@ stories
       </div>
     `,
   }));
-
-export default stories;

--- a/src/components/ec-currency-input/ec-currency-input.vue
+++ b/src/components/ec-currency-input/ec-currency-input.vue
@@ -23,8 +23,15 @@
       ref="popperWidthReference"
       class="ec-currency-input__input-group"
     >
+      <div
+        v-if="isCurrenciesDisabled"
+        class="ec-currency-input__currencies ec-currency-input__currencies--is-disabled"
+        :class="{ 'ec-currency-input__currencies--is-disabled-and-has-error': isInvalid }"
+        data-test="ec-currency-input__currencies"
+      >{{ currencyModel && currencyModel.text }}</div>
       <ec-dropdown
         :id="id"
+        v-else
         v-model="currencyModel"
         :class="{ 'ec-currency-input__currencies--is-focused': currenciesHasFocus }"
         :error-id="errorId"
@@ -34,7 +41,6 @@
         class="ec-currency-input__currencies"
         is-in-group="right"
         is-search-enabled
-        :disabled="isCurrenciesDisabled"
         :is-loading="currenciesAreLoading"
         :error-message="errorMessage"
         data-test="ec-currency-input__currencies"
@@ -148,7 +154,7 @@ export default {
     },
     currencyModel: {
       get() {
-        return { text: this.value.currency };
+        return this.currenciesItems.find(item => item.value === this.value.currency);
       },
       set(item) {
         this.$emit('value-change', { ...this.value, currency: item.value });
@@ -195,9 +201,29 @@ $ec-currency-input-invalid-color: $color-error !default;
   }
 
   &__currencies {
+    $currencies-width: 104px;
+
     margin-right: -1px;
-    width: 104px;
+    width: $currencies-width;
     flex-shrink: 0;
+
+    &--is-disabled {
+      @include shape-border-radius;
+
+      width: auto;
+      flex-grow: 0;
+      min-width: 48px;
+      max-width: $currencies-width;
+      padding: 8px 12px;
+      border: 1px solid $level-6-disabled-lines;
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+      background-color: $level-6-disabled-lines;
+    }
+
+    &--is-disabled-and-has-error {
+      border: 1px solid $ec-currency-input-invalid-color;
+    }
   }
 
   &__currencies--is-focused {

--- a/src/components/ec-dropdown/__snapshots__/ec-dropdown.spec.js.snap
+++ b/src/components/ec-dropdown/__snapshots__/ec-dropdown.spec.js.snap
@@ -120,7 +120,7 @@ exports[`EcDropdown multiple value :props should get disabled when disabled prop
       />
        
       <div
-        class="ec-input-field__icon-wrapper"
+        class="ec-input-field__icon-wrapper ec-input-field__icon-wrapper--is-disabled"
       >
         <svg
           class="ec-input-field__icon ec-icon"
@@ -900,7 +900,7 @@ exports[`EcDropdown single value :props should get disabled when disabled prop i
       />
        
       <div
-        class="ec-input-field__icon-wrapper"
+        class="ec-input-field__icon-wrapper ec-input-field__icon-wrapper--is-disabled"
       >
         <svg
           class="ec-input-field__icon ec-icon"

--- a/src/components/ec-input-field/__snapshots__/ec-input-field.spec.js.snap
+++ b/src/components/ec-input-field/__snapshots__/ec-input-field.spec.js.snap
@@ -1,5 +1,96 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EcInputField renders properly the icon when disabled 1`] = `
+<div
+  class="ec-input-field"
+  data-test="ec-input-field"
+>
+  <label
+    class="ec-input-field__label"
+    data-test="ec-input-field__label"
+    for="ec-input-field-37"
+  >
+    <span
+      class="ec-input-field__label-text"
+      data-test="ec-input-field__label-text"
+    >
+      label test
+    </span>
+     
+    <span
+      class="ec-input-field__note"
+      data-test="ec-input-field__note"
+    >
+      note test
+    </span>
+  </label>
+   
+  <input
+    class="ec-input-field__input ec-input-field__input--has-icon"
+    data-test="ec-input-field__input"
+    disabled="disabled"
+    id="ec-input-field-37"
+    type="text"
+  />
+   
+  <div
+    class="ec-input-field__icon-wrapper ec-input-field__icon-wrapper--is-disabled"
+  >
+    <svg
+      class="ec-input-field__icon ec-icon"
+      data-test="ec-input-field__icon"
+      height="20"
+      width="20"
+    >
+      <use
+        xlink:href="#ec-simple-check"
+      />
+    </svg>
+  </div>
+   
+  <!---->
+</div>
+`;
+
+exports[`EcInputField renders properly when disabled 1`] = `
+<div
+  class="ec-input-field"
+  data-test="ec-input-field"
+>
+  <label
+    class="ec-input-field__label"
+    data-test="ec-input-field__label"
+    for="ec-input-field-35"
+  >
+    <span
+      class="ec-input-field__label-text"
+      data-test="ec-input-field__label-text"
+    >
+      label test
+    </span>
+     
+    <span
+      class="ec-input-field__note"
+      data-test="ec-input-field__note"
+    >
+      note test
+    </span>
+  </label>
+   
+  <input
+    class="ec-input-field__input"
+    data-test="ec-input-field__input"
+    disabled="disabled"
+    id="ec-input-field-35"
+    type="text"
+  />
+   
+  <!---->
+   
+  <!---->
+</div>
+`;
+
 exports[`EcInputField renders properly with the errorId from the parent 1`] = `
 <div
   class="ec-input-field"

--- a/src/components/ec-input-field/ec-input-field.spec.js
+++ b/src/components/ec-input-field/ec-input-field.spec.js
@@ -145,4 +145,14 @@ describe('EcInputField', () => {
     const wrapper = mountInputField({ iconSize: 40 });
     expect(wrapper.find('.ec-input-field__icon-wrapper').exists()).toBe(false);
   });
+
+  it('renders properly when disabled', () => {
+    const wrapper = mountInputField({}, { attrs: { disabled: true } });
+    expect(wrapper.element).toMatchSnapshot();
+  });
+
+  it('renders properly the icon when disabled', () => {
+    const wrapper = mountInputField({ icon: 'simple-check' }, { attrs: { disabled: true } });
+    expect(wrapper.element).toMatchSnapshot();
+  });
 });

--- a/src/components/ec-input-field/ec-input-field.vue
+++ b/src/components/ec-input-field/ec-input-field.vue
@@ -38,6 +38,7 @@
     <div
       v-if="icon"
       class="ec-input-field__icon-wrapper"
+      :class="{ 'ec-input-field__icon-wrapper--is-disabled': isDisabled }"
     >
       <ec-icon
         class="ec-input-field__icon"
@@ -117,6 +118,9 @@ export default {
     isInvalid() {
       return !!this.errorMessage;
     },
+    isDisabled() {
+      return !!this.$attrs.disabled;
+    },
     inputModel: {
       get() {
         return this.value;
@@ -140,6 +144,7 @@ $ec-input-field-note-color: $level-5-placeholders !default;
 $ec-input-field-background-disabled: $level-7-backgrounds !default;
 $ec-input-field-icon-area-size: 42px !default;
 $ec-input-field-icon-color: $ec-input-field-text-color !default;
+$ec-input-field-icon-disabled-color: $level-6-disabled-lines !default;
 $ec-input-field-invalid-color: $color-error !default;
 
 .ec-input-field {
@@ -228,6 +233,10 @@ $ec-input-field-invalid-color: $color-error !default;
     line-height: $ec-input-field-icon-area-size;
     font-size: 0;
     text-align: center;
+
+    &--is-disabled {
+      color: $ec-input-field-icon-disabled-color;
+    }
   }
 
   &__icon {


### PR DESCRIPTION
The design:
![Screenshot 2020-04-29 at 12 19 39](https://user-images.githubusercontent.com/5777410/80602796-7a64b780-8a27-11ea-85da-4f70c35c5d17.png)

Little bit of details why I have split the disabled state of dropdown and created a new `<div>` instead of using `disabled` prop of `ec-dropdown` as it was before:

Disabled ec-dropdown renders:
```
<input disabled value="EUR">
```

When I disable a dropdown inside ec-currency-input, I need the the dropdown to fit the width of its content. That's not possible when the content is inside an `input`. input has width of `201px` and ignores attempts like `min-width: 0; flex-grow: 0; width: auto;`. That's why in this component I have switched the disabled state to be 
```
<div>EUR</div>
```

Second problem which is solved by using a `div` is that Uve insists on having different background color for disabled currencies than we use in regular dropdown and input-field components. I wouldn't be able to do it if we continue using ec-dropdown for disabled state.