### PR TITLE
ONL-4419: fix: typography plugin produces invalid CSS.

### DIFF
--- a/src/styles/utilities/typography.story.js
+++ b/src/styles/utilities/typography.story.js
@@ -7,7 +7,7 @@ stories.add('basic', () => ({
     return {
       types: [
         'tw-h1', 'tw-h2', 'tw-h3', 'tw-h4', 'tw-h5', 'tw-h6',
-        'tw-body-text', 'tw-body-strong',
+        'tw-body-text', 'tw-body-strong', 'tw-body-condensed',
         'tw-mini-header', 'tw-table-header',
         'tw-small-text', 'tw-caption-text',
         'tw-input-label', 'tw-btn-text', 'tw-flags-text',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -582,36 +582,36 @@ module.exports = {
       700: '700ms',
       1000: '1000ms',
     },
-    typography: {
+    typography: theme => ({
       h1: { fontSize: '35px', lineHeight: '40px', fontWeight: 400 },
       h2: { fontSize: '25px', lineHeight: '35px', fontWeight: 300 },
       h3: { fontSize: '20px', lineHeight: '30px', fontWeight: 500 },
       h4: { fontSize: '18px', lineHeight: '24px', fontWeight: 300 },
       h5: { fontSize: '16px', lineHeight: '26px', fontWeight: 500 },
       h6: {
-        fontSize: '14px', lineHeight: '24px', fontWeight: 500, '@apply uppercase': '',
+        fontSize: '14px', lineHeight: '24px', fontWeight: 500, textTransform: 'uppercase',
       },
       'body-text': { fontSize: '16px', lineHeight: '24px', fontWeight: 400 },
       'body-strong': { fontSize: '16px', lineHeight: '24px', fontWeight: 700 },
       'body-condensed': {
-        fontSize: '16px', lineHeight: '24px', fontWeight: 400, '@apply font-sans-condensed': '',
+        fontSize: '16px', lineHeight: '24px', fontWeight: 400, fontFamily: theme('fontFamily.sans-condensed').join(', '),
       },
       'small-text': { fontSize: '14px', lineHeight: '20px', fontWeight: 400 },
       'mini-header': {
-        fontSize: '14px', lineHeight: '20px', fontWeight: 400, '@apply uppercase text-gray-5': '',
+        fontSize: '14px', lineHeight: '20px', fontWeight: 400, color: theme('textColor.gray.5'), textTransform: 'uppercase',
       },
       'caption-text': {
-        fontSize: '14px', lineHeight: '20px', fontWeight: 400, '@apply text-gray-5': '',
+        fontSize: '14px', lineHeight: '20px', fontWeight: 400, color: theme('textColor.gray.5'),
       },
       'input-label': {
-        fontSize: '14px', lineHeight: '20px', fontWeight: 700, '@apply text-gray-3': '',
+        fontSize: '14px', lineHeight: '20px', fontWeight: 700, color: theme('textColor.gray.3'),
       },
       'table-header': {
-        fontSize: '14px', lineHeight: '20px', fontWeight: 700, '@apply text-gray-5': '',
+        fontSize: '14px', lineHeight: '20px', fontWeight: 700, color: theme('textColor.gray.5'),
       },
       'btn-text': { fontSize: '16px', lineHeight: '22px', fontWeight: 400 },
       'flags-text': { fontSize: '12px', lineHeight: '20px', fontWeight: 400 },
-    },
+    }),
   },
   variants: {
     accessibility: [ /* 'responsive', 'focus' */ ],


### PR DESCRIPTION
A quick fix:

After merging all 4 ITCSS layers to master I decided to run visual regression tests using old SASS and new PostCSS/Tailwind and tests detected discrepancies. Those were caused by typography plugin I wrote in tailwind:

```
h6: {
        fontSize: '14px', lineHeight: '24px', fontWeight: 500, '@apply uppercase': '',
      },
```
works only in generated utility class:
```
.tw-h6 {
  ...
  text-transform: uppercase;
}
```
but it doesn't work in `@apply`:
```
h6 {
  @apply tw-h6;
}
/* outputs invalid CSS: */
h6 {
  ...
 @apply uppercase:
}
```

It seems like tailwind cannot handle nested apply calls.

I have fixed it and run the regression tests again, everything seems working fine now.