### PR TITLE
ONL-4585 feat: Allow the sorting order of a column to be configurable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.101",
+  "version": "0.1.102",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.100",
+  "version": "0.1.101",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.101",
+  "version": "0.1.102",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "0.1.101",
+  "version": "0.1.100",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/components/ec-smart-table/__snapshots__/ec-smart-table.spec.js.snap
+++ b/src/components/ec-smart-table/__snapshots__/ec-smart-table.spec.js.snap
@@ -103,7 +103,9 @@ exports[`EcSmartTable should render resolved data properly 1`] = `
     class="ec-loading__content ec-loading__content--is-transparent"
     data-test="ec-loading__content"
   >
-    <div>
+    <div
+      defaultsortcycle=",asc,desc"
+    >
       <!---->
        
       <div

--- a/src/components/ec-smart-table/__snapshots__/ec-smart-table.spec.js.snap
+++ b/src/components/ec-smart-table/__snapshots__/ec-smart-table.spec.js.snap
@@ -103,9 +103,7 @@ exports[`EcSmartTable should render resolved data properly 1`] = `
     class="ec-loading__content ec-loading__content--is-transparent"
     data-test="ec-loading__content"
   >
-    <div
-      defaultsortcycle=",asc,desc"
-    >
+    <div>
       <!---->
        
       <div

--- a/src/components/ec-smart-table/ec-smart-table.story.js
+++ b/src/components/ec-smart-table/ec-smart-table.story.js
@@ -20,6 +20,7 @@ const columns = [
     name: 'original-amount',
     title: 'Original amount',
     sortable: true,
+    sortCycle: [null, 'desc', 'asc'],
   },
   {
     name: 'repayment-date',
@@ -99,6 +100,12 @@ stories
       fetchEmptyList: {
         default: boolean('fetchEmptyList', false),
       },
+      defaultSortCycle: {
+        default: select('Sort Cycle by default', {
+          ascFirst: [null, 'asc', 'desc'],
+          descFirst: [null, 'desc', 'asc'],
+        }),
+      },
     },
     methods: {
       onSort: action('sort'),
@@ -162,6 +169,7 @@ stories
             :sticky-column="stickyColumn || null"
             :error-message="errorMessage || undefined"
             :empty-message="emptyMessage || undefined"
+            :default-sort-cycle="defaultSortCycle"
             @sort="onSort"
             @abort="onAborted"
             @error="onError">

--- a/src/components/ec-smart-table/ec-smart-table.story.js
+++ b/src/components/ec-smart-table/ec-smart-table.story.js
@@ -9,6 +9,7 @@ import {
 import { action } from '@storybook/addon-actions';
 import EcSmartTable from './ec-smart-table.vue';
 import * as SortDirection from '../../enums/sort-direction';
+import * as SortDirectionCycle from '../../enums/sort-direction-cycle';
 
 const columns = [
   {
@@ -20,7 +21,7 @@ const columns = [
     name: 'original-amount',
     title: 'Original amount',
     sortable: true,
-    sortCycle: [null, 'desc', 'asc'],
+    sortCycle: SortDirectionCycle.HIGHEST_FIRST,
   },
   {
     name: 'repayment-date',
@@ -100,10 +101,10 @@ stories
       fetchEmptyList: {
         default: boolean('fetchEmptyList', false),
       },
-      defaultSortCycle: {
-        default: select('Sort Cycle by default', {
-          ascFirst: [null, 'asc', 'desc'],
-          descFirst: [null, 'desc', 'asc'],
+      sortCycle: {
+        default: select('sortCycle', {
+          lowestFirst: SortDirectionCycle.LOWEST_FIRST,
+          highestFirst: SortDirectionCycle.HIGHEST_FIRST,
         }),
       },
     },
@@ -169,7 +170,7 @@ stories
             :sticky-column="stickyColumn || null"
             :error-message="errorMessage || undefined"
             :empty-message="emptyMessage || undefined"
-            :default-sort-cycle="defaultSortCycle"
+            :sort-cycle="sortCycle"
             @sort="onSort"
             @abort="onAborted"
             @error="onError">

--- a/src/components/ec-table-head/ec-table-head.spec.js
+++ b/src/components/ec-table-head/ec-table-head.spec.js
@@ -89,7 +89,7 @@ describe('EcTableHead', () => {
     });
 
     wrapper.findByDataTest('ec-table-head__cell--0').findByDataTest('ec-table-sort__icon').trigger('click');
-    expect(wrapper.emitted('sort')).toEqual([['column-a']]);
+    expect(wrapper.emitted('sort')).toEqual([[{ name: 'column-a', sortable: true, title: 'Column A' }]]);
   });
 
   it('should render info icon with a tooltip as expected', () => {

--- a/src/components/ec-table-head/ec-table-head.vue
+++ b/src/components/ec-table-head/ec-table-head.vue
@@ -82,7 +82,7 @@ export default {
       return existingSort && existingSort.direction;
     },
     onSort(column) {
-      this.$emit('sort', column.name);
+      this.$emit('sort', column);
     },
     getWidthStyle(column) {
       if (column && (column.maxWidth || column.minWidth)) {

--- a/src/components/ec-table/ec-table.spec.js
+++ b/src/components/ec-table/ec-table.spec.js
@@ -304,7 +304,7 @@ describe('EcTable', () => {
       ],
     });
     wrapper.findByDataTest('ec-table-head__cell--0').findByDataTest('ec-table-sort__icon').trigger('click');
-    expect(wrapper.emitted('sort')).toEqual([['lorem']]);
+    expect(wrapper.emitted('sort')).toEqual([[{ name: 'lorem', sortable: true, title: 'Lorem' }]]);
   });
 
   it('the first th should have the ec-table-head__cell--sticky-left class if stickyColumn prop is left and the changes to right when the prop is get changed to right', () => {

--- a/src/enums/sort-direction-cycle.js
+++ b/src/enums/sort-direction-cycle.js
@@ -1,0 +1,4 @@
+import * as SortDirection from './sort-direction';
+
+export const LOWEST_FIRST = [SortDirection.ASC, SortDirection.DESC];
+export const HIGHEST_FIRST = [SortDirection.DESC, SortDirection.ASC];

--- a/src/hocs/ec-with-sorting/__snapshots__/ec-with-sorting.spec.js.snap
+++ b/src/hocs/ec-with-sorting/__snapshots__/ec-with-sorting.spec.js.snap
@@ -1,7 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EcWithSorting should render properly 1`] = `
-<div
-  defaultsortcycle=",asc,desc"
-/>
+exports[`EcWithSorting should render properly 1`] = `<div />`;
+
+exports[`EcWithSorting should throw an error if sort direction cycle is not valid 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "[Vue warn]: Invalid prop: custom validator check failed for prop \\"sortCycle\\".
+
+found in
+
+---> <EcWithSorting>
+       <Root>",
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
 `;

--- a/src/hocs/ec-with-sorting/__snapshots__/ec-with-sorting.spec.js.snap
+++ b/src/hocs/ec-with-sorting/__snapshots__/ec-with-sorting.spec.js.snap
@@ -1,3 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`EcWithSorting should render properly 1`] = `<div />`;
+exports[`EcWithSorting should render properly 1`] = `
+<div
+  defaultsortcycle=",asc,desc"
+/>
+`;

--- a/src/hocs/ec-with-sorting/ec-with-sorting.spec.js
+++ b/src/hocs/ec-with-sorting/ec-with-sorting.spec.js
@@ -1,6 +1,8 @@
 import { mount, createLocalVue, createWrapper } from '@vue/test-utils';
 import * as SortDirection from '../../enums/sort-direction';
+import * as SortDirectionCycle from '../../enums/sort-direction-cycle';
 import withSorting from './ec-with-sorting';
+import { withMockedConsole } from '../../../tests/utils/console';
 
 describe('EcWithSorting', () => {
   function mountEcWithSorting(props, mountOpts) {
@@ -32,6 +34,13 @@ describe('EcWithSorting', () => {
   it('should render properly', () => {
     const { hocWrapper } = mountEcWithSorting();
     expect(hocWrapper.element).toMatchSnapshot();
+  });
+
+  it('should throw an error if sort direction cycle is not valid', () => {
+    withMockedConsole((errorSpy) => {
+      mountEcWithSorting({ sortCycle: ['HI', 'LO'] });
+      expect(errorSpy).toMatchSnapshot();
+    });
   });
 
   describe('multi sort', () => {
@@ -125,7 +134,7 @@ describe('EcWithSorting', () => {
 
     describe('with default sort cycle: desc -> asc', () => {
       function mountMultiEcWithSortingDesc(props, mountOpts) {
-        return mountEcWithSorting({ multiSort: true, defaultSortCycle: [null, 'desc', 'asc'], ...props }, mountOpts);
+        return mountEcWithSorting({ multiSort: true, sortCycle: SortDirectionCycle.HIGHEST_FIRST, ...props }, mountOpts);
       }
       it('should use default sort direction when column is not sorted yet', () => {
         const { componentWrapper } = mountMultiEcWithSortingDesc();
@@ -186,7 +195,6 @@ describe('EcWithSorting', () => {
             { column: 'test-column-2', direction: SortDirection.DESC },
             { column: 'test-column-3', direction: SortDirection.ASC },
           ],
-          defaultSortCycle: [null, 'desc', 'asc'],
         });
 
         // sorting test-column-1 3 times should move it to bottom of the sorts array
@@ -251,7 +259,7 @@ describe('EcWithSorting', () => {
     });
     describe('with default sort cycle: desc -> asc', () => {
       function mountSingleEcWithSortingDesc(props, mountOpts) {
-        return mountEcWithSorting({ defaultSortCycle: [null, 'desc', 'asc'], multiSort: false, ...props }, mountOpts);
+        return mountEcWithSorting({ sortCycle: SortDirectionCycle.HIGHEST_FIRST, multiSort: false, ...props }, mountOpts);
       }
 
       it('should use default sort direction when column is not sorted yet', () => {

--- a/src/hocs/ec-with-sorting/ec-with-sorting.spec.js
+++ b/src/hocs/ec-with-sorting/ec-with-sorting.spec.js
@@ -35,128 +35,255 @@ describe('EcWithSorting', () => {
   });
 
   describe('multi sort', () => {
-    function mountMultiEcWithSorting(props, mountOpts) {
-      return mountEcWithSorting({ multiSort: true, ...props }, mountOpts);
-    }
-
-    it('should use default sort direction when column is not sorted yet', () => {
-      const { componentWrapper } = mountMultiEcWithSorting();
-      componentWrapper.vm.$emit('sort', 'test-column');
-      expect(componentWrapper.vm.sorts).toEqual([
-        { column: 'test-column', direction: SortDirection.ASC },
-      ]);
-    });
-
-    it('should go from ASC to DESC', () => {
-      const { componentWrapper } = mountMultiEcWithSorting({ sorts: [{ column: 'test-column', direction: SortDirection.ASC }] });
-      componentWrapper.vm.$emit('sort', 'test-column');
-      expect(componentWrapper.vm.sorts).toEqual([
-        { column: 'test-column', direction: SortDirection.DESC },
-      ]);
-    });
-
-    it('should go from DESC to nothing', () => {
-      const { componentWrapper } = mountMultiEcWithSorting({ sorts: [{ column: 'test-column', direction: SortDirection.DESC }] });
-      componentWrapper.vm.$emit('sort', 'test-column');
-      expect(componentWrapper.vm.sorts).toEqual([]);
-    });
-
-    it('should allow sort by multiple columns', () => {
-      const { componentWrapper } = mountMultiEcWithSorting();
-      componentWrapper.vm.$emit('sort', 'test-column-1');
-      componentWrapper.vm.$emit('sort', 'test-column-2');
-      expect(componentWrapper.vm.sorts).toEqual([
-        { column: 'test-column-1', direction: SortDirection.ASC },
-        { column: 'test-column-2', direction: SortDirection.ASC },
-      ]);
-    });
-
-    it('should update existing sorting when there are multiple column sorted', () => {
-      const { componentWrapper } = mountMultiEcWithSorting({
-        sorts: [
-          { column: 'test-column-1', direction: SortDirection.ASC },
-          { column: 'test-column-2', direction: SortDirection.DESC },
-        ],
+    describe('with default sort cycle: asc -> desc', () => {
+      function mountMultiEcWithSorting(props, mountOpts) {
+        return mountEcWithSorting({ multiSort: true, ...props }, mountOpts);
+      }
+      it('should use default sort direction when column is not sorted yet', () => {
+        const { componentWrapper } = mountMultiEcWithSorting();
+        componentWrapper.vm.$emit('sort', { name: 'test-column' });
+        expect(componentWrapper.vm.sorts).toEqual([
+          { column: 'test-column', direction: SortDirection.ASC },
+        ]);
       });
 
-      componentWrapper.vm.$emit('sort', 'test-column-1');
-      expect(componentWrapper.vm.sorts).toEqual([
-        { column: 'test-column-1', direction: SortDirection.DESC },
-        { column: 'test-column-2', direction: SortDirection.DESC },
-      ]);
+      it('should go from ASC to DESC', () => {
+        const { componentWrapper } = mountMultiEcWithSorting({ sorts: [{ column: 'test-column', direction: SortDirection.ASC }] });
+        componentWrapper.vm.$emit('sort', { name: 'test-column' });
+        expect(componentWrapper.vm.sorts).toEqual([
+          { column: 'test-column', direction: SortDirection.DESC },
+        ]);
+      });
 
-      componentWrapper.vm.$emit('sort', 'test-column-2');
-      expect(componentWrapper.vm.sorts).toEqual([
-        { column: 'test-column-1', direction: SortDirection.DESC },
-      ]);
-    });
+      it('should go from DESC to nothing', () => {
+        const { componentWrapper } = mountMultiEcWithSorting({ sorts: [{ column: 'test-column', direction: SortDirection.DESC }] });
+        componentWrapper.vm.$emit('sort', { name: 'test-column' });
+        expect(componentWrapper.vm.sorts).toEqual([]);
+      });
 
-    it('should preserve sorting order', () => {
-      const { componentWrapper } = mountMultiEcWithSorting({
-        sorts: [
+      it('should allow sort by multiple columns', () => {
+        const { componentWrapper } = mountMultiEcWithSorting();
+        componentWrapper.vm.$emit('sort', { name: 'test-column-1' });
+        componentWrapper.vm.$emit('sort', { name: 'test-column-2' });
+        expect(componentWrapper.vm.sorts).toEqual([
           { column: 'test-column-1', direction: SortDirection.ASC },
+          { column: 'test-column-2', direction: SortDirection.ASC },
+        ]);
+      });
+
+      it('should update existing sorting when there are multiple column sorted', () => {
+        const { componentWrapper } = mountMultiEcWithSorting({
+          sorts: [
+            { column: 'test-column-1', direction: SortDirection.ASC },
+            { column: 'test-column-2', direction: SortDirection.DESC },
+          ],
+        });
+
+        componentWrapper.vm.$emit('sort', { name: 'test-column-1' });
+        expect(componentWrapper.vm.sorts).toEqual([
+          { column: 'test-column-1', direction: SortDirection.DESC },
+          { column: 'test-column-2', direction: SortDirection.DESC },
+        ]);
+
+        componentWrapper.vm.$emit('sort', { name: 'test-column-2' });
+        expect(componentWrapper.vm.sorts).toEqual([
+          { column: 'test-column-1', direction: SortDirection.DESC },
+        ]);
+      });
+
+      it('should preserve sorting order', () => {
+        const { componentWrapper } = mountMultiEcWithSorting({
+          sorts: [
+            { column: 'test-column-1', direction: SortDirection.ASC },
+            { column: 'test-column-2', direction: SortDirection.DESC },
+            { column: 'test-column-3', direction: SortDirection.ASC },
+          ],
+        });
+
+        // sorting test-column-1 3 times should move it to bottom of the sorts array
+        componentWrapper.vm.$emit('sort', { name: 'test-column-1' }); // ASC -> DESC
+        componentWrapper.vm.$emit('sort', { name: 'test-column-1' }); // DESC -> null
+        componentWrapper.vm.$emit('sort', { name: 'test-column-1' }); // null -> ASC
+
+        expect(componentWrapper.vm.sorts).toEqual([
           { column: 'test-column-2', direction: SortDirection.DESC },
           { column: 'test-column-3', direction: SortDirection.ASC },
-        ],
+          { column: 'test-column-1', direction: SortDirection.ASC },
+        ]);
+
+        // sorting test-column-2 2 times should move it to bottom of the sorts array
+        componentWrapper.vm.$emit('sort', { name: 'test-column-2' }); // DESC -> null
+        componentWrapper.vm.$emit('sort', { name: 'test-column-2' }); // null -> ASC
+
+        expect(componentWrapper.vm.sorts).toEqual([
+          { column: 'test-column-3', direction: SortDirection.ASC },
+          { column: 'test-column-1', direction: SortDirection.ASC },
+          { column: 'test-column-2', direction: SortDirection.ASC },
+        ]);
+      });
+    });
+
+    describe('with default sort cycle: desc -> asc', () => {
+      function mountMultiEcWithSortingDesc(props, mountOpts) {
+        return mountEcWithSorting({ multiSort: true, defaultSortCycle: [null, 'desc', 'asc'], ...props }, mountOpts);
+      }
+      it('should use default sort direction when column is not sorted yet', () => {
+        const { componentWrapper } = mountMultiEcWithSortingDesc();
+        componentWrapper.vm.$emit('sort', { name: 'test-column' });
+        expect(componentWrapper.vm.sorts).toEqual([
+          { column: 'test-column', direction: SortDirection.DESC },
+        ]);
       });
 
-      // sorting test-column-1 3 times should move it to bottom of the sorts array
-      componentWrapper.vm.$emit('sort', 'test-column-1'); // ASC -> DESC
-      componentWrapper.vm.$emit('sort', 'test-column-1'); // DESC -> null
-      componentWrapper.vm.$emit('sort', 'test-column-1'); // null -> ASC
+      it('should go from ASC to nothing', () => {
+        const { componentWrapper } = mountMultiEcWithSortingDesc({ sorts: [{ column: 'test-column', direction: SortDirection.ASC }] });
+        componentWrapper.vm.$emit('sort', { name: 'test-column' });
+        expect(componentWrapper.vm.sorts).toEqual([]);
+      });
 
-      expect(componentWrapper.vm.sorts).toEqual([
-        { column: 'test-column-2', direction: SortDirection.DESC },
-        { column: 'test-column-3', direction: SortDirection.ASC },
-        { column: 'test-column-1', direction: SortDirection.ASC },
-      ]);
+      it('should go from DESC to ASC', () => {
+        const { componentWrapper } = mountMultiEcWithSortingDesc({ sorts: [{ column: 'test-column', direction: SortDirection.DESC }] });
+        componentWrapper.vm.$emit('sort', { name: 'test-column' });
+        expect(componentWrapper.vm.sorts).toEqual([
+          { column: 'test-column', direction: SortDirection.ASC },
+        ]);
+      });
 
-      // sorting test-column-2 2 times should move it to bottom of the sorts array
-      componentWrapper.vm.$emit('sort', 'test-column-2'); // DESC -> null
-      componentWrapper.vm.$emit('sort', 'test-column-2'); // null -> ASC
+      it('should allow sort by multiple columns', () => {
+        const { componentWrapper } = mountMultiEcWithSortingDesc();
+        componentWrapper.vm.$emit('sort', { name: 'test-column-1' });
+        componentWrapper.vm.$emit('sort', { name: 'test-column-2' });
+        expect(componentWrapper.vm.sorts).toEqual([
+          { column: 'test-column-1', direction: SortDirection.DESC },
+          { column: 'test-column-2', direction: SortDirection.DESC },
+        ]);
+      });
 
-      expect(componentWrapper.vm.sorts).toEqual([
-        { column: 'test-column-3', direction: SortDirection.ASC },
-        { column: 'test-column-1', direction: SortDirection.ASC },
-        { column: 'test-column-2', direction: SortDirection.ASC },
-      ]);
+      it('should update existing sorting when there are multiple column sorted', () => {
+        const { componentWrapper } = mountMultiEcWithSortingDesc({
+          sorts: [
+            { column: 'test-column-1', direction: SortDirection.DESC },
+            { column: 'test-column-2', direction: SortDirection.ASC },
+          ],
+        });
+
+        componentWrapper.vm.$emit('sort', { name: 'test-column-1' });
+        expect(componentWrapper.vm.sorts).toEqual([
+          { column: 'test-column-1', direction: SortDirection.ASC },
+          { column: 'test-column-2', direction: SortDirection.ASC },
+        ]);
+
+        componentWrapper.vm.$emit('sort', { name: 'test-column-2' });
+        expect(componentWrapper.vm.sorts).toEqual([
+          { column: 'test-column-1', direction: SortDirection.ASC },
+        ]);
+      });
+
+      it('should preserve sorting order', () => {
+        const { componentWrapper } = mountMultiEcWithSortingDesc({
+          sorts: [
+            { column: 'test-column-1', direction: SortDirection.ASC },
+            { column: 'test-column-2', direction: SortDirection.DESC },
+            { column: 'test-column-3', direction: SortDirection.ASC },
+          ],
+          defaultSortCycle: [null, 'desc', 'asc'],
+        });
+
+        // sorting test-column-1 3 times should move it to bottom of the sorts array
+        componentWrapper.vm.$emit('sort', { name: 'test-column-1' }); // ASC -> null
+        componentWrapper.vm.$emit('sort', { name: 'test-column-1' }); // DESC -> ASC
+        componentWrapper.vm.$emit('sort', { name: 'test-column-1' }); // null -> DESC
+
+        expect(componentWrapper.vm.sorts).toEqual([
+          { column: 'test-column-2', direction: SortDirection.DESC },
+          { column: 'test-column-3', direction: SortDirection.ASC },
+          { column: 'test-column-1', direction: SortDirection.ASC },
+        ]);
+
+        // sorting test-column-2 2 times should move it to bottom of the sorts array
+        componentWrapper.vm.$emit('sort', { name: 'test-column-2' }); // DESC -> ASC
+        componentWrapper.vm.$emit('sort', { name: 'test-column-2' }); // ASC -> null
+
+        expect(componentWrapper.vm.sorts).toEqual([
+          { column: 'test-column-3', direction: SortDirection.ASC },
+          { column: 'test-column-1', direction: SortDirection.ASC },
+        ]);
+      });
     });
   });
 
   describe('single sort', () => {
-    function mountSingleEcWithSorting(props, mountOpts) {
-      return mountEcWithSorting({ multiSort: false, ...props }, mountOpts);
-    }
+    describe('with default sort cycle: asc -> desc', () => {
+      function mountSingleEcWithSorting(props, mountOpts) {
+        return mountEcWithSorting({ multiSort: false, ...props }, mountOpts);
+      }
 
-    it('should use default sort direction when column is not sorted yet', () => {
-      const { componentWrapper } = mountSingleEcWithSorting();
-      componentWrapper.vm.$emit('sort', 'test-column');
-      expect(componentWrapper.vm.sorts).toEqual([
-        { column: 'test-column', direction: SortDirection.ASC },
-      ]);
+      it('should use default sort direction when column is not sorted yet', () => {
+        const { componentWrapper } = mountSingleEcWithSorting();
+        componentWrapper.vm.$emit('sort', { name: 'test-column' });
+        expect(componentWrapper.vm.sorts).toEqual([
+          { column: 'test-column', direction: SortDirection.ASC },
+        ]);
+      });
+
+      it('should go from ASC to DESC', () => {
+        const { componentWrapper } = mountSingleEcWithSorting({ sorts: [{ column: 'test-column', direction: SortDirection.ASC }] });
+        componentWrapper.vm.$emit('sort', { name: 'test-column' });
+        expect(componentWrapper.vm.sorts).toEqual([
+          { column: 'test-column', direction: SortDirection.DESC },
+        ]);
+      });
+
+      it('should go from DESC to nothing', () => {
+        const { componentWrapper } = mountSingleEcWithSorting({ sorts: [{ column: 'test-column', direction: SortDirection.DESC }] });
+        componentWrapper.vm.$emit('sort', { name: 'test-column' });
+        expect(componentWrapper.vm.sorts).toEqual([]);
+      });
+
+      it('should not allow sort by multiple columns', () => {
+        const { componentWrapper } = mountSingleEcWithSorting();
+        componentWrapper.vm.$emit('sort', { name: 'test-column-1' });
+        componentWrapper.vm.$emit('sort', { name: 'test-column-2' });
+        expect(componentWrapper.vm.sorts).toEqual([
+          { column: 'test-column-2', direction: SortDirection.ASC },
+        ]);
+      });
     });
+    describe('with default sort cycle: desc -> asc', () => {
+      function mountSingleEcWithSortingDesc(props, mountOpts) {
+        return mountEcWithSorting({ defaultSortCycle: [null, 'desc', 'asc'], multiSort: false, ...props }, mountOpts);
+      }
 
-    it('should go from ASC to DESC', () => {
-      const { componentWrapper } = mountSingleEcWithSorting({ sorts: [{ column: 'test-column', direction: SortDirection.ASC }] });
-      componentWrapper.vm.$emit('sort', 'test-column');
-      expect(componentWrapper.vm.sorts).toEqual([
-        { column: 'test-column', direction: SortDirection.DESC },
-      ]);
-    });
+      it('should use default sort direction when column is not sorted yet', () => {
+        const { componentWrapper } = mountSingleEcWithSortingDesc();
+        componentWrapper.vm.$emit('sort', { name: 'test-column' });
+        expect(componentWrapper.vm.sorts).toEqual([
+          { column: 'test-column', direction: SortDirection.DESC },
+        ]);
+      });
 
-    it('should go from DESC to nothing', () => {
-      const { componentWrapper } = mountSingleEcWithSorting({ sorts: [{ column: 'test-column', direction: SortDirection.DESC }] });
-      componentWrapper.vm.$emit('sort', 'test-column');
-      expect(componentWrapper.vm.sorts).toEqual([]);
-    });
+      it('should go from ASC to nothing', () => {
+        const { componentWrapper } = mountSingleEcWithSortingDesc({ sorts: [{ column: 'test-column', direction: SortDirection.ASC }] });
+        componentWrapper.vm.$emit('sort', { name: 'test-column' });
+        expect(componentWrapper.vm.sorts).toEqual([]);
+      });
 
-    it('should not allow sort by multiple columns', () => {
-      const { componentWrapper } = mountSingleEcWithSorting();
-      componentWrapper.vm.$emit('sort', 'test-column-1');
-      componentWrapper.vm.$emit('sort', 'test-column-2');
-      expect(componentWrapper.vm.sorts).toEqual([
-        { column: 'test-column-2', direction: SortDirection.ASC },
-      ]);
+      it('should go from DESC to ASC', () => {
+        const { componentWrapper } = mountSingleEcWithSortingDesc({ sorts: [{ column: 'test-column', direction: SortDirection.DESC }] });
+        componentWrapper.vm.$emit('sort', { name: 'test-column' });
+        expect(componentWrapper.vm.sorts).toEqual([
+          { column: 'test-column', direction: SortDirection.ASC },
+        ]);
+      });
+
+      it('should not allow sort by multiple columns', () => {
+        const { componentWrapper } = mountSingleEcWithSortingDesc();
+        componentWrapper.vm.$emit('sort', { name: 'test-column-1' });
+        componentWrapper.vm.$emit('sort', { name: 'test-column-2' });
+        expect(componentWrapper.vm.sorts).toEqual([
+          { column: 'test-column-2', direction: SortDirection.DESC },
+        ]);
+      });
     });
   });
 });


### PR DESCRIPTION
**TL,DR;**

- Adds `defaultSortCycle` property to `EcWithSorting`. This property controls the default sort cycle of all the columns, if none is applied to specific column. It is an array like: `[null, 'asc','desc']` (default)

- Column object definition can override the default for any specific column, providing a `sortCycle` property

This PR adds the possibility to configure the cycle in which the sorts are applied to the table when a user clicks on the table column. To represent this cycle, I am using an array. The first element of the array represents the state where no sort is applied, and the elements 1 and 2 represents the states after the user clicks. For instance, the current sorting cycle goes like this: 'none', 'ascending', 'descending'. It will be represented as `[null, 'asc', 'desc']`

