### PR TITLE
ONL-4790 fix: prevent double click on panel ctas

### DIFF
--- a/src/components/ec-panel/ec-panel.spec.js
+++ b/src/components/ec-panel/ec-panel.spec.js
@@ -41,9 +41,11 @@ describe('EcPanel', () => {
   });
 
   describe('@events', () => {
-    it('@close - should emit both "show-panel" and "close" events when the simple-close icon is clicked', () => {
+    it('@close - should emit both "show-panel" and "close" events once when the simple-close icon is clicked', () => {
       const wrapper = mountPanel({ show: true });
-      wrapper.findByDataTest('ec-panel__header-action--close').trigger('click');
+      const closeCTA = wrapper.findByDataTest('ec-panel__header-action--close');
+      closeCTA.trigger('click');
+      closeCTA.trigger('click');
 
       expect(wrapper.emitted('show-panel').length).toBe(1);
       expect(wrapper.emitted('close').length).toBe(1);
@@ -87,7 +89,7 @@ describe('EcPanel', () => {
         expect(wrapper.element).toMatchSnapshot();
       });
 
-      it('should emit a "back" event when the simple-chevron-left icon is clicked', () => {
+      it('should execute callback once when the simple-chevron-left icon is clicked', () => {
         const anyGivenCallback = jest.fn();
         const wrapper = mountPanelAsTemplate(
           '<ec-panel v-model="show" @back="anyGivenCallback"></ec-panel>',
@@ -103,10 +105,11 @@ describe('EcPanel', () => {
             },
           },
         );
+        const backCTA = wrapper.findByDataTest('ec-panel__header-action--back');
+        backCTA.trigger('click');
+        backCTA.trigger('click');
 
-        wrapper.findByDataTest('ec-panel__header-action--back').trigger('click');
-
-        expect(anyGivenCallback).toHaveBeenCalled();
+        expect(anyGivenCallback).toHaveBeenCalledTimes(1);
         expect(wrapper.findByDataTest('ec-panel').exists()).toBeFalsy();
       });
     });

--- a/src/components/ec-panel/ec-panel.vue
+++ b/src/components/ec-panel/ec-panel.vue
@@ -18,7 +18,7 @@
           aria-label="Go back"
           class="ec-panel__header-action ec-panel__header-action--back"
           data-test="ec-panel__header-action--back"
-          @click.stop.prevent="goBack"
+          @click.once.stop.prevent="goBack"
         >
           <ec-icon
             class="ec-panel__header-icon"
@@ -32,7 +32,7 @@
           aria-label="Close panel"
           class="ec-panel__header-action ec-panel__header-action--close"
           data-test="ec-panel__header-action--close"
-          @click.stop.prevent="closePanel"
+          @click.once.stop.prevent="closePanel"
         >
           <ec-icon
             class="ec-panel__header-icon"


### PR DESCRIPTION
Opening this PR for discussion of a fix for [ONL-4790](https://fxsolutions.atlassian.net/browse/ONL-4790). This bug can be reproduced by double clicking on the back CTA of the panel. Using the Vue devtools you can see that the event is triggered twice. The first one is handled correctly, but not the second one. 
![Screenshot_20200731_091718](https://user-images.githubusercontent.com/1553182/89010397-cec15100-d30e-11ea-932f-7bb0af87feb2.png)

I propose to avoid the double click by using the `once` directive. About the root cause, I am not 100% sure. I belive it has to do with the fact that the second event is not handled. Using the debugger tools, I can see  the line that throws when the second event is emitted:
![Screenshot_20200731_092027](https://user-images.githubusercontent.com/1553182/89010740-75a5ed00-d30f-11ea-8b1d-29cf181b60bf.png)
