### PR TITLE
fix: Removed webpack aliases

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,11 +1,9 @@
 /* eslint-disable import/no-extraneous-dependencies */
-const path = require('path');
 const StyleLintPlugin = require('stylelint-webpack-plugin');
 
 module.exports = async ({ config }) => {
   config.resolve.alias = {
     ...config.resolve.alias,
-    '@': path.resolve(__dirname, '..', 'src'),
   };
 
   config.module.rules.push({

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,9 +13,6 @@ module.exports = {
   transformIgnorePatterns: [
     '/node_modules/',
   ],
-  moduleNameMapper: {
-    '^@/(.*)$': '<rootDir>/src/$1',
-  },
   snapshotSerializers: [
     'jest-serializer-vue',
   ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/components/ec-dropdown-search/ec-dropdown-search.vue
+++ b/src/components/ec-dropdown-search/ec-dropdown-search.vue
@@ -126,7 +126,7 @@
 </template>
 
 <script>
-import { ARROW_UP, ARROW_DOWN } from '@/enums/key-code';
+import { ARROW_UP, ARROW_DOWN } from '../../enums/key-code';
 import EcIcon from '../ec-icon';
 import EcPopover from '../ec-popover';
 import EcLoading from '../ec-loading';

--- a/src/components/ec-inline-actions/ec-inline-actions.spec.js
+++ b/src/components/ec-inline-actions/ec-inline-actions.spec.js
@@ -1,5 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
-import EcInlineActions from '@/components/ec-inline-actions/ec-inline-actions.vue';
+import EcInlineActions from './ec-inline-actions.vue';
 import { withMockedConsole } from '../../../tests/utils/console';
 
 describe('EcInlineActions', () => {

--- a/src/components/ec-navigation-link/ec-navigation-link.spec.js
+++ b/src/components/ec-navigation-link/ec-navigation-link.spec.js
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils';
-import EcNavigationLink from '@/components/ec-navigation-link/ec-navigation-link.vue';
+import EcNavigationLink from './ec-navigation-link.vue';
 import { withMockedConsole } from '../../../tests/utils/console';
 
 describe('EcNavigationLink', () => {

--- a/src/components/ec-popover/ec-popover.spec.js
+++ b/src/components/ec-popover/ec-popover.spec.js
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import { shallowMount, mount } from '@vue/test-utils';
-import EcPopover from '@/components/ec-popover/ec-popover.vue';
+import EcPopover from './ec-popover.vue';
 
 describe('EcPopover component', () => {
   it('should pass default options when no additional props are given', () => {

--- a/src/components/ec-table/ec-table.story.js
+++ b/src/components/ec-table/ec-table.story.js
@@ -6,7 +6,7 @@ import {
   select,
 } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
-import EcIcon from '@/components/ec-icon/ec-icon.vue';
+import EcIcon from '../ec-icon/ec-icon.vue';
 import EcTable from './ec-table.vue';
 import * as SortDirection from '../../enums/sort-direction';
 

--- a/src/components/ec-user-info/ec-user-info.spec.js
+++ b/src/components/ec-user-info/ec-user-info.spec.js
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils';
-import EcUserInfo from '@/components/ec-user-info/ec-user-info.vue';
+import EcUserInfo from './ec-user-info.vue';
 import { withMockedConsole } from '../../../tests/utils/console';
 
 const user = {

--- a/src/styles/components/ec-btn/ec-btn.story.js
+++ b/src/styles/components/ec-btn/ec-btn.story.js
@@ -1,8 +1,8 @@
 import { storiesOf } from '@storybook/vue';
 import { boolean, select, text } from '@storybook/addon-knobs';
 import StoryRouter from 'storybook-vue-router';
-import EcIcon from '@/components/ec-icon';
-import EcBtn from '@/components/ec-btn';
+import EcIcon from '../../../components/ec-icon';
+import EcBtn from '../../../components/ec-btn';
 import { LIGHT_THEME, DARK_THEME } from '../../../../.storybook/backgrounds';
 
 const stories = storiesOf('Button', module);


### PR DESCRIPTION
After installing the 1.0.5 in EBO, webpack started throwing errors that `@/enums/key-code` doesn't exist. It's because we should not be using webpack aliases in this library because `@/` alias can change the value in the application.

We could use them in stories and spec.js but then we cannot spot problem that the alias is being used in the "production" code (vue and js files). I decided to remove them completely from storybook and jest. We were using it only on a few places and most of the usage didn't make sense anyway.