### PR TITLE
ONL-4443: fix: Fixed currency input weird behaviour when changing currency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.88",
+  "version": "0.1.89",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.87",
+  "version": "0.1.88",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.88",
+  "version": "0.1.89",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.87",
+  "version": "0.1.88",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/components/ec-amount-input/ec-amount-input.vue
+++ b/src/components/ec-amount-input/ec-amount-input.vue
@@ -80,16 +80,19 @@ export default {
           }
 
           if (!Number.isNaN(newValue) && this.formattedValue !== '-') {
-            const formatted = format(newValue, this.getFormattingOptions());
-            this.formattedValue = formatted;
+            if (typeof newValue === 'number') {
+              this.formattedValue = new Intl.NumberFormat(this.locale, { type: 'decimal', maximumFractionDigits: this.precision }).format(this.value);
+            } else {
+              this.formattedValue = format(newValue, this.getFormattingOptions());
+            }
           }
           this.unformattedValue = newValue;
         }
       },
     },
     currency() {
-      const formatted = format(this.value, this.getFormattingOptions());
-      this.formattedValue = formatted;
+      const formatted = new Intl.NumberFormat(this.locale, { type: 'decimal', maximumFractionDigits: this.precision }).format(this.unformattedValue);
+      this.formattedValue = format(formatted, this.getFormattingOptions());
     },
     locale() {
       const formatted = new Intl.NumberFormat(this.locale, { type: 'decimal', maximumFractionDigits: this.precision }).format(this.unformattedValue);

--- a/src/components/ec-currency-input/ec-currency-input.spec.js
+++ b/src/components/ec-currency-input/ec-currency-input.spec.js
@@ -197,6 +197,61 @@ describe('EcCurrencyInput', () => {
       await wrapper.vm.$nextTick();
       expect(wrapper.findByDataTest('ec-currency-input__amount').element.value).toEqual('11,111');
     });
+
+    it('should not add decimal back when switching from JPY back to GBP', async () => {
+      const wrapper = mountCurrencyInputAsTemplate(
+        '<ec-currency-input :currencies="currencies" v-model="value" />',
+        {},
+        {
+          data() {
+            return { currencies, value: { currency: 'GBP', amount: 11111.11 } };
+          },
+        },
+      );
+
+      expect(wrapper.findByDataTest('ec-currency-input__amount').element.value).toEqual('11,111.11');
+      selectItem(wrapper, currencies.indexOf('JPY'));
+      await wrapper.vm.$nextTick();
+      expect(wrapper.findByDataTest('ec-currency-input__amount').element.value).toEqual('11,111');
+
+      selectItem(wrapper, currencies.indexOf('GBP'));
+      await wrapper.vm.$nextTick();
+      expect(wrapper.findByDataTest('ec-currency-input__amount').element.value).toEqual('11,111');
+    });
+
+    it('should preserve same format when currency changes', async () => {
+      const wrapper = mountCurrencyInputAsTemplate(
+        '<ec-currency-input :currencies="currencies" v-model="value" locale="en" />',
+        {},
+        {
+          data() {
+            return { currencies, value: { currency: 'GBP', amount: 11111.11 } };
+          },
+        },
+      );
+
+      expect(wrapper.findByDataTest('ec-currency-input__amount').element.value).toEqual('11,111.11');
+      selectItem(wrapper, currencies.indexOf('EUR'));
+      await wrapper.vm.$nextTick();
+      expect(wrapper.findByDataTest('ec-currency-input__amount').element.value).toEqual('11,111.11');
+    });
+
+    it('should preserve same format when currency changes and the locale does not use dot as a decimal separator', async () => {
+      const wrapper = mountCurrencyInputAsTemplate(
+        '<ec-currency-input :currencies="currencies" v-model="value" locale="es" />',
+        {},
+        {
+          data() {
+            return { currencies, value: { currency: 'GBP', amount: 11111.11 } };
+          },
+        },
+      );
+
+      expect(wrapper.findByDataTest('ec-currency-input__amount').element.value).toEqual('11.111,11');
+      selectItem(wrapper, currencies.indexOf('EUR'));
+      await wrapper.vm.$nextTick();
+      expect(wrapper.findByDataTest('ec-currency-input__amount').element.value).toEqual('11.111,11');
+    });
   });
 });
 


### PR DESCRIPTION
Days without a fix of currency-input: 0

This issue was found while testing latest IE11 fixes in this component.
Problem, if grouping separator is the same as the decimal separator for JS, then changing a currency leads to weird behaviour:

1. go to https://chameleon.ebury.now.sh/?path=/story/currency-input--basic
2. Chose es locale in knobs
3. Select GBP
4. Insert 123.456,78
5. Change currency to EUR
6. The value in amount should stay 123.456,78 but it changes to 12.345.678!

This was caused by the fact that grouping separator in `es` locale is `.`, same as decimal separator in JS. The problem doesn't happen with `en` locale because their grouping separator is `,`. 

All fixed!