### PR TITLE
chore: Fix warning coming from tailwind when building the production app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22062,9 +22062,9 @@
       }
     },
     "tailwindcss": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-1.4.4.tgz",
-      "integrity": "sha512-49Hy/+WnqQhxtGGjcGlhRlE7+hooX2A0/JOeJnA78fCEqDRlhURWujHY05aCl+lJ6G2qQ+1wlQTg4PqMPUcFVA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-1.4.5.tgz",
+      "integrity": "sha512-MJW96Rz3G3RrFDbDuQCU893y4bf5hMWeVbMgcCqUfLNPbO9wRogDibCEvdKitD6aX9Y90SDT2FOKD17+WmIFLQ==",
       "requires": {
         "@fullhuman/postcss-purgecss": "^2.1.2",
         "autoprefixer": "^9.4.5",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "focus-trap": "5.1.0",
-    "tailwindcss": "1.4.4",
+    "tailwindcss": "1.4.5",
     "v-tooltip": "2.0.3",
     "vue": "2.6.11",
     "vue-hoc": "0.4.7"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,7 +9,7 @@ module.exports = {
   // 2. we need to tweak the purgecss config in the real application
   // 3. we want to have purgecss available for other parts of the code in the future, e.g. purging other 3rd party libraries
   // so we set up purgecss manually. see: https://tailwindcss.com/docs/controlling-file-size/#setting-up-purgecss-manually
-  purge: [],
+  purge: false,
   target: 'ie11',
   prefix: 'tw-',
   important: false,


### PR DESCRIPTION
Remove warning which appears during production build:

```
⚠️  Tailwind is not purging unused styles because no template paths have been provided.
If you have manually configured PurgeCSS outside of Tailwind or are deliberately not
removing unused styles, set `purge: false` in your Tailwind config file to silence
this warning.
```