### PR TITLE
ONL-4901: fix: Fixed ec-smart-table can cause infinite loop if data of the parent component have been modified in the fetch phase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/components/ec-smart-table/__snapshots__/ec-smart-table.spec.js.snap
+++ b/src/components/ec-smart-table/__snapshots__/ec-smart-table.spec.js.snap
@@ -1056,21 +1056,7 @@ exports[`EcSmartTable should render resolved data properly 1`] = `
   class="ec-loading"
   data-test="ec-loading"
 >
-  <div
-    class="ec-loading__backdrop ec-loading__backdrop--is-transparent"
-    data-test="ec-loading__backdrop"
-  >
-    <svg
-      class="ec-loading__icon ec-icon"
-      data-test="ec-loading__icon"
-      height="48"
-      width="48"
-    >
-      <use
-        xlink:href="#ec-simple-loading"
-      />
-    </svg>
-  </div>
+  <!---->
    
   <div
     class="ec-loading__content ec-loading__content--is-transparent"

--- a/src/components/ec-smart-table/ec-smart-table.spec.js
+++ b/src/components/ec-smart-table/ec-smart-table.spec.js
@@ -214,7 +214,7 @@ describe('EcSmartTable', () => {
 
     it('should re-fetch the data when next page is selected', async () => {
       const wrapper = await mountEcSmartTableWithResolvedData(lotsOfData, { columns, isPaginationEnabled: true });
-      wrapper.findByDataTest('ec-table-pagination__action--next').trigger('click');
+      await wrapper.findByDataTest('ec-table-pagination__action--next').trigger('click');
       expect(wrapper.findByDataTest('ec-loading__icon').element).toMatchSnapshot('loading icon while loading new page');
       await flushPromises();
       expect(wrapper.findByDataTest('ec-loading__icon').element).toMatchSnapshot('loading icon after loading new page');

--- a/src/components/ec-smart-table/ec-smart-table.vue
+++ b/src/components/ec-smart-table/ec-smart-table.vue
@@ -92,15 +92,20 @@ const withEcSmartTableRenderer = (Component) => {
 const withEcSmartTableContainer = createHOCc({
   name: 'EcSmartTable',
   props: ['sorts', 'page', 'numberOfItems'],
+  computed: {
+    dataSourceFetchArgs() {
+      return {
+        sorts: this.sorts,
+        page: this.page,
+        numberOfItems: this.numberOfItems,
+      };
+    },
+  },
 }, {
   props(props) {
     return {
       ...props,
-      fetchArgs: {
-        sorts: this.sorts,
-        page: this.page,
-        numberOfItems: this.numberOfItems,
-      },
+      fetchArgs: this.dataSourceFetchArgs,
     };
   },
 });


### PR DESCRIPTION
Problem we discovered in ONL-4901 PR in EBO. ec-smart-table can cause an infinite loop when we touch the data object of its parent while doing the fetching.

```
dataSource: {
        fetch: async ({ page, numberOfItems }, cancelToken) => {
          const response = await getFees(page, numberOfItems, cancelToken);
          const { summary } = response;
          const { totalAmount, currency } = summary;
          this.footerData = { currency, totalAmount: totalAmount }; // this line forces the fees view to re-rendered and the chain of events will cause an infinite loop
      })
}
```

The component uses the ec-smart-table this way:
```
  <ec-smart-table>
    <template #footer>
      <ebo-fees-and-charges-table-footer
        :currency="footerData.currency"
        :amount="footerData.totalAmount"
      />
    </template>
  </ec-smart-table>
```

If you assign anything to footerData, footer slot must be re-rendered, ec-smart-table should be re-rendered too. Unfortunately, smart-table passes the fetchArgs down to ecWithAbortableFetch always as a new object:
```
props(props) {
  return {
    ...props,
      fetchArgs: {
        sorts: this.sorts,	
        page: this.page,	
        numberOfItems: this.numberOfItems,	
      },	
    };
  },
```
A new object means the props is always changed and ecWithAbortableFetch will re-fetch the data by calling dataSource.fetch() again. Fetch will get the data again, re-assign footerData again, that will re-rendered ec-smart-table, ec-smart-table will pass new fetchArgs to the ecWithAbortableFetch, abortableFetch will call dataSource.fetch() again and so on ...

The solution is to stop creating new object when passing props to fetchArgs. If the object is cached as computed prop, it will be invalidated and recreated only if sorts, page and numberOfItems props change.
