### PR TITLE
ONL-5407:fix: Fix declared function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/components/ec-smart-table/ec-smart-table.vue
+++ b/src/components/ec-smart-table/ec-smart-table.vue
@@ -46,13 +46,12 @@ const withEcSmartTableRenderer = (Component) => {
           totalRecords: total,
         };
 
-        // eslint-disable-next-line no-inner-declarations
-        function renderFilter(filterSlot) {
+        const renderFilter = function renderFilter(filterSlot) {
           if (filterSlot) {
             return (<div class="ec-smart-table__filter">{filterSlot()}</div>);
           }
           return null;
-        }
+        };
 
         return (
           <div class="ec-smart-table" data-test="ec-smart-table">


### PR DESCRIPTION
Based on our compatibility matrix on EBO, we allow firefox 44 but if we do login in EBO and we go to the Dashboard, we cannot see it because there is the next exception:

SyntaxError: in strict mode code, functions may be declared only at top level or immediately within another function. _webpack_require_()
app.js:876
hotCreateRequire/fn()
app.js:168
<anonymous>
index.js:2
["./node_modules/@ebury/chameleon-components/src/components/ec-smart-table/index.js"]()....

![image](https://user-images.githubusercontent.com/31845091/102785061-a14c7100-439d-11eb-9040-be5f48f7edeb.png)
