### PR TITLE
ONL-4311: fix: Fixed ec-btn as router-link behaviour.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/components/ec-btn/__snapshots__/ec-btn.spec.js.snap
+++ b/src/components/ec-btn/__snapshots__/ec-btn.spec.js.snap
@@ -382,6 +382,20 @@ exports[`EcBtn :props should render a router link with a custom tag when we defi
 </ebury-stub>
 `;
 
+exports[`EcBtn :props should render a router link with route object 1`] = `
+<router-link-stub
+  class="ec-btn ec-btn--md"
+  data-test="ec-btn"
+  to="Route with name 'trade-finance'"
+>
+  <!---->
+   
+  <!---->
+   
+  <!---->
+</router-link-stub>
+`;
+
 exports[`EcBtn :props should render an <a> element when we define the "href" prop 1`] = `
 <a
   class="ec-btn ec-btn--md"

--- a/src/components/ec-btn/ec-btn.spec.js
+++ b/src/components/ec-btn/ec-btn.spec.js
@@ -54,6 +54,19 @@ describe('EcBtn', () => {
       expect(wrapper.element).toMatchSnapshot();
     });
 
+    it('should render a router link with route object', () => {
+      const wrapper = mountBtn({
+        to: {
+          name: 'trade-finance',
+          toString() { return `Route with name '${this.name}'`; },
+        },
+      }, {
+        stubs: ['router-link'],
+      });
+
+      expect(wrapper.element).toMatchSnapshot();
+    });
+
     it('should render a router link with a custom tag when we define the "tag option"', () => {
       const wrapper = mountBtn({
         to: 'trade-finance',

--- a/src/components/ec-btn/ec-btn.vue
+++ b/src/components/ec-btn/ec-btn.vue
@@ -72,7 +72,7 @@ export default {
       type: String,
     },
     to: {
-      type: String,
+      type: [String, Object],
     },
     tag: {
       type: String,
@@ -131,17 +131,21 @@ export default {
       return this.tag || 'button';
     },
     componentProps() {
-      let type = null;
-      if (this.componentTag === 'button') {
-        type = this.isSubmit ? 'submit' : 'button';
-      }
-
-      return {
-        type,
-        to: this.to || null,
-        href: this.href || null,
+      const props = {
         disabled: !this.isAnchorLink && (this.isDisabled || this.isLoading),
       };
+
+      if (this.componentTag === 'button') {
+        props.type = this.isSubmit ? 'submit' : 'button';
+      }
+      if (this.to) {
+        props.to = this.to;
+      }
+      if (this.href) {
+        props.href = this.href;
+      }
+
+      return props;
     },
   },
   methods: {


### PR DESCRIPTION
Bugs fixed:
1. Couldn't pass route object to the `to` property of ec-btn, e.g.
```
<ec-btn to="/dashboard">This is okay</ec-btn>
<ec-btn :to="{ name: 'dashboard' }">This is not</ec-btn>
```
2. When passing down props to `<router-link>`, we were always passing `href` as null causing the router-link generates an anchor without the href.