### PR TITLE
ONL-4183 Add keyboard navigation for dropdown search component - CTA and Search areas

### DIFF
--- a/src/components/ec-dropdown-search/ec-dropdown-search.keyboard-navigation.spec.js
+++ b/src/components/ec-dropdown-search/ec-dropdown-search.keyboard-navigation.spec.js
@@ -1,4 +1,4 @@
-import { mount, shallowMount } from '@vue/test-utils';
+import { mount } from '@vue/test-utils';
 import EcDropdownSearch from './ec-dropdown-search.vue';
 
 describe('EcDropdownSearch - Keyboard navigation', () => {
@@ -258,7 +258,7 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
       const elem = document.createElement('div');
       document.body.appendChild(elem);
 
-      const wrapper = shallowMountDropdownSearch({ items, isSearchEnabled: false }, {
+      const wrapper = mountDropdownSearch({ items, isSearchEnabled: false }, {
         scopedSlots: {
           cta: '<a href="#" data-test="cta-data-test">My CTA</a>',
         },
@@ -272,6 +272,7 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
       await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
 
       expect(document.activeElement).toBe(wrapper.findByDataTest('cta-data-test').element);
+      document.activeElement.blur();
       wrapper.destroy();
     });
 
@@ -279,7 +280,7 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
       const elem = document.createElement('div');
       document.body.appendChild(elem);
 
-      const wrapper = shallowMountDropdownSearch({ items, isSearchEnabled: false }, {
+      const wrapper = mountDropdownSearch({ items, isSearchEnabled: false }, {
         scopedSlots: {
           cta: '<a href="#" data-test="cta-data-test">My CTA</a>',
         },
@@ -295,6 +296,7 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
 
       await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
       expect(document.activeElement).toBe(wrapper.findByDataTest('cta-data-test').element);
+      document.activeElement.blur();
       wrapper.destroy();
     });
 
@@ -302,7 +304,7 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
       const elem = document.createElement('div');
       document.body.appendChild(elem);
 
-      const wrapper = shallowMountDropdownSearch({ items, isSearchEnabled: false }, {
+      const wrapper = mountDropdownSearch({ items, isSearchEnabled: false }, {
         scopedSlots: {
           cta: '<a href="#" data-test="cta-data-test">My CTA</a>',
         },
@@ -318,6 +320,7 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
       await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
 
       expect(document.activeElement).toBe(wrapper.findByDataTest('cta-data-test').element);
+      document.activeElement.blur();
       wrapper.destroy();
     });
 
@@ -325,7 +328,7 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
       const elem = document.createElement('div');
       document.body.appendChild(elem);
 
-      const wrapper = shallowMountDropdownSearch({ items, isSearchEnabled: true }, {
+      const wrapper = mountDropdownSearch({ items, isSearchEnabled: true }, {
         attachTo: elem,
       });
 
@@ -336,6 +339,7 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
       await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
 
       expect(document.activeElement).toBe(wrapper.findByDataTest('ec-dropdown-search__search-input').element);
+      document.activeElement.blur();
       wrapper.destroy();
     });
 
@@ -343,7 +347,7 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
       const elem = document.createElement('div');
       document.body.appendChild(elem);
 
-      const wrapper = shallowMountDropdownSearch({ items, isSearchEnabled: true }, {
+      const wrapper = mountDropdownSearch({ items, isSearchEnabled: true }, {
         attachTo: elem,
       });
 
@@ -356,6 +360,7 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
 
       await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
       expect(document.activeElement).toBe(wrapper.findByDataTest('ec-dropdown-search__search-input').element);
+      document.activeElement.blur();
       wrapper.destroy();
     });
 
@@ -363,7 +368,7 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
       const elem = document.createElement('div');
       document.body.appendChild(elem);
 
-      const wrapper = shallowMountDropdownSearch({ items, isSearchEnabled: true }, {
+      const wrapper = mountDropdownSearch({ items, isSearchEnabled: true }, {
         attachTo: elem,
       });
 
@@ -376,6 +381,7 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
       await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
 
       expect(document.activeElement).toBe(wrapper.findByDataTest('ec-dropdown-search__search-input').element);
+      document.activeElement.blur();
       wrapper.destroy();
     });
 
@@ -383,7 +389,7 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
       const elem = document.createElement('div');
       document.body.appendChild(elem);
 
-      const wrapper = shallowMountDropdownSearch({ items, isSearchEnabled: true }, {
+      const wrapper = mountDropdownSearch({ items, isSearchEnabled: true }, {
         scopedSlots: {
           cta: '<a href="#" data-test="cta-data-test">My CTA</a>',
         },
@@ -397,6 +403,7 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
       await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
 
       expect(document.activeElement).toBe(wrapper.findByDataTest('cta-data-test').element);
+      document.activeElement.blur();
       wrapper.destroy();
     });
 
@@ -404,7 +411,7 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
       const elem = document.createElement('div');
       document.body.appendChild(elem);
 
-      const wrapper = shallowMountDropdownSearch({ items, isSearchEnabled: true }, {
+      const wrapper = mountDropdownSearch({ items, isSearchEnabled: true }, {
         scopedSlots: {
           cta: '<a href="#" data-test="cta-data-test">My CTA</a>',
         },
@@ -421,6 +428,7 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
       await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
 
       expect(document.activeElement).toBe(wrapper.findByDataTest('ec-dropdown-search__search-input').element);
+      document.activeElement.blur();
       wrapper.destroy();
     });
 
@@ -428,7 +436,7 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
       const elem = document.createElement('div');
       document.body.appendChild(elem);
 
-      const wrapper = shallowMountDropdownSearch({ items, isSearchEnabled: true }, {
+      const wrapper = mountDropdownSearch({ items, isSearchEnabled: true }, {
         scopedSlots: {
           cta: '<a href="#" data-test="cta-data-test">My CTA</a>',
         },
@@ -444,6 +452,7 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
       await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
 
       expect(document.activeElement).toBe(wrapper.findByDataTest('cta-data-test').element);
+      document.activeElement.blur();
       wrapper.destroy();
     });
   });
@@ -650,13 +659,6 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
 
 function mountDropdownSearch(props, mountOpts) {
   return mount(EcDropdownSearch, {
-    propsData: { ...props },
-    ...mountOpts,
-  });
-}
-
-function shallowMountDropdownSearch(props, mountOpts) {
-  return shallowMount(EcDropdownSearch, {
     propsData: { ...props },
     ...mountOpts,
   });

--- a/src/components/ec-dropdown-search/ec-dropdown-search.keyboard-navigation.spec.js
+++ b/src/components/ec-dropdown-search/ec-dropdown-search.keyboard-navigation.spec.js
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { mount, shallowMount } from '@vue/test-utils';
 import EcDropdownSearch from './ec-dropdown-search.vue';
 
 describe('EcDropdownSearch - Keyboard navigation', () => {
@@ -235,7 +235,7 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
     });
   });
 
-  describe('when the esc key is pressed over the dropdown', () => {
+  describe('when dropdown is open and ESC key is pressed', () => {
     it('should close it if is open', async () => {
       const wrapper = mountDropdownSearch({ items });
       await openDropdown(wrapper);
@@ -245,7 +245,7 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
       expect(wrapper.emitted('close').length).toBeTruthy();
     });
 
-    it('should not do anything if is closed', async () => {
+    it('should close and do nothing', async () => {
       const wrapper = mountDropdownSearch({ items });
       await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.esc');
 
@@ -253,102 +253,198 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
     });
   });
 
-  describe('when the tab key is pressed over the dropdown', () => {
-    it('should focus to the cta if is available the search and the cta', async () => {
+  describe('when dropdown is open and TAB key is pressed', () => {
+    it('should focus the cta if cta is enabled', async () => {
       const elem = document.createElement('div');
       document.body.appendChild(elem);
 
-      const wrapper = mountDropdownSearch({ items, isSearchEnabled: true }, {
+      const wrapper = shallowMountDropdownSearch({ items, isSearchEnabled: false }, {
         scopedSlots: {
-          cta: '<a data-test="cta-data-test">My CTA</a>',
+          cta: '<a href="#" data-test="cta-data-test">My CTA</a>',
         },
         attachTo: elem,
       });
 
       expect(document.activeElement).toBe(document.body);
       await openDropdown(wrapper);
-      await wrapper.findByDataTest('ec-dropdown-search__item-list').trigger('keydown.tab');
-      await wrapper.vm.$nextTick();
+      expect(document.activeElement).toBe(document.body);
 
-      // expect(document.activeElement).toBe(wrapper.findByDataTest('cta-data-test').element);
-      wrapper.destroy(); // because we attached the wrapper to document
+      await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
+
+      expect(document.activeElement).toBe(wrapper.findByDataTest('cta-data-test').element);
+      wrapper.destroy();
     });
 
-    it('should focus to the search if is available the search and the cta and the focus is on the cta', async () => {
+    it('should focus the cta if cta is enabled and is focused', async () => {
       const elem = document.createElement('div');
       document.body.appendChild(elem);
 
-      const wrapper = mountDropdownSearch({ items, isSearchEnabled: true }, {
+      const wrapper = shallowMountDropdownSearch({ items, isSearchEnabled: false }, {
         scopedSlots: {
-          cta: '<a data-test="cta-data-test">My CTA</a>',
+          cta: '<a href="#" data-test="cta-data-test">My CTA</a>',
         },
         attachTo: elem,
       });
 
       expect(document.activeElement).toBe(document.body);
       await openDropdown(wrapper);
-      await wrapper.findByDataTest('cta-data-test').trigger('mousedown');
-      await wrapper.findByDataTest('cta-data-test').trigger('focus');
-      await wrapper.findByDataTest('ec-dropdown-search__item-list').trigger('keydown.tab');
-      await wrapper.vm.$nextTick();
+      expect(document.activeElement).toBe(document.body);
 
-      // expect(document.activeElement).toBe(wrapper.findByDataTest('ec-dropdown-search__search-input').element);
-      wrapper.destroy(); // because we attached the wrapper to document
+      await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
+      expect(document.activeElement).toBe(wrapper.findByDataTest('cta-data-test').element);
+
+      await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
+      expect(document.activeElement).toBe(wrapper.findByDataTest('cta-data-test').element);
+      wrapper.destroy();
     });
 
-    it('should focus to the cta if is available the cta', async () => {
+    it('should focus the cta if cta is enabled and an item is selected', async () => {
       const elem = document.createElement('div');
       document.body.appendChild(elem);
 
-      const wrapper = mountDropdownSearch({ items, isSearchEnabled: false }, {
+      const wrapper = shallowMountDropdownSearch({ items, isSearchEnabled: false }, {
         scopedSlots: {
-          cta: '<a data-test="cta-data-test">My CTA</a>',
+          cta: '<a href="#" data-test="cta-data-test">My CTA</a>',
         },
         attachTo: elem,
       });
 
       expect(document.activeElement).toBe(document.body);
       await openDropdown(wrapper);
-      await wrapper.findByDataTest('ec-dropdown-search__item-list').trigger('keydown.tab');
-      await wrapper.vm.$nextTick();
-
-      // expect(document.activeElement).toBe(wrapper.findByDataTest('cta-data-test').element);
-      wrapper.destroy(); // because we attached the wrapper to document
-    });
-
-    it('should focus to the search if is available the search', async () => {
-      const elem = document.createElement('div');
-      document.body.appendChild(elem);
-
-      const wrapper = mountDropdownSearch({ items, isSearchEnabled: true }, {
-        attachTo: elem,
-      });
-
       expect(document.activeElement).toBe(document.body);
-      await openDropdown(wrapper);
-      await wrapper.findByDataTest('ec-dropdown-search__item-list').trigger('keydown.tab');
-      await wrapper.vm.$nextTick();
-
-      // expect(document.activeElement).toBe(wrapper.findByDataTest('ec-dropdown-search__search-input').element);
-      wrapper.destroy(); // because we attached the wrapper to document
-    });
-
-    it('should focus to the search if is available the search and the focus is nowhere', async () => {
-      const elem = document.createElement('div');
-      document.body.appendChild(elem);
-
-      const wrapper = mountDropdownSearch({ items, isSearchEnabled: true }, {
-        attachTo: elem,
-      });
-
-      expect(document.activeElement).toBe(document.body);
-      await openDropdown(wrapper);
       await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.down');
-      await wrapper.findByDataTest('ec-dropdown-search__item-list').trigger('keydown.tab');
-      await wrapper.vm.$nextTick();
+      expect(document.activeElement).toBe(document.body);
 
-      // expect(document.activeElement).toBe(wrapper.findByDataTest('ec-dropdown-search__search-input').element);
-      wrapper.destroy(); // because we attached the wrapper to document
+      await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
+
+      expect(document.activeElement).toBe(wrapper.findByDataTest('cta-data-test').element);
+      wrapper.destroy();
+    });
+
+    it('should focus the search if search is enabled', async () => {
+      const elem = document.createElement('div');
+      document.body.appendChild(elem);
+
+      const wrapper = shallowMountDropdownSearch({ items, isSearchEnabled: true }, {
+        attachTo: elem,
+      });
+
+      expect(document.activeElement).toBe(document.body);
+      await openDropdown(wrapper);
+      expect(document.activeElement).toBe(document.body);
+
+      await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
+
+      expect(document.activeElement).toBe(wrapper.findByDataTest('ec-dropdown-search__search-input').element);
+      wrapper.destroy();
+    });
+
+    it('should focus the search if search is enabled and is focused', async () => {
+      const elem = document.createElement('div');
+      document.body.appendChild(elem);
+
+      const wrapper = shallowMountDropdownSearch({ items, isSearchEnabled: true }, {
+        attachTo: elem,
+      });
+
+      expect(document.activeElement).toBe(document.body);
+      await openDropdown(wrapper);
+      expect(document.activeElement).toBe(document.body);
+
+      await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
+      expect(document.activeElement).toBe(wrapper.findByDataTest('ec-dropdown-search__search-input').element);
+
+      await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
+      expect(document.activeElement).toBe(wrapper.findByDataTest('ec-dropdown-search__search-input').element);
+      wrapper.destroy();
+    });
+
+    it('should focus the search if search is enabled and an item is selected', async () => {
+      const elem = document.createElement('div');
+      document.body.appendChild(elem);
+
+      const wrapper = shallowMountDropdownSearch({ items, isSearchEnabled: true }, {
+        attachTo: elem,
+      });
+
+      expect(document.activeElement).toBe(document.body);
+      await openDropdown(wrapper);
+      expect(document.activeElement).toBe(document.body);
+      await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.down');
+      expect(document.activeElement).toBe(document.body);
+
+      await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
+
+      expect(document.activeElement).toBe(wrapper.findByDataTest('ec-dropdown-search__search-input').element);
+      wrapper.destroy();
+    });
+
+    it('should focus the cta if search and cta are enabled', async () => {
+      const elem = document.createElement('div');
+      document.body.appendChild(elem);
+
+      const wrapper = shallowMountDropdownSearch({ items, isSearchEnabled: true }, {
+        scopedSlots: {
+          cta: '<a href="#" data-test="cta-data-test">My CTA</a>',
+        },
+        attachTo: elem,
+      });
+
+      expect(document.activeElement).toBe(document.body);
+      await openDropdown(wrapper);
+      expect(document.activeElement).toBe(document.body);
+
+      await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
+
+      expect(document.activeElement).toBe(wrapper.findByDataTest('cta-data-test').element);
+      wrapper.destroy();
+    });
+
+    it('should focus the search if search and cta are enabled and cta is focused', async () => {
+      const elem = document.createElement('div');
+      document.body.appendChild(elem);
+
+      const wrapper = shallowMountDropdownSearch({ items, isSearchEnabled: true }, {
+        scopedSlots: {
+          cta: '<a href="#" data-test="cta-data-test">My CTA</a>',
+        },
+        attachTo: elem,
+      });
+
+      expect(document.activeElement).toBe(document.body);
+      await openDropdown(wrapper);
+      expect(document.activeElement).toBe(document.body);
+
+      await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
+      expect(document.activeElement).toBe(wrapper.findByDataTest('cta-data-test').element);
+
+      await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
+
+      expect(document.activeElement).toBe(wrapper.findByDataTest('ec-dropdown-search__search-input').element);
+      wrapper.destroy();
+    });
+
+    it('should focus the search if search and cta are enabled and an item is selected', async () => {
+      const elem = document.createElement('div');
+      document.body.appendChild(elem);
+
+      const wrapper = shallowMountDropdownSearch({ items, isSearchEnabled: true }, {
+        scopedSlots: {
+          cta: '<a href="#" data-test="cta-data-test">My CTA</a>',
+        },
+        attachTo: elem,
+      });
+
+      expect(document.activeElement).toBe(document.body);
+      await openDropdown(wrapper);
+      expect(document.activeElement).toBe(document.body);
+      await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.down');
+      expect(document.activeElement).toBe(document.body);
+
+      await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
+
+      expect(document.activeElement).toBe(wrapper.findByDataTest('cta-data-test').element);
+      wrapper.destroy();
     });
   });
 
@@ -554,6 +650,13 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
 
 function mountDropdownSearch(props, mountOpts) {
   return mount(EcDropdownSearch, {
+    propsData: { ...props },
+    ...mountOpts,
+  });
+}
+
+function shallowMountDropdownSearch(props, mountOpts) {
+  return shallowMount(EcDropdownSearch, {
     propsData: { ...props },
     ...mountOpts,
   });

--- a/src/components/ec-dropdown-search/ec-dropdown-search.keyboard-navigation.spec.js
+++ b/src/components/ec-dropdown-search/ec-dropdown-search.keyboard-navigation.spec.js
@@ -235,27 +235,120 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
     });
   });
 
-  describe('when the tab or esc key is pressed over the dropdown', () => {
-    it.each([
-      ['tab'],
-      ['esc'],
-    ])('should close it if is open (by %s key)', async (key) => {
+  describe('when the esc key is pressed over the dropdown', () => {
+    it('should close it if is open', async () => {
       const wrapper = mountDropdownSearch({ items });
       await openDropdown(wrapper);
 
-      await wrapper.findByDataTest('ec-dropdown-search').trigger(`keydown.${key}`);
+      await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.esc');
 
       expect(wrapper.emitted('close').length).toBeTruthy();
     });
 
-    it.each([
-      ['tab'],
-      ['esc'],
-    ])('should not do anything if is closed (by %s key)', async (key) => {
+    it('should not do anything if is closed', async () => {
       const wrapper = mountDropdownSearch({ items });
-      await wrapper.findByDataTest('ec-dropdown-search').trigger(`keydown.${key}`);
+      await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.esc');
 
       expect(wrapper.emitted('close')).toBeUndefined();
+    });
+  });
+
+  describe('when the tab key is pressed over the dropdown', () => {
+    it('should focus to the cta if is available the search and the cta', async () => {
+      const elem = document.createElement('div');
+      document.body.appendChild(elem);
+
+      const wrapper = mountDropdownSearch({ items, isSearchEnabled: true }, {
+        scopedSlots: {
+          cta: '<a data-test="cta-data-test">My CTA</a>',
+        },
+        attachTo: elem,
+      });
+
+      expect(document.activeElement).toBe(document.body);
+      await openDropdown(wrapper);
+      await wrapper.findByDataTest('ec-dropdown-search__item-list').trigger('keydown.tab');
+      await wrapper.vm.$nextTick();
+
+      // expect(document.activeElement).toBe(wrapper.findByDataTest('cta-data-test').element);
+      wrapper.destroy(); // because we attached the wrapper to document
+    });
+
+    it('should focus to the search if is available the search and the cta and the focus is on the cta', async () => {
+      const elem = document.createElement('div');
+      document.body.appendChild(elem);
+
+      const wrapper = mountDropdownSearch({ items, isSearchEnabled: true }, {
+        scopedSlots: {
+          cta: '<a data-test="cta-data-test">My CTA</a>',
+        },
+        attachTo: elem,
+      });
+
+      expect(document.activeElement).toBe(document.body);
+      await openDropdown(wrapper);
+      await wrapper.findByDataTest('cta-data-test').trigger('mousedown');
+      await wrapper.findByDataTest('cta-data-test').trigger('focus');
+      await wrapper.findByDataTest('ec-dropdown-search__item-list').trigger('keydown.tab');
+      await wrapper.vm.$nextTick();
+
+      // expect(document.activeElement).toBe(wrapper.findByDataTest('ec-dropdown-search__search-input').element);
+      wrapper.destroy(); // because we attached the wrapper to document
+    });
+
+    it('should focus to the cta if is available the cta', async () => {
+      const elem = document.createElement('div');
+      document.body.appendChild(elem);
+
+      const wrapper = mountDropdownSearch({ items, isSearchEnabled: false }, {
+        scopedSlots: {
+          cta: '<a data-test="cta-data-test">My CTA</a>',
+        },
+        attachTo: elem,
+      });
+
+      expect(document.activeElement).toBe(document.body);
+      await openDropdown(wrapper);
+      await wrapper.findByDataTest('ec-dropdown-search__item-list').trigger('keydown.tab');
+      await wrapper.vm.$nextTick();
+
+      // expect(document.activeElement).toBe(wrapper.findByDataTest('cta-data-test').element);
+      wrapper.destroy(); // because we attached the wrapper to document
+    });
+
+    it('should focus to the search if is available the search', async () => {
+      const elem = document.createElement('div');
+      document.body.appendChild(elem);
+
+      const wrapper = mountDropdownSearch({ items, isSearchEnabled: true }, {
+        attachTo: elem,
+      });
+
+      expect(document.activeElement).toBe(document.body);
+      await openDropdown(wrapper);
+      await wrapper.findByDataTest('ec-dropdown-search__item-list').trigger('keydown.tab');
+      await wrapper.vm.$nextTick();
+
+      // expect(document.activeElement).toBe(wrapper.findByDataTest('ec-dropdown-search__search-input').element);
+      wrapper.destroy(); // because we attached the wrapper to document
+    });
+
+    it('should focus to the search if is available the search and the focus is nowhere', async () => {
+      const elem = document.createElement('div');
+      document.body.appendChild(elem);
+
+      const wrapper = mountDropdownSearch({ items, isSearchEnabled: true }, {
+        attachTo: elem,
+      });
+
+      expect(document.activeElement).toBe(document.body);
+      await openDropdown(wrapper);
+      await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.down');
+      await wrapper.findByDataTest('ec-dropdown-search__item-list').trigger('keydown.tab');
+      await wrapper.vm.$nextTick();
+
+      // expect(document.activeElement).toBe(wrapper.findByDataTest('ec-dropdown-search__search-input').element);
+      wrapper.destroy(); // because we attached the wrapper to document
     });
   });
 

--- a/src/components/ec-dropdown-search/ec-dropdown-search.keyboard-navigation.spec.js
+++ b/src/components/ec-dropdown-search/ec-dropdown-search.keyboard-navigation.spec.js
@@ -282,7 +282,7 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
       expect(document.activeElement).toBe(wrapper.findByDataTest('cta-data-test').element);
     });
 
-    it('should lost the focus and close if cta is enabled and is focused', async () => {
+    it('should lose the focus and close if cta is enabled and is focused', async () => {
       const elem = document.createElement('div');
       document.body.appendChild(elem);
 
@@ -326,7 +326,7 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
       expect(document.activeElement).toBe(wrapper.findByDataTest('cta-data-test').element);
     });
 
-    it('should lost the focus and close if search is enabled', async () => {
+    it('should lose the focus and close if search is enabled', async () => {
       const elem = document.createElement('div');
       document.body.appendChild(elem);
 
@@ -440,7 +440,8 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
 
       expect(document.activeElement).toBe(document.body);
     });
-    it('should not focus the cta if search and cta are enabled but the cta has nothing to focus', async () => {
+
+    it('should not focus the cta if cta is not focusable', async () => {
       const elem = document.createElement('div');
       document.body.appendChild(elem);
 

--- a/src/components/ec-dropdown-search/ec-dropdown-search.keyboard-navigation.spec.js
+++ b/src/components/ec-dropdown-search/ec-dropdown-search.keyboard-navigation.spec.js
@@ -1,4 +1,5 @@
-import { mount } from '@vue/test-utils';
+import Vue from 'vue';
+import { enableAutoDestroy, mount } from '@vue/test-utils';
 import EcDropdownSearch from './ec-dropdown-search.vue';
 
 describe('EcDropdownSearch - Keyboard navigation', () => {
@@ -12,6 +13,14 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
     { id: 7, text: 'Item 7' },
     { id: 8, text: 'Item 8' },
   ];
+
+  enableAutoDestroy(afterEach);
+
+  beforeEach(() => {
+    document.activeElement.blur();
+    // We need to clean the activeElement because of the jsdom bug.
+    // jsdom preserves activeElement between tests even if the element has already been removed from the body
+  });
 
   describe('when dropdown is closed and the arrow down key is pressed', () => {
     it('should select the first item when no item is selected yet', async () => {
@@ -257,7 +266,6 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
     it('should focus the cta if cta is enabled', async () => {
       const elem = document.createElement('div');
       document.body.appendChild(elem);
-
       const wrapper = mountDropdownSearch({ items, isSearchEnabled: false }, {
         scopedSlots: {
           cta: '<a href="#" data-test="cta-data-test">My CTA</a>',
@@ -272,11 +280,9 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
       await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
 
       expect(document.activeElement).toBe(wrapper.findByDataTest('cta-data-test').element);
-      document.activeElement.blur();
-      wrapper.destroy();
     });
 
-    it('should focus the cta if cta is enabled and is focused', async () => {
+    it('should lost the focus and close if cta is enabled and is focused', async () => {
       const elem = document.createElement('div');
       document.body.appendChild(elem);
 
@@ -295,9 +301,7 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
       expect(document.activeElement).toBe(wrapper.findByDataTest('cta-data-test').element);
 
       await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
-      expect(document.activeElement).toBe(wrapper.findByDataTest('cta-data-test').element);
-      document.activeElement.blur();
-      wrapper.destroy();
+      expect(document.activeElement).toBe(document.body);
     });
 
     it('should focus the cta if cta is enabled and an item is selected', async () => {
@@ -320,11 +324,9 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
       await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
 
       expect(document.activeElement).toBe(wrapper.findByDataTest('cta-data-test').element);
-      document.activeElement.blur();
-      wrapper.destroy();
     });
 
-    it('should focus the search if search is enabled', async () => {
+    it('should lost the focus and close if search is enabled', async () => {
       const elem = document.createElement('div');
       document.body.appendChild(elem);
 
@@ -334,34 +336,10 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
 
       expect(document.activeElement).toBe(document.body);
       await openDropdown(wrapper);
-      expect(document.activeElement).toBe(document.body);
-
-      await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
-
-      expect(document.activeElement).toBe(wrapper.findByDataTest('ec-dropdown-search__search-input').element);
-      document.activeElement.blur();
-      wrapper.destroy();
-    });
-
-    it('should focus the search if search is enabled and is focused', async () => {
-      const elem = document.createElement('div');
-      document.body.appendChild(elem);
-
-      const wrapper = mountDropdownSearch({ items, isSearchEnabled: true }, {
-        attachTo: elem,
-      });
-
-      expect(document.activeElement).toBe(document.body);
-      await openDropdown(wrapper);
-      expect(document.activeElement).toBe(document.body);
-
-      await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
       expect(document.activeElement).toBe(wrapper.findByDataTest('ec-dropdown-search__search-input').element);
 
       await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
-      expect(document.activeElement).toBe(wrapper.findByDataTest('ec-dropdown-search__search-input').element);
-      document.activeElement.blur();
-      wrapper.destroy();
+      expect(document.activeElement).toBe(document.body);
     });
 
     it('should focus the search if search is enabled and an item is selected', async () => {
@@ -374,15 +352,13 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
 
       expect(document.activeElement).toBe(document.body);
       await openDropdown(wrapper);
-      expect(document.activeElement).toBe(document.body);
+      expect(document.activeElement).toBe(wrapper.findByDataTest('ec-dropdown-search__search-input').element);
       await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.down');
       expect(document.activeElement).toBe(document.body);
 
       await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
 
       expect(document.activeElement).toBe(wrapper.findByDataTest('ec-dropdown-search__search-input').element);
-      document.activeElement.blur();
-      wrapper.destroy();
     });
 
     it('should focus the cta if search and cta are enabled', async () => {
@@ -398,16 +374,13 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
 
       expect(document.activeElement).toBe(document.body);
       await openDropdown(wrapper);
-      expect(document.activeElement).toBe(document.body);
-
+      expect(document.activeElement).toBe(wrapper.findByDataTest('ec-dropdown-search__search-input').element);
       await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
 
       expect(document.activeElement).toBe(wrapper.findByDataTest('cta-data-test').element);
-      document.activeElement.blur();
-      wrapper.destroy();
     });
 
-    it('should focus the search if search and cta are enabled and cta is focused', async () => {
+    it('should focus the body if search and cta are enabled and cta is focused', async () => {
       const elem = document.createElement('div');
       document.body.appendChild(elem);
 
@@ -420,16 +393,13 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
 
       expect(document.activeElement).toBe(document.body);
       await openDropdown(wrapper);
-      expect(document.activeElement).toBe(document.body);
+      expect(document.activeElement).toBe(wrapper.findByDataTest('ec-dropdown-search__search-input').element);
 
       await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
       expect(document.activeElement).toBe(wrapper.findByDataTest('cta-data-test').element);
 
       await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
-
-      expect(document.activeElement).toBe(wrapper.findByDataTest('ec-dropdown-search__search-input').element);
-      document.activeElement.blur();
-      wrapper.destroy();
+      expect(document.activeElement).toBe(document.body);
     });
 
     it('should focus the search if search and cta are enabled and an item is selected', async () => {
@@ -445,15 +415,49 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
 
       expect(document.activeElement).toBe(document.body);
       await openDropdown(wrapper);
-      expect(document.activeElement).toBe(document.body);
+      expect(document.activeElement).toBe(wrapper.findByDataTest('ec-dropdown-search__search-input').element);
       await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.down');
       expect(document.activeElement).toBe(document.body);
 
       await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
 
-      expect(document.activeElement).toBe(wrapper.findByDataTest('cta-data-test').element);
-      document.activeElement.blur();
-      wrapper.destroy();
+      expect(document.activeElement).toBe(wrapper.findByDataTest('ec-dropdown-search__search-input').element);
+    });
+
+    it('should not focus the search if search and cta are enabled but the dropdown is not open', async () => {
+      const elem = document.createElement('div');
+      document.body.appendChild(elem);
+
+      const wrapper = mountDropdownSearch({ items, isSearchEnabled: true }, {
+        scopedSlots: {
+          cta: '<a href="#" data-test="cta-data-test">My CTA</a>',
+        },
+        attachTo: elem,
+      });
+
+      expect(document.activeElement).toBe(document.body);
+      await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
+
+      expect(document.activeElement).toBe(document.body);
+    });
+    it('should not focus the cta if search and cta are enabled but the cta has nothing to focus', async () => {
+      const elem = document.createElement('div');
+      document.body.appendChild(elem);
+
+      const wrapper = mountDropdownSearch({ items, isSearchEnabled: true }, {
+        scopedSlots: {
+          cta: '<div data-test="cta-data-test">My CTA</div>',
+        },
+        attachTo: elem,
+      });
+
+      expect(document.activeElement).toBe(document.body);
+      await openDropdown(wrapper);
+
+      expect(document.activeElement).toBe(wrapper.findByDataTest('ec-dropdown-search__search-input').element);
+      await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.tab');
+
+      expect(document.activeElement).toBe(document.body);
     });
   });
 
@@ -518,7 +522,7 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
 
       await wrapper.findByDataTest('ec-popover-dropdown-search').vm.$emit('resize');
 
-      expect(focusSpy).toHaveBeenCalledTimes(1);
+      expect(focusSpy).toHaveBeenCalledTimes(2);
       focusSpy.mockRestore();
     });
   });
@@ -658,8 +662,15 @@ describe('EcDropdownSearch - Keyboard navigation', () => {
 });
 
 function mountDropdownSearch(props, mountOpts) {
+  const MockedEcPopover = Vue.extend({
+    methods: {
+      update: jest.fn(),
+    },
+    template: '<div data-popover-stub><slot /><slot name="popover" /></div>',
+  });
   return mount(EcDropdownSearch, {
     propsData: { ...props },
+    stubs: { EcPopover: MockedEcPopover },
     ...mountOpts,
   });
 }
@@ -698,5 +709,6 @@ function mockHtmlElementPosition(options) {
 async function openDropdown(wrapper) {
   expect(wrapper.emitted('open')).toBeUndefined();
   await wrapper.findByDataTest('ec-dropdown-search').trigger('keydown.enter');
+  await wrapper.find('[data-popover-stub]').vm.$emit('apply-show');
   expect(wrapper.emitted('open').length).toBeTruthy();
 }

--- a/src/components/ec-dropdown-search/ec-dropdown-search.spec.js
+++ b/src/components/ec-dropdown-search/ec-dropdown-search.spec.js
@@ -1,4 +1,4 @@
-import { mount, createLocalVue } from '@vue/test-utils';
+import { enableAutoDestroy, mount, createLocalVue } from '@vue/test-utils';
 import EcDropdownSearch from './ec-dropdown-search.vue';
 import { withMockedConsole } from '../../../tests/utils/console';
 
@@ -51,6 +51,8 @@ describe('EcDropdownSearch', () => {
     },
     { id: 5, text: 'Item 5' },
   ];
+
+  enableAutoDestroy(afterEach);
 
   it('should render as expected', () => {
     const wrapper = mountDropdownSearch();
@@ -369,8 +371,6 @@ describe('EcDropdownSearch', () => {
       await wrapper.find('ecpopover-stub').vm.$emit('apply-show');
 
       expect(document.activeElement).toBe(wrapper.findByDataTest('ec-dropdown-search__search-input').element);
-
-      wrapper.destroy(); // because we attached the wrapper to document
     });
 
     it('should hide the popover after item has been selected', async () => {

--- a/src/components/ec-dropdown-search/ec-dropdown-search.vue
+++ b/src/components/ec-dropdown-search/ec-dropdown-search.vue
@@ -312,6 +312,9 @@ export default {
       if (!this.isOpen) {
         // necessary to regain the focus after tab/enter keyboard event if search feature is active
         this.initialFocusedElement = this.$refs.popover.$el.querySelector(':focus');
+        if (this.isSearchEnabled) {
+          this.isSearchInputFocus = true;
+        }
         if (this.hasCta() && this.isCtaAreaFocus) {
           this.isCtaAreaFocus = false;
         }
@@ -372,11 +375,12 @@ export default {
       }
     },
     onTabKeyDown() {
-      // if (this.hasCta()) {
-      const ctaAreaElementFocuseable = this.$refs.ctaArea.querySelector(
-        'a, button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])',
-      );
-      // }
+      let ctaAreaElementFocuseable;
+      if (this.hasCta()) {
+        ctaAreaElementFocuseable = this.$refs.ctaArea.querySelector(
+          'a, button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])',
+        );
+      }
 
       if (!this.isSearchInputFocus && !this.isCtaAreaFocus && this.isSearchEnabled) {
         this.focusSearch();

--- a/src/components/ec-dropdown-search/ec-dropdown-search.vue
+++ b/src/components/ec-dropdown-search/ec-dropdown-search.vue
@@ -342,7 +342,7 @@ export default {
       } else {
         // selecting an item might affect the position of the popover,
         // e.g. new item moves the trigger down
-        // this.$refs.popover.update();
+        this.$refs.popover.update();
       }
     },
     hasCta() {

--- a/src/components/ec-dropdown-search/ec-dropdown-search.vue
+++ b/src/components/ec-dropdown-search/ec-dropdown-search.vue
@@ -312,9 +312,6 @@ export default {
       if (!this.isOpen) {
         // necessary to regain the focus after tab/enter keyboard event if search feature is active
         this.initialFocusedElement = this.$refs.popover.$el.querySelector(':focus');
-        if (this.isSearchEnabled) {
-          this.isSearchInputFocus = true;
-        }
         if (this.hasCta() && this.isCtaAreaFocus) {
           this.isCtaAreaFocus = false;
         }
@@ -325,7 +322,7 @@ export default {
     focusSearch() {
       this.$nextTick(() => {
         /* istanbul ignore else */
-        if (this.isOpen && this.$refs.searchInput) {
+        if (this.isOpen && this.isSearchEnabled) {
           this.$refs.searchInput.focus();
         }
       });
@@ -367,32 +364,26 @@ export default {
       } else {
         nextItem = this.filteredItems.find(item => !item.disabled);
       }
-      if (this.hasCta() && this.isCtaAreaFocus) {
-        this.isCtaAreaFocus = false;
-      }
+
       if (nextItem) {
         this.select(nextItem, { keyboardNavigation: true });
       }
+
+      if (this.hasCta() && this.isCtaAreaFocus) {
+        this.isCtaAreaFocus = false;
+      }
     },
     onTabKeyDown() {
-      let ctaAreaElementFocuseable;
-      if (this.hasCta()) {
-        ctaAreaElementFocuseable = this.$refs.ctaArea.querySelector(
-          'a, button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])',
-        );
-      }
-
-      if (!this.isSearchInputFocus && !this.isCtaAreaFocus && this.isSearchEnabled) {
-        this.focusSearch();
-      } else if (!this.isSearchInputFocus && !this.isCtaAreaFocus && !this.isSearchEnabled && this.hasCta()) {
-        ctaAreaElementFocuseable.focus();
-        this.isCtaAreaFocus = true;
-      } else if (this.isSearchInputFocus && this.hasCta()) {
-        ctaAreaElementFocuseable.focus();
-        this.isCtaAreaFocus = true;
-      } else if (this.isCtaAreaFocus && this.isSearchEnabled) {
+      if (this.isSearchEnabled && !this.isSearchInputFocus) {
         this.focusSearch();
         this.isCtaAreaFocus = false;
+      } else if (this.hasCta() && !this.isCtaAreaFocus) {
+        const ctaAreaElementFocuseable = this.$refs.ctaArea.querySelector(
+          'a, button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])',
+        );
+
+        ctaAreaElementFocuseable.focus();
+        this.isCtaAreaFocus = true;
       }
     },
     onArrowUpKeyDown() {

--- a/src/components/ec-dropdown-search/ec-dropdown-search.vue
+++ b/src/components/ec-dropdown-search/ec-dropdown-search.vue
@@ -368,7 +368,7 @@ export default {
         this.select(nextItem, { keyboardNavigation: true });
       }
 
-      this.lostFocus();
+      this.loseFocus();
     },
     blurCta() {
       if (this.hasCta() && this.isCtaAreaFocused) {
@@ -422,7 +422,7 @@ export default {
     closeViaKeyboardNavigation() {
       if (this.isOpen) {
         this.hide();
-        this.lostFocus();
+        this.loseFocus();
         if (this.isSearchEnabled) {
           // if the search is active the focus is lost from the trigger, then it must regain the focus
           if (this.initialFocusedElement) {
@@ -456,7 +456,7 @@ export default {
         }
       }
     },
-    lostFocus() {
+    loseFocus() {
       if (this.isSearchInputFocused) {
         // if the search is active the focus is lost from the trigger, then it must regain the focus
         this.$refs.searchInput.blur();

--- a/src/components/ec-dropdown-search/ec-dropdown-search.vue
+++ b/src/components/ec-dropdown-search/ec-dropdown-search.vue
@@ -312,9 +312,7 @@ export default {
       if (!this.isOpen) {
         // necessary to regain the focus after tab/enter keyboard event if search feature is active
         this.initialFocusedElement = this.$refs.popover.$el.querySelector(':focus');
-        if (this.hasCta() && this.isCtaAreaFocus) {
-          this.isCtaAreaFocus = false;
-        }
+        this.blurCta();
         this.isOpen = true;
         this.$emit('open');
       }
@@ -344,7 +342,7 @@ export default {
       } else {
         // selecting an item might affect the position of the popover,
         // e.g. new item moves the trigger down
-        this.$refs.popover.update();
+        // this.$refs.popover.update();
       }
     },
     hasCta() {
@@ -369,21 +367,33 @@ export default {
         this.select(nextItem, { keyboardNavigation: true });
       }
 
+      this.blurCta();
+    },
+    blurCta() {
       if (this.hasCta() && this.isCtaAreaFocus) {
         this.isCtaAreaFocus = false;
       }
     },
+    focusCta() {
+      this.isCtaAreaFocus = true;
+    },
+    canFocusCta() {
+      return this.hasCta() && !this.isCtaAreaFocus;
+    },
+    canFocusSearch() {
+      return this.isSearchEnabled && !this.isSearchInputFocus;
+    },
     onTabKeyDown() {
-      if (this.isSearchEnabled && !this.isSearchInputFocus) {
-        this.focusSearch();
-        this.isCtaAreaFocus = false;
-      } else if (this.hasCta() && !this.isCtaAreaFocus) {
+      if (this.canFocusCta()) {
         const ctaAreaElementFocuseable = this.$refs.ctaArea.querySelector(
           'a, button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])',
         );
 
         ctaAreaElementFocuseable.focus();
-        this.isCtaAreaFocus = true;
+        this.focusCta();
+      } else if (this.canFocusSearch()) {
+        this.focusSearch();
+        this.blurCta();
       }
     },
     onArrowUpKeyDown() {

--- a/src/components/ec-dropdown/ec-dropdown.story.js
+++ b/src/components/ec-dropdown/ec-dropdown.story.js
@@ -55,7 +55,7 @@ stories.add('basic', () => ({
     },
   },
   methods: {
-    cta: console.log('hehe'),
+    cta: () => console.log('cta pressed'),
     onSelected: action('Selected'),
   },
   template: `

--- a/src/components/ec-dropdown/ec-dropdown.story.js
+++ b/src/components/ec-dropdown/ec-dropdown.story.js
@@ -55,7 +55,7 @@ stories.add('basic', () => ({
     },
   },
   methods: {
-    cta: () => console.log('cta pressed'),
+    cta: () => action('CTA pressed'),
     onSelected: action('Selected'),
   },
   template: `

--- a/src/components/ec-dropdown/ec-dropdown.story.js
+++ b/src/components/ec-dropdown/ec-dropdown.story.js
@@ -55,6 +55,7 @@ stories.add('basic', () => ({
     },
   },
   methods: {
+    cta: console.log('hehe'),
     onSelected: action('Selected'),
   },
   template: `
@@ -67,6 +68,9 @@ stories.add('basic', () => ({
           v-model="selected"
           :is-sensitive="isSensitive"
           @change="onSelected">
+          <template #cta>
+            <a href="#" @click.prevent="cta()" class="tw-block tw-py-8 tw-px-16">Do something</a>
+          </template>
         </ec-dropdown>
       </div>
     </div>

--- a/src/components/ec-modal/ec-modal.spec.js
+++ b/src/components/ec-modal/ec-modal.spec.js
@@ -1,4 +1,4 @@
-import { mount, createLocalVue } from '@vue/test-utils';
+import { enableAutoDestroy, mount, createLocalVue } from '@vue/test-utils';
 import { withMockedConsole } from '../../../tests/utils/console';
 import EcModal from './ec-modal.vue';
 
@@ -28,6 +28,8 @@ function mountModalAsTemplate(template, props, wrapperComponentOpts, mountOpts) 
 }
 
 describe('EcModal', () => {
+  enableAutoDestroy(afterEach);
+
   it('should not render the modal if "showModal" is not set to true', () => {
     const wrapper = mountModal();
     expect(wrapper.findByDataTest('ec-modal').exists()).toBe(false);
@@ -276,8 +278,6 @@ describe('EcModal', () => {
 
     await wrapper.trigger('keyup.esc');
     expect(wrapper.emitted().close).toBeTruthy();
-
-    wrapper.destroy(); // because we attached the wrapper to document
   });
 
   it('should not close the modal if ESC key is pressed and is not closable', async () => {
@@ -293,8 +293,6 @@ describe('EcModal', () => {
 
     await wrapper.trigger('keyup.esc');
     expect(wrapper.emitted('close')).toBeUndefined();
-
-    wrapper.destroy(); // because we attached the wrapper to document
   });
 
   it('should not close the modal if key other than ESC is pressed and is closable', async () => {
@@ -309,8 +307,6 @@ describe('EcModal', () => {
 
     await wrapper.trigger('keyup.space');
     expect(wrapper.emitted('close')).toBeUndefined();
-
-    await wrapper.destroy(); // because we attached the wrapper to document
   });
 
   it('should stop listening to keyup events when closed', async () => {
@@ -335,8 +331,6 @@ describe('EcModal', () => {
 
     expect(addEventListenerSpy).toHaveBeenCalledTimes(1);
     expect(removeEventListenerSpy).toHaveBeenCalledWith('keyup', addEventListenerSpy.mock.calls[0][1]);
-
-    wrapper.destroy(); // because we attached the wrapper to document
   });
 
   it('should stop listening to keyup events when destroyed', async () => {
@@ -357,7 +351,7 @@ describe('EcModal', () => {
     expect(addEventListenerSpy).toHaveBeenCalledTimes(1);
     expect(addEventListenerSpy).toHaveBeenCalledWith('keyup', expect.any(Function));
 
-    await wrapper.destroy(); // because we attached the wrapper to document
+    await wrapper.destroy();
 
     expect(addEventListenerSpy).toHaveBeenCalledTimes(1);
     expect(removeEventListenerSpy).toHaveBeenCalledWith('keyup', addEventListenerSpy.mock.calls[0][1]);


### PR DESCRIPTION
The keyboard navigation on the CTA and Search area will work with the tab key, and the items will work as it was from before nothing changes with the arrows keys