### PR TITLE
 [ONL-5378] EcWithAbortableFetch: fetchError in the state is not reset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/hocs/ec-with-abortable-fetch/__snapshots__/ec-with-abortable-fetch.spec.js.snap
+++ b/src/hocs/ec-with-abortable-fetch/__snapshots__/ec-with-abortable-fetch.spec.js.snap
@@ -34,6 +34,76 @@ Object {
 }
 `;
 
+exports[`EcWithAbortableFetch should not propagate the error when re-fetching after an error occurred 1`] = `
+Object {
+  "data": null,
+  "error": [Error: Random error],
+  "loading": false,
+}
+`;
+
+exports[`EcWithAbortableFetch should not propagate the error when re-fetching after an error occurred 2`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      undefined,
+      AbortSignal {},
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`EcWithAbortableFetch should not propagate the error when re-fetching after an error occurred 3`] = `
+Array [
+  Array [
+    [Error: Random error],
+  ],
+]
+`;
+
+exports[`EcWithAbortableFetch should not propagate the error when re-fetching after an error occurred 4`] = `
+Object {
+  "data": null,
+  "error": null,
+  "loading": true,
+}
+`;
+
+exports[`EcWithAbortableFetch should not propagate the error when re-fetching after an error occurred 5`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Object {
+        "anotherProp": 2,
+      },
+      AbortSignal {},
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": Promise {},
+    },
+  ],
+}
+`;
+
+exports[`EcWithAbortableFetch should not propagate the error when re-fetching after an error occurred 6`] = `
+Object {
+  "data": Object {
+    "result": 1,
+  },
+  "error": null,
+  "loading": false,
+}
+`;
+
 exports[`EcWithAbortableFetch should re-fetch the data if arguments change 1`] = `
 Object {
   "data": null,

--- a/src/hocs/ec-with-abortable-fetch/ec-with-abortable-fetch.js
+++ b/src/hocs/ec-with-abortable-fetch/ec-with-abortable-fetch.js
@@ -42,6 +42,7 @@ const withAbortableFetch = createHOCc({
     async fetch(fetchArgs) {
       this.abort();
       this.isFetching = true;
+      this.fetchError = null;
 
       this.fetchAbortController = new global.AbortController();
       try {

--- a/src/hocs/ec-with-abortable-fetch/ec-with-abortable-fetch.spec.js
+++ b/src/hocs/ec-with-abortable-fetch/ec-with-abortable-fetch.spec.js
@@ -89,6 +89,42 @@ describe('EcWithAbortableFetch', () => {
     expect(errorSpy.mock.calls).toMatchSnapshot();
   });
 
+  it('should not propagate the error when re-fetching after an error occurred', async () => {
+    const error = new Error('Random error');
+    const dataSource = {
+      fetch: jest.fn().mockRejectedValueOnce(error).mockResolvedValueOnce({ result: 1 }),
+    };
+
+    const errorSpy = jest.fn();
+
+    const { componentWrapper, hocWrapper } = mountEcWithAbortableFetch({ dataSource }, {
+      listeners: {
+        error: errorSpy,
+      },
+    });
+    await flushPromises();
+    expect(getWrappedComponentState(componentWrapper).error).toBe(error);
+    expect(getWrappedComponentState(componentWrapper)).toMatchSnapshot();
+    expect(dataSource.fetch).toMatchSnapshot();
+    expect(errorSpy.mock.calls).toMatchSnapshot();
+
+    dataSource.fetch.mockClear();
+    errorSpy.mockClear();
+
+    await hocWrapper.setProps({
+      fetchArgs: { anotherProp: 2 },
+    });
+
+    expect(getWrappedComponentState(componentWrapper)).toMatchSnapshot();
+    expect(dataSource.fetch).toMatchSnapshot();
+
+    await flushPromises();
+    expect(getWrappedComponentState(componentWrapper)).toMatchSnapshot();
+    expect(getWrappedComponentState(componentWrapper).error).toBe(null);
+    await flushPromises();
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
   it('should send the given fetch arguments', async () => {
     const dataSource = {
       fetch: jest.fn(),

--- a/src/hocs/ec-with-abortable-fetch/ec-with-abortable-fetch.spec.js
+++ b/src/hocs/ec-with-abortable-fetch/ec-with-abortable-fetch.spec.js
@@ -121,7 +121,6 @@ describe('EcWithAbortableFetch', () => {
     await flushPromises();
     expect(getWrappedComponentState(componentWrapper)).toMatchSnapshot();
     expect(getWrappedComponentState(componentWrapper).error).toBe(null);
-    await flushPromises();
     expect(errorSpy).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
We need to reset the fetchError in the state of the component when the fetch method is called.  Currently, if a request fails, the subsequent requests are considered to fail because the state is not reset. This is an issue now that we are implementing the filters and there can be more requests if the user selects a new filter