### PR TITLE
ONL-4900: feat: Added pagination

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/components/ec-smart-table/__snapshots__/ec-smart-table.spec.js.snap
+++ b/src/components/ec-smart-table/__snapshots__/ec-smart-table.spec.js.snap
@@ -671,7 +671,7 @@ exports[`EcSmartTable pagination should re-fetch the data when prev page is sele
 </div>
 `;
 
-exports[`EcSmartTable pagination should render footer slot inside of the pagination when pagination is not enabled 1`] = `
+exports[`EcSmartTable pagination should render footer slot inside of the pagination when pagination is enabled 1`] = `
 <tfoot
   class="ec-table-footer"
   data-test="ec-table-footer"

--- a/src/components/ec-smart-table/__snapshots__/ec-smart-table.spec.js.snap
+++ b/src/components/ec-smart-table/__snapshots__/ec-smart-table.spec.js.snap
@@ -32,6 +32,979 @@ exports[`EcSmartTable #slots should render error with custom template and custom
 </div>
 `;
 
+exports[`EcSmartTable pagination should pass pages slot into the pagination 1`] = `
+<div
+  class="ec-table-pagination__current-page"
+  data-test="ec-table-pagination__current-page"
+>
+  <div>
+    Pages: {"page":1,"numberOfItems":10,"totalPages":5,"total":50}
+  </div>
+</div>
+`;
+
+exports[`EcSmartTable pagination should re-fetch the data when next page is selected: loading icon after loading new page 1`] = `undefined`;
+
+exports[`EcSmartTable pagination should re-fetch the data when next page is selected: loading icon while loading new page 1`] = `
+<svg
+  class="ec-loading__icon ec-icon"
+  data-test="ec-loading__icon"
+  height="48"
+  width="48"
+>
+  <use
+    xlink:href="#ec-simple-loading"
+  />
+</svg>
+`;
+
+exports[`EcSmartTable pagination should re-fetch the data when next page is selected: pagination after loading new page 1`] = `
+<div
+  class="ec-table-pagination"
+  data-test="ec-smart-table-pagination ec-table-pagination"
+>
+  <div
+    class="ec-table-pagination__page-size"
+    data-test="ec-table-pagination__page-size"
+  >
+    <div
+      class="ec-table-pagination__page-size-text"
+    >
+      Items per page:
+    </div>
+     
+    <div
+      class="ec-dropdown-search"
+      data-test="ec-dropdown-search"
+    >
+      <ecpopover-stub
+        class="ec-dropdown-search__trigger"
+        data-test="ec-popover-dropdown-search"
+        offset="8"
+        placement="bottom"
+        popoverinnerclass="ec-dropdown-search__popover"
+        popperoptions="[object Object]"
+      >
+        <button
+          class="ec-table-pagination__action ec-table-pagination__action--page-size"
+          data-test="ec-table-pagination__action--page-size"
+        >
+          
+        10
+        
+          <svg
+            class="ec-table-pagination__action-icon ec-icon"
+            height="24"
+            width="24"
+          >
+            <use
+              xlink:href="#ec-simple-chevron-down"
+            />
+          </svg>
+        </button>
+         
+        <div>
+          <ul
+            class="ec-dropdown-search__item-list"
+            data-test="ec-dropdown-search__item-list"
+          >
+            <!---->
+             
+            <!---->
+             
+            <li
+              class="ec-dropdown-search__item"
+              data-test="ec-dropdown-search__item ec-dropdown-search__item--0"
+              title="5"
+            >
+              5
+            </li>
+            <li
+              class="ec-dropdown-search__item ec-dropdown-search__item--is-selected"
+              data-test="ec-dropdown-search__item ec-dropdown-search__item--1"
+              title="10"
+            >
+              10
+            </li>
+            <li
+              class="ec-dropdown-search__item"
+              data-test="ec-dropdown-search__item ec-dropdown-search__item--2"
+              title="50"
+            >
+              50
+            </li>
+            <li
+              class="ec-dropdown-search__item"
+              data-test="ec-dropdown-search__item ec-dropdown-search__item--3"
+              title="100"
+            >
+              100
+            </li>
+          </ul>
+        </div>
+      </ecpopover-stub>
+    </div>
+  </div>
+   
+  <div
+    class="ec-table-pagination__current-page"
+    data-test="ec-table-pagination__current-page"
+  >
+    <span>
+      2 of 5 pages
+    </span>
+     
+    <span>
+      (50 items)
+    </span>
+  </div>
+   
+  <div
+    class="ec-table-pagination__total"
+    data-test="ec-table-pagination__total"
+  />
+   
+  <div
+    class="ec-table-pagination__actions"
+    data-test="ec-table-pagination__actions"
+  >
+    <button
+      class="ec-table-pagination__action ec-table-pagination__action--prev"
+      data-test="ec-table-pagination__action--prev"
+      type="button"
+    >
+      <svg
+        class="ec-table-pagination__action-icon ec-icon"
+        height="24"
+        width="24"
+      >
+        <use
+          xlink:href="#ec-simple-chevron-left"
+        />
+      </svg>
+    </button>
+     
+    <button
+      class="ec-table-pagination__action ec-table-pagination__action--next"
+      data-test="ec-table-pagination__action--next"
+      type="button"
+    >
+      <svg
+        class="ec-table-pagination__action-icon ec-icon"
+        height="24"
+        width="24"
+      >
+        <use
+          xlink:href="#ec-simple-chevron-right"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`EcSmartTable pagination should re-fetch the data when page size is changed: loading icon after loading new page 1`] = `undefined`;
+
+exports[`EcSmartTable pagination should re-fetch the data when page size is changed: loading icon while loading new page 1`] = `
+<svg
+  class="ec-loading__icon ec-icon"
+  data-test="ec-loading__icon"
+  height="48"
+  width="48"
+>
+  <use
+    xlink:href="#ec-simple-loading"
+  />
+</svg>
+`;
+
+exports[`EcSmartTable pagination should re-fetch the data when page size is changed: pagination after loading new page 1`] = `
+<div
+  class="ec-table-pagination"
+  data-test="ec-smart-table-pagination ec-table-pagination"
+>
+  <div
+    class="ec-table-pagination__page-size"
+    data-test="ec-table-pagination__page-size"
+  >
+    <div
+      class="ec-table-pagination__page-size-text"
+    >
+      Items per page:
+    </div>
+     
+    <div
+      class="ec-dropdown-search"
+      data-test="ec-dropdown-search"
+    >
+      <ecpopover-stub
+        class="ec-dropdown-search__trigger"
+        data-test="ec-popover-dropdown-search"
+        offset="8"
+        placement="bottom"
+        popoverinnerclass="ec-dropdown-search__popover"
+        popperoptions="[object Object]"
+      >
+        <button
+          class="ec-table-pagination__action ec-table-pagination__action--page-size"
+          data-test="ec-table-pagination__action--page-size"
+        >
+          
+        50
+        
+          <svg
+            class="ec-table-pagination__action-icon ec-icon"
+            height="24"
+            width="24"
+          >
+            <use
+              xlink:href="#ec-simple-chevron-down"
+            />
+          </svg>
+        </button>
+         
+        <div>
+          <ul
+            class="ec-dropdown-search__item-list"
+            data-test="ec-dropdown-search__item-list"
+          >
+            <!---->
+             
+            <!---->
+             
+            <li
+              class="ec-dropdown-search__item"
+              data-test="ec-dropdown-search__item ec-dropdown-search__item--0"
+              title="5"
+            >
+              5
+            </li>
+            <li
+              class="ec-dropdown-search__item"
+              data-test="ec-dropdown-search__item ec-dropdown-search__item--1"
+              title="10"
+            >
+              10
+            </li>
+            <li
+              class="ec-dropdown-search__item ec-dropdown-search__item--is-selected"
+              data-test="ec-dropdown-search__item ec-dropdown-search__item--2"
+              title="50"
+            >
+              50
+            </li>
+            <li
+              class="ec-dropdown-search__item"
+              data-test="ec-dropdown-search__item ec-dropdown-search__item--3"
+              title="100"
+            >
+              100
+            </li>
+          </ul>
+        </div>
+      </ecpopover-stub>
+    </div>
+  </div>
+   
+  <div
+    class="ec-table-pagination__current-page"
+    data-test="ec-table-pagination__current-page"
+  >
+    <span>
+      1 of 1 pages
+    </span>
+     
+    <span>
+      (50 items)
+    </span>
+  </div>
+   
+  <div
+    class="ec-table-pagination__total"
+    data-test="ec-table-pagination__total"
+  />
+   
+  <div
+    class="ec-table-pagination__actions"
+    data-test="ec-table-pagination__actions"
+  >
+    <button
+      class="ec-table-pagination__action ec-table-pagination__action--prev ec-table-pagination__action--is-disabled"
+      data-test="ec-table-pagination__action--prev"
+      disabled="disabled"
+      type="button"
+    >
+      <svg
+        class="ec-table-pagination__action-icon ec-icon"
+        height="24"
+        width="24"
+      >
+        <use
+          xlink:href="#ec-simple-chevron-left"
+        />
+      </svg>
+    </button>
+     
+    <button
+      class="ec-table-pagination__action ec-table-pagination__action--next ec-table-pagination__action--is-disabled"
+      data-test="ec-table-pagination__action--next"
+      disabled="disabled"
+      type="button"
+    >
+      <svg
+        class="ec-table-pagination__action-icon ec-icon"
+        height="24"
+        width="24"
+      >
+        <use
+          xlink:href="#ec-simple-chevron-right"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`EcSmartTable pagination should re-fetch the data when prev page is selected 1`] = `
+<div
+  class="ec-table-pagination"
+  data-test="ec-smart-table-pagination ec-table-pagination"
+>
+  <div
+    class="ec-table-pagination__page-size"
+    data-test="ec-table-pagination__page-size"
+  >
+    <div
+      class="ec-table-pagination__page-size-text"
+    >
+      Items per page:
+    </div>
+     
+    <div
+      class="ec-dropdown-search"
+      data-test="ec-dropdown-search"
+    >
+      <ecpopover-stub
+        class="ec-dropdown-search__trigger"
+        data-test="ec-popover-dropdown-search"
+        offset="8"
+        placement="bottom"
+        popoverinnerclass="ec-dropdown-search__popover"
+        popperoptions="[object Object]"
+      >
+        <button
+          class="ec-table-pagination__action ec-table-pagination__action--page-size"
+          data-test="ec-table-pagination__action--page-size"
+        >
+          
+        10
+        
+          <svg
+            class="ec-table-pagination__action-icon ec-icon"
+            height="24"
+            width="24"
+          >
+            <use
+              xlink:href="#ec-simple-chevron-down"
+            />
+          </svg>
+        </button>
+         
+        <div>
+          <ul
+            class="ec-dropdown-search__item-list"
+            data-test="ec-dropdown-search__item-list"
+          >
+            <!---->
+             
+            <!---->
+             
+            <li
+              class="ec-dropdown-search__item"
+              data-test="ec-dropdown-search__item ec-dropdown-search__item--0"
+              title="5"
+            >
+              5
+            </li>
+            <li
+              class="ec-dropdown-search__item ec-dropdown-search__item--is-selected"
+              data-test="ec-dropdown-search__item ec-dropdown-search__item--1"
+              title="10"
+            >
+              10
+            </li>
+            <li
+              class="ec-dropdown-search__item"
+              data-test="ec-dropdown-search__item ec-dropdown-search__item--2"
+              title="50"
+            >
+              50
+            </li>
+            <li
+              class="ec-dropdown-search__item"
+              data-test="ec-dropdown-search__item ec-dropdown-search__item--3"
+              title="100"
+            >
+              100
+            </li>
+          </ul>
+        </div>
+      </ecpopover-stub>
+    </div>
+  </div>
+   
+  <div
+    class="ec-table-pagination__current-page"
+    data-test="ec-table-pagination__current-page"
+  >
+    <span>
+      2 of 5 pages
+    </span>
+     
+    <span>
+      (50 items)
+    </span>
+  </div>
+   
+  <div
+    class="ec-table-pagination__total"
+    data-test="ec-table-pagination__total"
+  />
+   
+  <div
+    class="ec-table-pagination__actions"
+    data-test="ec-table-pagination__actions"
+  >
+    <button
+      class="ec-table-pagination__action ec-table-pagination__action--prev"
+      data-test="ec-table-pagination__action--prev"
+      type="button"
+    >
+      <svg
+        class="ec-table-pagination__action-icon ec-icon"
+        height="24"
+        width="24"
+      >
+        <use
+          xlink:href="#ec-simple-chevron-left"
+        />
+      </svg>
+    </button>
+     
+    <button
+      class="ec-table-pagination__action ec-table-pagination__action--next"
+      data-test="ec-table-pagination__action--next"
+      type="button"
+    >
+      <svg
+        class="ec-table-pagination__action-icon ec-icon"
+        height="24"
+        width="24"
+      >
+        <use
+          xlink:href="#ec-simple-chevron-right"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`EcSmartTable pagination should re-fetch the data when prev page is selected: loading icon after loading new page 1`] = `undefined`;
+
+exports[`EcSmartTable pagination should re-fetch the data when prev page is selected: loading icon while loading new page 1`] = `
+<svg
+  class="ec-loading__icon ec-icon"
+  data-test="ec-loading__icon"
+  height="48"
+  width="48"
+>
+  <use
+    xlink:href="#ec-simple-loading"
+  />
+</svg>
+`;
+
+exports[`EcSmartTable pagination should re-fetch the data when prev page is selected: pagination after loading new page 1`] = `
+<div
+  class="ec-table-pagination"
+  data-test="ec-smart-table-pagination ec-table-pagination"
+>
+  <div
+    class="ec-table-pagination__page-size"
+    data-test="ec-table-pagination__page-size"
+  >
+    <div
+      class="ec-table-pagination__page-size-text"
+    >
+      Items per page:
+    </div>
+     
+    <div
+      class="ec-dropdown-search"
+      data-test="ec-dropdown-search"
+    >
+      <ecpopover-stub
+        class="ec-dropdown-search__trigger"
+        data-test="ec-popover-dropdown-search"
+        offset="8"
+        placement="bottom"
+        popoverinnerclass="ec-dropdown-search__popover"
+        popperoptions="[object Object]"
+      >
+        <button
+          class="ec-table-pagination__action ec-table-pagination__action--page-size"
+          data-test="ec-table-pagination__action--page-size"
+        >
+          
+        10
+        
+          <svg
+            class="ec-table-pagination__action-icon ec-icon"
+            height="24"
+            width="24"
+          >
+            <use
+              xlink:href="#ec-simple-chevron-down"
+            />
+          </svg>
+        </button>
+         
+        <div>
+          <ul
+            class="ec-dropdown-search__item-list"
+            data-test="ec-dropdown-search__item-list"
+          >
+            <!---->
+             
+            <!---->
+             
+            <li
+              class="ec-dropdown-search__item"
+              data-test="ec-dropdown-search__item ec-dropdown-search__item--0"
+              title="5"
+            >
+              5
+            </li>
+            <li
+              class="ec-dropdown-search__item ec-dropdown-search__item--is-selected"
+              data-test="ec-dropdown-search__item ec-dropdown-search__item--1"
+              title="10"
+            >
+              10
+            </li>
+            <li
+              class="ec-dropdown-search__item"
+              data-test="ec-dropdown-search__item ec-dropdown-search__item--2"
+              title="50"
+            >
+              50
+            </li>
+            <li
+              class="ec-dropdown-search__item"
+              data-test="ec-dropdown-search__item ec-dropdown-search__item--3"
+              title="100"
+            >
+              100
+            </li>
+          </ul>
+        </div>
+      </ecpopover-stub>
+    </div>
+  </div>
+   
+  <div
+    class="ec-table-pagination__current-page"
+    data-test="ec-table-pagination__current-page"
+  >
+    <span>
+      1 of 5 pages
+    </span>
+     
+    <span>
+      (50 items)
+    </span>
+  </div>
+   
+  <div
+    class="ec-table-pagination__total"
+    data-test="ec-table-pagination__total"
+  />
+   
+  <div
+    class="ec-table-pagination__actions"
+    data-test="ec-table-pagination__actions"
+  >
+    <button
+      class="ec-table-pagination__action ec-table-pagination__action--prev ec-table-pagination__action--is-disabled"
+      data-test="ec-table-pagination__action--prev"
+      disabled="disabled"
+      type="button"
+    >
+      <svg
+        class="ec-table-pagination__action-icon ec-icon"
+        height="24"
+        width="24"
+      >
+        <use
+          xlink:href="#ec-simple-chevron-left"
+        />
+      </svg>
+    </button>
+     
+    <button
+      class="ec-table-pagination__action ec-table-pagination__action--next"
+      data-test="ec-table-pagination__action--next"
+      type="button"
+    >
+      <svg
+        class="ec-table-pagination__action-icon ec-icon"
+        height="24"
+        width="24"
+      >
+        <use
+          xlink:href="#ec-simple-chevron-right"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
+exports[`EcSmartTable pagination should render footer slot inside of the pagination when pagination is not enabled 1`] = `
+<tfoot
+  class="ec-table-footer"
+  data-test="ec-table-footer"
+>
+  <tr>
+    <td
+      class="ec-table-footer__cell"
+      colspan="3"
+    >
+      <div
+        class="ec-table-footer__contents"
+      >
+        <div
+          class="ec-table-pagination"
+          data-test="ec-smart-table-pagination ec-table-pagination"
+        >
+          <div
+            class="ec-table-pagination__page-size"
+            data-test="ec-table-pagination__page-size"
+          >
+            <div
+              class="ec-table-pagination__page-size-text"
+            >
+              Items per page:
+            </div>
+             
+            <div
+              class="ec-dropdown-search"
+              data-test="ec-dropdown-search"
+            >
+              <ecpopover-stub
+                class="ec-dropdown-search__trigger"
+                data-test="ec-popover-dropdown-search"
+                offset="8"
+                placement="bottom"
+                popoverinnerclass="ec-dropdown-search__popover"
+                popperoptions="[object Object]"
+              >
+                <button
+                  class="ec-table-pagination__action ec-table-pagination__action--page-size"
+                  data-test="ec-table-pagination__action--page-size"
+                >
+                  
+        10
+        
+                  <svg
+                    class="ec-table-pagination__action-icon ec-icon"
+                    height="24"
+                    width="24"
+                  >
+                    <use
+                      xlink:href="#ec-simple-chevron-down"
+                    />
+                  </svg>
+                </button>
+                 
+                <div>
+                  <ul
+                    class="ec-dropdown-search__item-list"
+                    data-test="ec-dropdown-search__item-list"
+                  >
+                    <!---->
+                     
+                    <!---->
+                     
+                    <li
+                      class="ec-dropdown-search__item"
+                      data-test="ec-dropdown-search__item ec-dropdown-search__item--0"
+                      title="5"
+                    >
+                      5
+                    </li>
+                    <li
+                      class="ec-dropdown-search__item ec-dropdown-search__item--is-selected"
+                      data-test="ec-dropdown-search__item ec-dropdown-search__item--1"
+                      title="10"
+                    >
+                      10
+                    </li>
+                    <li
+                      class="ec-dropdown-search__item"
+                      data-test="ec-dropdown-search__item ec-dropdown-search__item--2"
+                      title="50"
+                    >
+                      50
+                    </li>
+                    <li
+                      class="ec-dropdown-search__item"
+                      data-test="ec-dropdown-search__item ec-dropdown-search__item--3"
+                      title="100"
+                    >
+                      100
+                    </li>
+                  </ul>
+                </div>
+              </ecpopover-stub>
+            </div>
+          </div>
+           
+          <div
+            class="ec-table-pagination__current-page"
+            data-test="ec-table-pagination__current-page"
+          >
+            <span>
+              1 of 5 pages
+            </span>
+             
+            <span>
+              (50 items)
+            </span>
+          </div>
+           
+          <div
+            class="ec-table-pagination__total"
+            data-test="ec-table-pagination__total"
+          >
+            <div>
+              My custom footer
+            </div>
+          </div>
+           
+          <div
+            class="ec-table-pagination__actions"
+            data-test="ec-table-pagination__actions"
+          >
+            <button
+              class="ec-table-pagination__action ec-table-pagination__action--prev ec-table-pagination__action--is-disabled"
+              data-test="ec-table-pagination__action--prev"
+              disabled="disabled"
+              type="button"
+            >
+              <svg
+                class="ec-table-pagination__action-icon ec-icon"
+                height="24"
+                width="24"
+              >
+                <use
+                  xlink:href="#ec-simple-chevron-left"
+                />
+              </svg>
+            </button>
+             
+            <button
+              class="ec-table-pagination__action ec-table-pagination__action--next"
+              data-test="ec-table-pagination__action--next"
+              type="button"
+            >
+              <svg
+                class="ec-table-pagination__action-icon ec-icon"
+                height="24"
+                width="24"
+              >
+                <use
+                  xlink:href="#ec-simple-chevron-right"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </td>
+  </tr>
+</tfoot>
+`;
+
+exports[`EcSmartTable pagination should render footer slot when pagination is not enabled 1`] = `
+<tfoot
+  class="ec-table-footer"
+  data-test="ec-table-footer"
+>
+  <tr>
+    <td
+      class="ec-table-footer__cell"
+      colspan="3"
+    >
+      <div
+        class="ec-table-footer__contents"
+      >
+        <div>
+          My custom footer
+        </div>
+      </div>
+    </td>
+  </tr>
+</tfoot>
+`;
+
+exports[`EcSmartTable pagination should render pagination when it's enabled 1`] = `
+<div
+  class="ec-table-pagination"
+  data-test="ec-smart-table-pagination ec-table-pagination"
+>
+  <div
+    class="ec-table-pagination__page-size"
+    data-test="ec-table-pagination__page-size"
+  >
+    <div
+      class="ec-table-pagination__page-size-text"
+    >
+      Items per page:
+    </div>
+     
+    <div
+      class="ec-dropdown-search"
+      data-test="ec-dropdown-search"
+    >
+      <ecpopover-stub
+        class="ec-dropdown-search__trigger"
+        data-test="ec-popover-dropdown-search"
+        offset="8"
+        placement="bottom"
+        popoverinnerclass="ec-dropdown-search__popover"
+        popperoptions="[object Object]"
+      >
+        <button
+          class="ec-table-pagination__action ec-table-pagination__action--page-size"
+          data-test="ec-table-pagination__action--page-size"
+        >
+          
+        10
+        
+          <svg
+            class="ec-table-pagination__action-icon ec-icon"
+            height="24"
+            width="24"
+          >
+            <use
+              xlink:href="#ec-simple-chevron-down"
+            />
+          </svg>
+        </button>
+         
+        <div>
+          <ul
+            class="ec-dropdown-search__item-list"
+            data-test="ec-dropdown-search__item-list"
+          >
+            <!---->
+             
+            <!---->
+             
+            <li
+              class="ec-dropdown-search__item"
+              data-test="ec-dropdown-search__item ec-dropdown-search__item--0"
+              title="5"
+            >
+              5
+            </li>
+            <li
+              class="ec-dropdown-search__item ec-dropdown-search__item--is-selected"
+              data-test="ec-dropdown-search__item ec-dropdown-search__item--1"
+              title="10"
+            >
+              10
+            </li>
+            <li
+              class="ec-dropdown-search__item"
+              data-test="ec-dropdown-search__item ec-dropdown-search__item--2"
+              title="50"
+            >
+              50
+            </li>
+            <li
+              class="ec-dropdown-search__item"
+              data-test="ec-dropdown-search__item ec-dropdown-search__item--3"
+              title="100"
+            >
+              100
+            </li>
+          </ul>
+        </div>
+      </ecpopover-stub>
+    </div>
+  </div>
+   
+  <div
+    class="ec-table-pagination__current-page"
+    data-test="ec-table-pagination__current-page"
+  >
+    <span>
+      1 of 5 pages
+    </span>
+     
+    <span>
+      (50 items)
+    </span>
+  </div>
+   
+  <div
+    class="ec-table-pagination__total"
+    data-test="ec-table-pagination__total"
+  />
+   
+  <div
+    class="ec-table-pagination__actions"
+    data-test="ec-table-pagination__actions"
+  >
+    <button
+      class="ec-table-pagination__action ec-table-pagination__action--prev ec-table-pagination__action--is-disabled"
+      data-test="ec-table-pagination__action--prev"
+      disabled="disabled"
+      type="button"
+    >
+      <svg
+        class="ec-table-pagination__action-icon ec-icon"
+        height="24"
+        width="24"
+      >
+        <use
+          xlink:href="#ec-simple-chevron-left"
+        />
+      </svg>
+    </button>
+     
+    <button
+      class="ec-table-pagination__action ec-table-pagination__action--next"
+      data-test="ec-table-pagination__action--next"
+      type="button"
+    >
+      <svg
+        class="ec-table-pagination__action-icon ec-icon"
+        height="24"
+        width="24"
+      >
+        <use
+          xlink:href="#ec-simple-chevron-right"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;
+
 exports[`EcSmartTable should render empty data properly 1`] = `
 <div
   data-test="ec-smart-table-empty"

--- a/src/components/ec-smart-table/ec-smart-table.spec.js
+++ b/src/components/ec-smart-table/ec-smart-table.spec.js
@@ -262,7 +262,7 @@ describe('EcSmartTable', () => {
       expect(wrapper.findByDataTest('ec-table-footer').element).toMatchSnapshot();
     });
 
-    it('should render footer slot inside of the pagination when pagination is not enabled', async () => {
+    it('should render footer slot inside of the pagination when pagination is enabled', async () => {
       const wrapper = await mountEcSmartTableWithResolvedData(lotsOfData, {
         columns,
         isPaginationEnabled: true,

--- a/src/components/ec-smart-table/ec-smart-table.story.js
+++ b/src/components/ec-smart-table/ec-smart-table.story.js
@@ -104,6 +104,9 @@ stories
           highestFirst: SortDirectionCycle.HIGHEST_FIRST,
         }),
       },
+      isPaginationEnabled: {
+        default: boolean('isPaginationEnabled', true),
+      },
     },
     methods: {
       onSort: action('sort'),
@@ -113,19 +116,19 @@ stories
     data() {
       return {
         dataSource: {
-          fetch: ({ sorts /* , pagination coming soon */ }, cancelToken) => {
+          fetch: ({ sorts, page = 1, numberOfItems }, cancelToken) => {
             // use real service in a real application:
             // e.g.
-            // return myService.getData(sorts, pagination, cancelToken);
+            // return myService.getData(sorts, page, numberOfItems, cancelToken);
             // and pass the cancelToken into a fetch() call
             // e.g.
-            // getData: (sorts, pagination, cancelToken) => fetch('/my/url', { body: { sorts, pagination }, signal: cancelToken });
+            // getData: (sorts, page, numberOfItems, cancelToken) => fetch('/my/url', { body: { sorts, page, numberOfItems }, signal: cancelToken });
 
-            action('fetching')(sorts);
+            action('fetching')(sorts, page, numberOfItems);
 
             return new Promise((resolve, reject) => {
               this.loadingTimeout = setTimeout(() => {
-                action('resolving data')(sorts);
+                action('resolving data')(sorts, page, numberOfItems);
                 if (this.failOnFetch) {
                   reject(new Error('Random error'));
                 } else if (this.fetchEmptyList) {
@@ -137,8 +140,8 @@ stories
                 } else {
                   resolve({
                     items: this.data,
-                    total: this.data.length,
-                    count: this.data.length,
+                    total: 52,
+                    count: Math.min(this.data.length, numberOfItems),
                   });
                 }
               }, this.loadingDelay);
@@ -167,6 +170,7 @@ stories
             :error-message="errorMessage || undefined"
             :empty-message="emptyMessage || undefined"
             :sort-cycle="sortCycle"
+            :is-pagination-enabled="isPaginationEnabled"
             @sort="onSort"
             @abort="onAborted"
             @error="onError">
@@ -176,6 +180,8 @@ stories
             <template #empty="{ emptyMessage }">
               Empty state template - {{ emptyMessage }}
             </template>
+            <template #footer><div class="tw-text-right">Custom footer info</div></template>
+            <template #pages="{ page, totalPages, total}">{{ page }}&nbsp;of&nbsp;{{ totalPages }} pages ({{ total }}&nbsp;ipsums)</template>
           </ec-smart-table>
         </div>
       </div>

--- a/src/components/ec-table-footer/__snapshots__/ec-table-footer.spec.js.snap
+++ b/src/components/ec-table-footer/__snapshots__/ec-table-footer.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`EcTableFooter should render with footer slot 1`] = `
 <tfoot
   class="ec-table-footer"
+  data-test="ec-table-footer"
 >
   <tr>
     <td
@@ -23,6 +24,7 @@ exports[`EcTableFooter should render with footer slot 1`] = `
 exports[`EcTableFooter should render without footer slot 1`] = `
 <tfoot
   class="ec-table-footer"
+  data-test="ec-table-footer"
 >
   <tr>
     <td

--- a/src/components/ec-table-footer/ec-table-footer.vue
+++ b/src/components/ec-table-footer/ec-table-footer.vue
@@ -1,5 +1,8 @@
 <template>
-  <tfoot class="ec-table-footer">
+  <tfoot
+    class="ec-table-footer"
+    data-test="ec-table-footer"
+  >
     <tr>
       <td
         class="ec-table-footer__cell"

--- a/src/components/ec-table-pagination/__snapshots__/ec-table-pagination.spec.js.snap
+++ b/src/components/ec-table-pagination/__snapshots__/ec-table-pagination.spec.js.snap
@@ -1,0 +1,490 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EcTablePagination #slots should use given pages slot 1`] = `
+<div
+  class="ec-table-pagination__current-page"
+  data-test="ec-table-pagination__current-page"
+>
+  <div>
+    Pages slot: {"page":1,"numberOfItems":5,"totalPages":4,"total":20}
+  </div>
+</div>
+`;
+
+exports[`EcTablePagination #slots should use given total slot 1`] = `
+<div
+  class="ec-table-pagination__total"
+  data-test="ec-table-pagination__total"
+>
+  <div>
+    Total slot: {"page":1,"numberOfItems":5,"totalPages":4,"total":20}
+  </div>
+</div>
+`;
+
+exports[`EcTablePagination should display first page information by calculating total number of pages 1`] = `
+<div
+  class="ec-table-pagination__current-page"
+  data-test="ec-table-pagination__current-page"
+>
+  <span>
+    1 of 4 pages
+  </span>
+   
+  <span>
+    (20 items)
+  </span>
+</div>
+`;
+
+exports[`EcTablePagination should display last page information by calculating total number of pages 1`] = `
+<div
+  class="ec-table-pagination__current-page"
+  data-test="ec-table-pagination__current-page"
+>
+  <span>
+    4 of 4 pages
+  </span>
+   
+  <span>
+    (20 items)
+  </span>
+</div>
+`;
+
+exports[`EcTablePagination should display next and prev buttons disabled if pagination has only one page 1`] = `
+<div
+  class="ec-table-pagination__actions"
+  data-test="ec-table-pagination__actions"
+>
+  <button
+    class="ec-table-pagination__action ec-table-pagination__action--prev ec-table-pagination__action--is-disabled"
+    data-test="ec-table-pagination__action--prev"
+    disabled="disabled"
+    type="button"
+  >
+    <svg
+      class="ec-table-pagination__action-icon ec-icon"
+      height="24"
+      width="24"
+    >
+      <use
+        xlink:href="#ec-simple-chevron-left"
+      />
+    </svg>
+  </button>
+   
+  <button
+    class="ec-table-pagination__action ec-table-pagination__action--next ec-table-pagination__action--is-disabled"
+    data-test="ec-table-pagination__action--next"
+    disabled="disabled"
+    type="button"
+  >
+    <svg
+      class="ec-table-pagination__action-icon ec-icon"
+      height="24"
+      width="24"
+    >
+      <use
+        xlink:href="#ec-simple-chevron-right"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`EcTablePagination should display next and prev buttons enabled if pagination is in the middle 1`] = `
+<div
+  class="ec-table-pagination__actions"
+  data-test="ec-table-pagination__actions"
+>
+  <button
+    class="ec-table-pagination__action ec-table-pagination__action--prev"
+    data-test="ec-table-pagination__action--prev"
+    type="button"
+  >
+    <svg
+      class="ec-table-pagination__action-icon ec-icon"
+      height="24"
+      width="24"
+    >
+      <use
+        xlink:href="#ec-simple-chevron-left"
+      />
+    </svg>
+  </button>
+   
+  <button
+    class="ec-table-pagination__action ec-table-pagination__action--next"
+    data-test="ec-table-pagination__action--next"
+    type="button"
+  >
+    <svg
+      class="ec-table-pagination__action-icon ec-icon"
+      height="24"
+      width="24"
+    >
+      <use
+        xlink:href="#ec-simple-chevron-right"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`EcTablePagination should display only next button disabled if pagination is on the last page 1`] = `
+<div
+  class="ec-table-pagination__actions"
+  data-test="ec-table-pagination__actions"
+>
+  <button
+    class="ec-table-pagination__action ec-table-pagination__action--prev"
+    data-test="ec-table-pagination__action--prev"
+    type="button"
+  >
+    <svg
+      class="ec-table-pagination__action-icon ec-icon"
+      height="24"
+      width="24"
+    >
+      <use
+        xlink:href="#ec-simple-chevron-left"
+      />
+    </svg>
+  </button>
+   
+  <button
+    class="ec-table-pagination__action ec-table-pagination__action--next ec-table-pagination__action--is-disabled"
+    data-test="ec-table-pagination__action--next"
+    disabled="disabled"
+    type="button"
+  >
+    <svg
+      class="ec-table-pagination__action-icon ec-icon"
+      height="24"
+      width="24"
+    >
+      <use
+        xlink:href="#ec-simple-chevron-right"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`EcTablePagination should display only prev button disabled if pagination is on the first page 1`] = `
+<div
+  class="ec-table-pagination__actions"
+  data-test="ec-table-pagination__actions"
+>
+  <button
+    class="ec-table-pagination__action ec-table-pagination__action--prev ec-table-pagination__action--is-disabled"
+    data-test="ec-table-pagination__action--prev"
+    disabled="disabled"
+    type="button"
+  >
+    <svg
+      class="ec-table-pagination__action-icon ec-icon"
+      height="24"
+      width="24"
+    >
+      <use
+        xlink:href="#ec-simple-chevron-left"
+      />
+    </svg>
+  </button>
+   
+  <button
+    class="ec-table-pagination__action ec-table-pagination__action--next"
+    data-test="ec-table-pagination__action--next"
+    type="button"
+  >
+    <svg
+      class="ec-table-pagination__action-icon ec-icon"
+      height="24"
+      width="24"
+    >
+      <use
+        xlink:href="#ec-simple-chevron-right"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
+exports[`EcTablePagination should display page information by calculating total number of pages 1`] = `
+<div
+  class="ec-table-pagination__current-page"
+  data-test="ec-table-pagination__current-page"
+>
+  <span>
+    2 of 4 pages
+  </span>
+   
+  <span>
+    (20 items)
+  </span>
+</div>
+`;
+
+exports[`EcTablePagination should display page information even if the total is 0 1`] = `
+<div
+  class="ec-table-pagination__current-page"
+  data-test="ec-table-pagination__current-page"
+>
+  <span>
+    1 of 1 pages
+  </span>
+   
+  <span>
+    (0 items)
+  </span>
+</div>
+`;
+
+exports[`EcTablePagination should display page information when last page is incomplete 1`] = `
+<div
+  class="ec-table-pagination__current-page"
+  data-test="ec-table-pagination__current-page"
+>
+  <span>
+    6 of 6 pages
+  </span>
+   
+  <span>
+    (29 items)
+  </span>
+</div>
+`;
+
+exports[`EcTablePagination should display the page size dropdown with preselected value 1`] = `
+<div
+  class="ec-table-pagination__page-size"
+  data-test="ec-table-pagination__page-size"
+>
+  <div
+    class="ec-table-pagination__page-size-text"
+  >
+    Items per page:
+  </div>
+   
+  <div
+    class="ec-dropdown-search"
+    data-test="ec-dropdown-search"
+  >
+    <ecpopover-stub
+      class="ec-dropdown-search__trigger"
+      data-test="ec-popover-dropdown-search"
+      offset="8"
+      placement="bottom"
+      popoverinnerclass="ec-dropdown-search__popover"
+      popperoptions="[object Object]"
+    >
+      <button
+        class="ec-table-pagination__action ec-table-pagination__action--page-size"
+        data-test="ec-table-pagination__action--page-size"
+      >
+        
+        50
+        
+        <svg
+          class="ec-table-pagination__action-icon ec-icon"
+          height="24"
+          width="24"
+        >
+          <use
+            xlink:href="#ec-simple-chevron-down"
+          />
+        </svg>
+      </button>
+       
+      <div>
+        <ul
+          class="ec-dropdown-search__item-list"
+          data-test="ec-dropdown-search__item-list"
+        >
+          <!---->
+           
+          <!---->
+           
+          <li
+            class="ec-dropdown-search__item"
+            data-test="ec-dropdown-search__item ec-dropdown-search__item--0"
+            title="5"
+          >
+            5
+          </li>
+          <li
+            class="ec-dropdown-search__item"
+            data-test="ec-dropdown-search__item ec-dropdown-search__item--1"
+            title="10"
+          >
+            10
+          </li>
+          <li
+            class="ec-dropdown-search__item ec-dropdown-search__item--is-selected"
+            data-test="ec-dropdown-search__item ec-dropdown-search__item--2"
+            title="50"
+          >
+            50
+          </li>
+          <li
+            class="ec-dropdown-search__item"
+            data-test="ec-dropdown-search__item ec-dropdown-search__item--3"
+            title="100"
+          >
+            100
+          </li>
+        </ul>
+      </div>
+    </ecpopover-stub>
+  </div>
+</div>
+`;
+
+exports[`EcTablePagination should render as expected 1`] = `
+<div
+  class="ec-table-pagination"
+  data-test="ec-table-pagination"
+>
+  <div
+    class="ec-table-pagination__page-size"
+    data-test="ec-table-pagination__page-size"
+  >
+    <div
+      class="ec-table-pagination__page-size-text"
+    >
+      Items per page:
+    </div>
+     
+    <div
+      class="ec-dropdown-search"
+      data-test="ec-dropdown-search"
+    >
+      <ecpopover-stub
+        class="ec-dropdown-search__trigger"
+        data-test="ec-popover-dropdown-search"
+        offset="8"
+        placement="bottom"
+        popoverinnerclass="ec-dropdown-search__popover"
+        popperoptions="[object Object]"
+      >
+        <button
+          class="ec-table-pagination__action ec-table-pagination__action--page-size"
+          data-test="ec-table-pagination__action--page-size"
+        >
+          
+        10
+        
+          <svg
+            class="ec-table-pagination__action-icon ec-icon"
+            height="24"
+            width="24"
+          >
+            <use
+              xlink:href="#ec-simple-chevron-down"
+            />
+          </svg>
+        </button>
+         
+        <div>
+          <ul
+            class="ec-dropdown-search__item-list"
+            data-test="ec-dropdown-search__item-list"
+          >
+            <!---->
+             
+            <!---->
+             
+            <li
+              class="ec-dropdown-search__item"
+              data-test="ec-dropdown-search__item ec-dropdown-search__item--0"
+              title="5"
+            >
+              5
+            </li>
+            <li
+              class="ec-dropdown-search__item ec-dropdown-search__item--is-selected"
+              data-test="ec-dropdown-search__item ec-dropdown-search__item--1"
+              title="10"
+            >
+              10
+            </li>
+            <li
+              class="ec-dropdown-search__item"
+              data-test="ec-dropdown-search__item ec-dropdown-search__item--2"
+              title="50"
+            >
+              50
+            </li>
+            <li
+              class="ec-dropdown-search__item"
+              data-test="ec-dropdown-search__item ec-dropdown-search__item--3"
+              title="100"
+            >
+              100
+            </li>
+          </ul>
+        </div>
+      </ecpopover-stub>
+    </div>
+  </div>
+   
+  <div
+    class="ec-table-pagination__current-page"
+    data-test="ec-table-pagination__current-page"
+  >
+    <span>
+      1 of 1 pages
+    </span>
+     
+    <span>
+      (0 items)
+    </span>
+  </div>
+   
+  <div
+    class="ec-table-pagination__total"
+    data-test="ec-table-pagination__total"
+  />
+   
+  <div
+    class="ec-table-pagination__actions"
+    data-test="ec-table-pagination__actions"
+  >
+    <button
+      class="ec-table-pagination__action ec-table-pagination__action--prev ec-table-pagination__action--is-disabled"
+      data-test="ec-table-pagination__action--prev"
+      disabled="disabled"
+      type="button"
+    >
+      <svg
+        class="ec-table-pagination__action-icon ec-icon"
+        height="24"
+        width="24"
+      >
+        <use
+          xlink:href="#ec-simple-chevron-left"
+        />
+      </svg>
+    </button>
+     
+    <button
+      class="ec-table-pagination__action ec-table-pagination__action--next ec-table-pagination__action--is-disabled"
+      data-test="ec-table-pagination__action--next"
+      disabled="disabled"
+      type="button"
+    >
+      <svg
+        class="ec-table-pagination__action-icon ec-icon"
+        height="24"
+        width="24"
+      >
+        <use
+          xlink:href="#ec-simple-chevron-right"
+        />
+      </svg>
+    </button>
+  </div>
+</div>
+`;

--- a/src/components/ec-table-pagination/ec-table-pagination.spec.js
+++ b/src/components/ec-table-pagination/ec-table-pagination.spec.js
@@ -1,0 +1,130 @@
+import { mount } from '@vue/test-utils';
+import EcTablePagination from './ec-table-pagination.vue';
+import { withMockedConsole } from '../../../tests/utils/console';
+
+describe('EcTablePagination', () => {
+  function mountEcTablePagination(props, mountOpts) {
+    return mount(EcTablePagination, {
+      propsData: { ...props },
+      stubs: { EcPopover: true },
+      ...mountOpts,
+    });
+  }
+
+  it('should render as expected', () => {
+    const wrapper = mountEcTablePagination();
+    expect(wrapper.element).toMatchSnapshot();
+  });
+
+  it('should throw if the prop numberOfItems has a invalid value', () => {
+    withMockedConsole((errorSpy) => {
+      mountEcTablePagination({ numberOfItems: 7 });
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      expect(errorSpy.mock.calls[0][0]).toContain('Invalid prop: custom validator check failed for prop "numberOfItems"');
+    });
+  });
+
+  it('should display page information by calculating total number of pages', () => {
+    const wrapper = mountEcTablePagination({ total: 20, numberOfItems: 5, page: 2 });
+    expect(wrapper.findByDataTest('ec-table-pagination__current-page').element).toMatchSnapshot();
+  });
+
+  it('should display last page information by calculating total number of pages', () => {
+    const wrapper = mountEcTablePagination({ total: 20, numberOfItems: 5, page: 4 });
+    expect(wrapper.findByDataTest('ec-table-pagination__current-page').element).toMatchSnapshot();
+  });
+
+  it('should display first page information by calculating total number of pages', () => {
+    const wrapper = mountEcTablePagination({ total: 20, numberOfItems: 5, page: 1 });
+    expect(wrapper.findByDataTest('ec-table-pagination__current-page').element).toMatchSnapshot();
+  });
+
+  it('should display page information even if the total is 0', () => {
+    const wrapper = mountEcTablePagination({ total: 0 });
+    expect(wrapper.findByDataTest('ec-table-pagination__current-page').element).toMatchSnapshot();
+  });
+
+  it('should display page information when last page is incomplete', () => {
+    const wrapper = mountEcTablePagination({ total: 29, numberOfItems: 5, page: 6 });
+    expect(wrapper.findByDataTest('ec-table-pagination__current-page').element).toMatchSnapshot();
+  });
+
+  it('should display the page size dropdown with preselected value', () => {
+    const wrapper = mountEcTablePagination({ numberOfItems: 50 });
+    expect(wrapper.findByDataTest('ec-table-pagination__page-size').element).toMatchSnapshot();
+  });
+
+  it('should display next and prev buttons disabled if pagination has only one page', () => {
+    const wrapper = mountEcTablePagination({ numberOfItems: 50, total: 50, page: 1 });
+    expect(wrapper.findByDataTest('ec-table-pagination__actions').element).toMatchSnapshot();
+  });
+
+  it('should display only next button disabled if pagination is on the last page', () => {
+    const wrapper = mountEcTablePagination({ numberOfItems: 10, total: 50, page: 5 });
+    expect(wrapper.findByDataTest('ec-table-pagination__actions').element).toMatchSnapshot();
+  });
+
+  it('should display only prev button disabled if pagination is on the first page', () => {
+    const wrapper = mountEcTablePagination({ numberOfItems: 10, total: 50, page: 1 });
+    expect(wrapper.findByDataTest('ec-table-pagination__actions').element).toMatchSnapshot();
+  });
+
+  it('should display next and prev buttons enabled if pagination is in the middle', () => {
+    const wrapper = mountEcTablePagination({ numberOfItems: 10, total: 50, page: 3 });
+    expect(wrapper.findByDataTest('ec-table-pagination__actions').element).toMatchSnapshot();
+  });
+
+  describe('#slots', () => {
+    it('should use given pages slot', () => {
+      const wrapper = mountEcTablePagination({ total: 20, numberOfItems: 5, page: 1 }, {
+        scopedSlots: {
+          pages(slotProps) {
+            return (<div>Pages slot: {JSON.stringify(slotProps)}</div>);
+          },
+        },
+      });
+
+      expect(wrapper.findByDataTest('ec-table-pagination__current-page').element).toMatchSnapshot();
+    });
+
+    it('should use given total slot', () => {
+      const wrapper = mountEcTablePagination({ total: 20, numberOfItems: 5, page: 1 }, {
+        scopedSlots: {
+          total(slotProps) {
+            return (<div>Total slot: {JSON.stringify(slotProps)}</div>);
+          },
+        },
+      });
+
+      expect(wrapper.findByDataTest('ec-table-pagination__total').element).toMatchSnapshot();
+    });
+  });
+
+  describe('@events', () => {
+    it('should change the selected page size', async () => {
+      const wrapper = mountEcTablePagination({ numberOfItems: 10 });
+      await wrapper.findByDataTest('ec-table-pagination__action--page-size').trigger('click');
+      await wrapper.findByDataTest('ec-dropdown-search__item--2').trigger('click');
+      expect(wrapper.emitted('change')).toStrictEqual([[1, 50]]);
+    });
+
+    it('should change the selected page size and reset current page when pagination is not showing the first page', async () => {
+      const wrapper = mountEcTablePagination({ total: 100, page: 2, numberOfItems: 10 });
+      await wrapper.findByDataTest('ec-table-pagination__action--page-size').trigger('click');
+      await wrapper.findByDataTest('ec-dropdown-search__item--2').trigger('click');
+      expect(wrapper.emitted('change')).toStrictEqual([[1, 50]]);
+    });
+
+    it('should change the current page when prev button is clicked', async () => {
+      const wrapper = mountEcTablePagination({ numberOfItems: 10, total: 50, page: 3 });
+      await wrapper.findByDataTest('ec-table-pagination__action--prev').trigger('click');
+      expect(wrapper.emitted('change')).toStrictEqual([[2, 10]]);
+    });
+
+    it('should change the current page when next button is clicked', async () => {
+      const wrapper = mountEcTablePagination({ numberOfItems: 10, total: 50, page: 3 });
+      await wrapper.findByDataTest('ec-table-pagination__action--next').trigger('click');
+      expect(wrapper.emitted('change')).toStrictEqual([[4, 10]]);
+    });
+  });
+});

--- a/src/components/ec-table-pagination/ec-table-pagination.vue
+++ b/src/components/ec-table-pagination/ec-table-pagination.vue
@@ -152,7 +152,7 @@ export default {
   @apply tw-flex;
   @apply tw--mx-16;
 
-  width: calc(100% + 32px);
+  width: calc(100% + theme('spacing.32'));
 
   &__page-size,
   &__current-page,
@@ -187,6 +187,7 @@ export default {
     @apply tw-outline-none;
     @apply tw-cursor-pointer;
     @apply tw-border-l tw-border-solid tw-border-gray-6;
+    @apply tw-whitespace-no-wrap;
 
     &:hover,
     &:focus {

--- a/src/components/ec-table-pagination/ec-table-pagination.vue
+++ b/src/components/ec-table-pagination/ec-table-pagination.vue
@@ -21,7 +21,7 @@
           class="ec-table-pagination__action ec-table-pagination__action--page-size"
           data-test="ec-table-pagination__action--page-size"
         >
-          {{ seletedPageSizeText }}
+          {{ selectedPageSizeText }}
           <ec-icon
             class="ec-table-pagination__action-icon"
             name="simple-chevron-down"
@@ -140,7 +140,7 @@ export default {
         this.$emit('change', 1, pageSizeItem.value);
       },
     },
-    seletedPageSizeText() {
+    selectedPageSizeText() {
       return this.pageSizeModel?.text;
     },
   },

--- a/src/components/ec-table-pagination/ec-table-pagination.vue
+++ b/src/components/ec-table-pagination/ec-table-pagination.vue
@@ -1,0 +1,223 @@
+<template>
+  <div
+    class="ec-table-pagination"
+    v-bind="{
+      ...$attrs,
+      'data-test': $attrs['data-test'] ? `${$attrs['data-test']} ec-table-pagination` : 'ec-table-pagination'
+    }"
+  >
+
+    <div
+      class="ec-table-pagination__page-size"
+      data-test="ec-table-pagination__page-size"
+    >
+      <div class="ec-table-pagination__page-size-text">{{ itemsPerPageText }}:</div>
+      <ec-dropdown-search
+        v-model="pageSizeModel"
+        :items="pageSizeItems"
+        :is-search-enabled="false"
+      >
+        <button
+          class="ec-table-pagination__action ec-table-pagination__action--page-size"
+          data-test="ec-table-pagination__action--page-size"
+        >
+          {{ seletedPageSizeText }}
+          <ec-icon
+            class="ec-table-pagination__action-icon"
+            name="simple-chevron-down"
+            :size="24"
+          />
+        </button>
+      </ec-dropdown-search>
+    </div>
+
+    <div
+      class="ec-table-pagination__current-page"
+      data-test="ec-table-pagination__current-page"
+    >
+      <slot
+        name="pages"
+        v-bind="{ page, numberOfItems, totalPages, total }"
+      >
+        <span>{{ page }}&nbsp;of&nbsp;{{ totalPages }} pages</span>
+        <span>({{ total }}&nbsp;items)</span>
+      </slot>
+    </div>
+
+    <div
+      class="ec-table-pagination__total"
+      data-test="ec-table-pagination__total"
+    >
+      <slot
+        name="total"
+        v-bind="{ page, numberOfItems, totalPages, total }"
+      />
+    </div>
+
+    <div
+      class="ec-table-pagination__actions"
+      data-test="ec-table-pagination__actions"
+    >
+      <button
+        type="button"
+        class="ec-table-pagination__action ec-table-pagination__action--prev"
+        data-test="ec-table-pagination__action--prev"
+        :class="{ 'ec-table-pagination__action--is-disabled': !hasPrev }"
+        :disabled="!hasPrev"
+        @click.prevent.stop="$emit('change', page - 1, numberOfItems)"
+      ><ec-icon
+        class="ec-table-pagination__action-icon"
+        name="simple-chevron-left"
+        :size="24"
+      /></button>
+      <button
+        type="button"
+        class="ec-table-pagination__action ec-table-pagination__action--next"
+        data-test="ec-table-pagination__action--next"
+        :class="{ 'ec-table-pagination__action--is-disabled': !hasNext }"
+        :disabled="!hasNext"
+        @click.prevent.stop="$emit('change', page + 1, numberOfItems)"
+      ><ec-icon
+        class="ec-table-pagination__action-icon"
+        name="simple-chevron-right"
+        :size="24"
+      /></button>
+    </div>
+  </div>
+</template>
+
+<script>
+import EcIcon from '../ec-icon';
+import EcDropdownSearch from '../ec-dropdown-search';
+import { DEFAULT_PAGE_SIZE, PAGE_SIZES } from '../../enums/pagination';
+
+export default {
+  name: 'EcTablePagination',
+  components: { EcIcon, EcDropdownSearch },
+  inheritAttrs: false,
+  props: {
+    page: {
+      type: Number,
+      default: 1,
+    },
+    numberOfItems: {
+      type: Number,
+      default: DEFAULT_PAGE_SIZE,
+      validator(value) {
+        return PAGE_SIZES.includes(value);
+      },
+    },
+    total: {
+      type: Number,
+      default: 0,
+    },
+    itemsPerPageText: {
+      type: String,
+      default: 'Items per page',
+    },
+  },
+  computed: {
+    hasPrev() {
+      return this.page > 1;
+    },
+    hasNext() {
+      return this.page < this.totalPages;
+    },
+    totalPages() {
+      if (this.total === 0) {
+        return 1;
+      }
+      return Math.ceil(this.total / this.numberOfItems);
+    },
+    pageSizeItems() {
+      return PAGE_SIZES.map(pageSize => ({ text: pageSize, value: pageSize }));
+    },
+    pageSizeModel: {
+      get() {
+        return this.pageSizeItems.find(item => item.value === this.numberOfItems);
+      },
+      set(pageSizeItem) {
+        this.$emit('change', 1, pageSizeItem.value);
+      },
+    },
+    seletedPageSizeText() {
+      return this.pageSizeModel?.text;
+    },
+  },
+};
+</script>
+
+<style>
+.ec-table-pagination {
+  @apply tw-flex;
+  @apply tw--mx-16;
+
+  width: calc(100% + 32px);
+
+  &__page-size,
+  &__current-page,
+  &__total {
+    @apply tw-py-8 tw-px-16;
+  }
+
+  &__page-size {
+    @apply tw-py-0;
+    @apply tw-border-r tw-border-solid tw-border-gray-6;
+    @apply tw-flex;
+  }
+
+  &__page-size-text {
+    @apply tw-whitespace-no-wrap;
+    @apply tw-py-8;
+  }
+
+  &__total {
+    @apply tw-flex-grow;
+  }
+
+  &__actions {
+    @apply tw-flex;
+  }
+
+  &__action {
+    @apply tw-flex-shrink-0;
+    @apply tw-border-0;
+    @apply tw-p-8;
+    @apply tw-bg-transparent tw-text-gray-3 tw-fill-gray-4;
+    @apply tw-outline-none;
+    @apply tw-cursor-pointer;
+    @apply tw-border-l tw-border-solid tw-border-gray-6;
+
+    &:hover,
+    &:focus {
+      @apply tw-bg-gray-6;
+    }
+
+    &--next {
+      @apply tw-rounded-br;
+    }
+
+    &--page-size {
+      @apply tw-body-text;
+      @apply tw-border-l-0;
+      @apply tw-ml-8;
+    }
+
+    &--is-disabled {
+      @apply tw-cursor-default;
+      @apply tw-fill-gray-6;
+
+      &:hover,
+      &:focus {
+        @apply tw-bg-transparent;
+      }
+    }
+  }
+
+  &__action-icon {
+    @apply tw-inline-block tw-align-top;
+
+    line-height: 0;
+  }
+}
+</style>

--- a/src/components/ec-table-pagination/index.js
+++ b/src/components/ec-table-pagination/index.js
@@ -1,0 +1,1 @@
+export { default } from './ec-table-pagination.vue';

--- a/src/components/ec-table/__snapshots__/ec-table.spec.js.snap
+++ b/src/components/ec-table/__snapshots__/ec-table.spec.js.snap
@@ -418,6 +418,7 @@ exports[`EcTable should render as expected if provided with data and columns, wi
        
       <tfoot
         class="ec-table-footer"
+        data-test="ec-table-footer"
       >
         <tr>
           <td
@@ -547,6 +548,7 @@ exports[`EcTable should render as expected if provided with data but no columns,
        
       <tfoot
         class="ec-table-footer"
+        data-test="ec-table-footer"
       >
         <tr>
           <td
@@ -590,6 +592,7 @@ exports[`EcTable should render as expected if provided with empty row and no col
        
       <tfoot
         class="ec-table-footer"
+        data-test="ec-table-footer"
       >
         <tr>
           <td
@@ -715,6 +718,7 @@ exports[`EcTable should render as expected if provided with rows and columns, wi
        
       <tfoot
         class="ec-table-footer"
+        data-test="ec-table-footer"
       >
         <tr>
           <td
@@ -840,6 +844,7 @@ exports[`EcTable should render slots as expected 1`] = `
        
       <tfoot
         class="ec-table-footer"
+        data-test="ec-table-footer"
       >
         <tr>
           <td

--- a/src/enums/pagination.js
+++ b/src/enums/pagination.js
@@ -1,0 +1,2 @@
+export const PAGE_SIZES = [5, 10, 50, 100];
+export const DEFAULT_PAGE_SIZE = 10;

--- a/src/hocs/ec-with-pagination/__snapshots__/ec-with-pagination.spec.js.snap
+++ b/src/hocs/ec-with-pagination/__snapshots__/ec-with-pagination.spec.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EcWithPagination should ignore null values when pagination event updates the number of items 1`] = `
+<div>
+  Page: 1, # items: 42
+</div>
+`;
+
+exports[`EcWithPagination should ignore null values when pagination event updates the page 1`] = `
+<div>
+  Page: 42, # items: 10
+</div>
+`;
+
+exports[`EcWithPagination should render properly 1`] = `
+<div>
+  Page: 1, # items: 10
+</div>
+`;
+
+exports[`EcWithPagination should update the pagination whe pagination event is emitted 1`] = `
+<div>
+  Page: 5, # items: 20
+</div>
+`;

--- a/src/hocs/ec-with-pagination/__snapshots__/ec-with-pagination.spec.js.snap
+++ b/src/hocs/ec-with-pagination/__snapshots__/ec-with-pagination.spec.js.snap
@@ -18,7 +18,7 @@ exports[`EcWithPagination should render properly 1`] = `
 </div>
 `;
 
-exports[`EcWithPagination should update the pagination whe pagination event is emitted 1`] = `
+exports[`EcWithPagination should update the pagination when pagination event is emitted 1`] = `
 <div>
   Page: 5, # items: 20
 </div>

--- a/src/hocs/ec-with-pagination/ec-with-pagination.js
+++ b/src/hocs/ec-with-pagination/ec-with-pagination.js
@@ -1,0 +1,31 @@
+import { createHOCc } from 'vue-hoc';
+
+import { DEFAULT_PAGE_SIZE } from '../../enums/pagination';
+
+const withPagination = createHOCc({
+  name: 'EcWithPagination',
+  data() {
+    return {
+      internalPagination: {
+        page: 1,
+        numberOfItems: DEFAULT_PAGE_SIZE,
+      },
+    };
+  },
+}, {
+  props(props) {
+    return {
+      ...props,
+      page: this.internalPagination.page,
+      numberOfItems: this.internalPagination.numberOfItems,
+    };
+  },
+  listeners: {
+    pagination(page, numberOfItems) {
+      this.internalPagination.page = page ?? this.internalPagination.page;
+      this.internalPagination.numberOfItems = numberOfItems ?? this.internalPagination.numberOfItems;
+    },
+  },
+});
+
+export default withPagination;

--- a/src/hocs/ec-with-pagination/ec-with-pagination.spec.js
+++ b/src/hocs/ec-with-pagination/ec-with-pagination.spec.js
@@ -28,7 +28,7 @@ describe('EcWithPagination', () => {
     expect(hocWrapper.element).toMatchSnapshot();
   });
 
-  it('should update the pagination whe pagination event is emitted', async () => {
+  it('should update the pagination when pagination event is emitted', async () => {
     const { hocWrapper, componentWrapper } = mountEcWithPagination();
 
     await componentWrapper.vm.$emit('pagination', 5, 20);

--- a/src/hocs/ec-with-pagination/ec-with-pagination.spec.js
+++ b/src/hocs/ec-with-pagination/ec-with-pagination.spec.js
@@ -1,0 +1,51 @@
+import { mount, createLocalVue, createWrapper } from '@vue/test-utils';
+import withPagination from './ec-with-pagination';
+
+describe('EcWithPagination', () => {
+  function mountEcWithPagination(props, mountOpts) {
+    const localVue = createLocalVue();
+
+    const Component = localVue.extend({
+      props: ['page', 'numberOfItems'],
+      render(h) {
+        return h('div', {}, `Page: ${this.page}, # items: ${this.numberOfItems}`);
+      },
+    });
+
+    const hocWrapper = mount(withPagination(Component), {
+      localVue,
+      propsData: { ...props },
+      ...mountOpts,
+    });
+
+    const componentWrapper = createWrapper(hocWrapper.vm.$children[0].$vnode);
+
+    return { hocWrapper, componentWrapper };
+  }
+
+  it('should render properly', () => {
+    const { hocWrapper } = mountEcWithPagination();
+    expect(hocWrapper.element).toMatchSnapshot();
+  });
+
+  it('should update the pagination whe pagination event is emitted', async () => {
+    const { hocWrapper, componentWrapper } = mountEcWithPagination();
+
+    await componentWrapper.vm.$emit('pagination', 5, 20);
+    expect(hocWrapper.element).toMatchSnapshot();
+  });
+
+  it('should ignore null values when pagination event updates the page', async () => {
+    const { hocWrapper, componentWrapper } = mountEcWithPagination();
+
+    await componentWrapper.vm.$emit('pagination', 42, null);
+    expect(hocWrapper.element).toMatchSnapshot();
+  });
+
+  it('should ignore null values when pagination event updates the number of items', async () => {
+    const { hocWrapper, componentWrapper } = mountEcWithPagination();
+
+    await componentWrapper.vm.$emit('pagination', null, 42);
+    expect(hocWrapper.element).toMatchSnapshot();
+  });
+});

--- a/src/hocs/ec-with-pagination/index.js
+++ b/src/hocs/ec-with-pagination/index.js
@@ -1,0 +1,1 @@
+export { default } from './ec-with-pagination';

--- a/src/hocs/ec-with-sorting/ec-with-sorting.js
+++ b/src/hocs/ec-with-sorting/ec-with-sorting.js
@@ -29,7 +29,7 @@ const withSorting = createHOCc({
   },
   methods: {
     sortBy(columnName, sortCycle = this.sortCycle) {
-      let sorts = this.internalSorts;
+      let sorts = [...this.internalSorts];
 
       const existingSort = sorts.find(sort => sort.column === columnName);
       if (existingSort) {
@@ -44,6 +44,7 @@ const withSorting = createHOCc({
       }
 
       this.internalSorts = sorts;
+      this.$emit('sort', sorts);
     },
     nextDirection(current, sortCycle) {
       const nextDirectionIndex = sortCycle.indexOf(current) + 1;
@@ -70,7 +71,6 @@ const withSorting = createHOCc({
     sort(column) {
       const { name: columnName, sortCycle } = column;
       this.sortBy(columnName, sortCycle);
-      this.$emit('sort', this.internalSorts);
     },
   },
 });

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,11 @@
 import * as SortDirection from './enums/sort-direction';
-import config from './config';
+import * as SortDirectionCycle from './enums/sort-direction-cycle';
+
+export { SortDirection, SortDirectionCycle };
+
+export { DEFAULT_PAGE_SIZE, PAGE_SIZES } from './enums/pagination';
+
+export { default as config } from './config';
 
 export { default as EcAlert } from './components/ec-alert';
 export { default as EcAmount } from './directives/ec-amount';
@@ -36,7 +42,5 @@ export { default as EcUserInfo } from './components/ec-user-info';
 
 export { default as ecWithAbortableFetch } from './hocs/ec-with-abortable-fetch';
 export { default as ecWithLoading } from './hocs/ec-with-loading';
+export { default as ecWithPagination } from './hocs/ec-with-pagination';
 export { default as ecWithSorting } from './hocs/ec-with-sorting';
-
-export { SortDirection };
-export { config };

--- a/src/styles/components/v-tooltip.css
+++ b/src/styles/components/v-tooltip.css
@@ -157,4 +157,8 @@
     @apply tw-opacity-100;
     @apply tw-duration-150 tw-transition-opacity;
   }
+
+  &:focus {
+    @apply tw-outline-none;
+  }
 }


### PR DESCRIPTION
EcSmartTable has a new prop: `isPaginationEnabled`, set to false by default. Currently balances table in EBO doesn't need pagination so I made it optional. 

I didn't create a story for ec-table-pagination because it doesn't make sense to reuse this component anywhere else outside of the table (just like we don't have ec-table-head, ec-table-footer, etc.)

The biggest development issue is that we would have to provide a translations for current page string for every table we use in EBO. The text says `1 of 10 pages (67 payments)`. So every table will require its own translation. The default value is:
```
      <slot
        name="pages"
        v-bind="{ page, numberOfItems, totalPages, total }"
      >
        <span>{{ page }}&nbsp;of&nbsp;{{ totalPages }} pages</span>
        <span>({{ total }}&nbsp;items)</span>
      </slot>
```
^^ `&nbsp;` are there because I don't want the breaking spaces between `1 of 6` and `XX items`. I really don't want to break this into 3 slots and having these slots wrapped in `tw-whitespace-nowrap`. And I don't want to have 3 props for 3 texts either.