### PR TITLE
ONL-5897:feat:infinite visible items for btn dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/components/ec-btn-dropdown/ec-btn-dropdown.vue
+++ b/src/components/ec-btn-dropdown/ec-btn-dropdown.vue
@@ -19,6 +19,7 @@
     <ec-dropdown-search
       :items="items"
       :is-search-enabled="false"
+      :max-visible-items="Infinity"
       :popper-modifiers="popperModifiers"
       :disabled="isDisabled"
       @change="(value) => $emit('change', value)"


### PR DESCRIPTION
In this PR I increase the max number of visible items for the button dropdown to Infinity. 

The default visible items for the dropdown search is 4. For btn dropdown though we don't want the scrollbar at all even if we have a large number of items. For this reason should be set to infinity.