### PR TITLE
ONL-5777: feat: Add data-test for dropdown list.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/components/ec-currency-input/__snapshots__/ec-currency-input.spec.js.snap
+++ b/src/components/ec-currency-input/__snapshots__/ec-currency-input.spec.js.snap
@@ -193,7 +193,7 @@ exports[`EcCurrencyInput :props should render the searching field with the place
 exports[`EcCurrencyInput :props should render without any currencies if the currencies prop is empty 1`] = `
 <div
   class="ec-dropdown-search ec-dropdown ec-currency-input__currencies"
-  data-test="ec-dropdown"
+  data-test="ec-dropdown ec-dropdown-search"
 >
   <ec-stub
     class="ec-dropdown-search__trigger"
@@ -288,7 +288,7 @@ exports[`EcCurrencyInput should render properly 1`] = `
   >
     <div
       class="ec-dropdown-search ec-dropdown ec-currency-input__currencies"
-      data-test="ec-dropdown"
+      data-test="ec-dropdown ec-dropdown-search"
     >
       <ec-stub
         class="ec-dropdown-search__trigger"
@@ -426,7 +426,7 @@ exports[`EcCurrencyInput should render with a sensitive class when isSensitive p
   >
     <div
       class="ec-dropdown-search ec-dropdown ec-currency-input__currencies"
-      data-test="ec-dropdown"
+      data-test="ec-dropdown ec-dropdown-search"
     >
       <ec-stub
         class="ec-dropdown-search__trigger"

--- a/src/components/ec-dropdown-search/__snapshots__/ec-dropdown-search.spec.js.snap
+++ b/src/components/ec-dropdown-search/__snapshots__/ec-dropdown-search.spec.js.snap
@@ -59,37 +59,37 @@ exports[`EcDropdownSearch should add a tooltip for any disabled item 1`] = `
    
   <li
     class="ec-dropdown-search__item"
-    data-test="ec-dropdown-search__item ec-dropdown-search__item--0"
+    data-test="ec-dropdown-search__item ec-dropdown-search__item--0 ec-mock ec-tooltip-mock"
     title="Item 1"
   >
     Item 1
   </li>
   <li
     class="ec-dropdown-search__item"
-    data-test="ec-dropdown-search__item ec-dropdown-search__item--1"
+    data-test="ec-dropdown-search__item ec-dropdown-search__item--1 ec-mock ec-tooltip-mock"
     title="Item 2"
   >
     Item 2
   </li>
   <li
     class="ec-dropdown-search__item"
-    data-test="ec-dropdown-search__item ec-dropdown-search__item--2"
+    data-test="ec-dropdown-search__item ec-dropdown-search__item--2 ec-mock ec-tooltip-mock"
     title="Item 3"
   >
     Item 3
   </li>
   <li
     class="ec-dropdown-search__item ec-dropdown-search__item--is-disabled"
-    data-test="ec-dropdown-search__item ec-dropdown-search__item--3"
-    mocked-tooltip-content="Random text"
-    mocked-tooltip-placement="right"
+    data-ec-tooltip-mock-content="Random text"
+    data-ec-tooltip-mock-placement="right"
+    data-test="ec-dropdown-search__item ec-dropdown-search__item--3 ec-mock ec-tooltip-mock"
     title="Item 4"
   >
     Item 4
   </li>
   <li
     class="ec-dropdown-search__item"
-    data-test="ec-dropdown-search__item ec-dropdown-search__item--4"
+    data-test="ec-dropdown-search__item ec-dropdown-search__item--4 ec-mock ec-tooltip-mock"
     title="Item 5"
   >
     Item 5
@@ -174,21 +174,21 @@ exports[`EcDropdownSearch should merge given tooltipOptions and item.tooltip pro
 - First value
 + Second value
 
-@@ -39,12 +39,12 @@
+@@ -38,12 +38,12 @@
+           
           <!---->
            
           <li
             class=\\"ec-dropdown-search__item ec-dropdown-search__item--is-disabled\\"
-            data-test=\\"ec-dropdown-search__item ec-dropdown-search__item--0\\"
--           mocked-tooltip-content=\\"This reason should not be seen because it's overridden by tooltip.content.\\"
--           mocked-tooltip-placement=\\"right\\"
-+           mocked-tooltip-content=\\"Content overridden by item\\"
-+           mocked-tooltip-placement=\\"top\\"
+-           data-ec-tooltip-mock-content=\\"This reason should not be seen because it's overridden by tooltip.content.\\"
+-           data-ec-tooltip-mock-placement=\\"right\\"
++           data-ec-tooltip-mock-content=\\"Content overridden by item\\"
++           data-ec-tooltip-mock-placement=\\"top\\"
+            data-test=\\"ec-dropdown-search__item ec-dropdown-search__item--0 ec-mock ec-tooltip-mock\\"
             title=\\"Random Item\\"
           >
             Random Item
-          </li>
-        </ul>"
+          </li>"
 `;
 
 exports[`EcDropdownSearch should not render the search if isSearchEnabled is set to false 1`] = `undefined`;
@@ -319,7 +319,7 @@ exports[`EcDropdownSearch should pass information whether an item is selected to
          
         <li
           class="ec-dropdown-search__item"
-          data-test="ec-dropdown-search__item ec-dropdown-search__item--0"
+          data-test="ec-dropdown-search__item ec-dropdown-search__item--0 ec-mock ec-tooltip-mock"
           title="Item 1"
         >
           <div>
@@ -328,7 +328,7 @@ exports[`EcDropdownSearch should pass information whether an item is selected to
         </li>
         <li
           class="ec-dropdown-search__item"
-          data-test="ec-dropdown-search__item ec-dropdown-search__item--1"
+          data-test="ec-dropdown-search__item ec-dropdown-search__item--1 ec-mock ec-tooltip-mock"
           title="Item 2"
         >
           <div>
@@ -337,7 +337,7 @@ exports[`EcDropdownSearch should pass information whether an item is selected to
         </li>
         <li
           class="ec-dropdown-search__item ec-dropdown-search__item--is-selected"
-          data-test="ec-dropdown-search__item ec-dropdown-search__item--2"
+          data-test="ec-dropdown-search__item ec-dropdown-search__item--2 ec-mock ec-tooltip-mock"
           title="Item 3"
         >
           <div>
@@ -346,9 +346,9 @@ exports[`EcDropdownSearch should pass information whether an item is selected to
         </li>
         <li
           class="ec-dropdown-search__item ec-dropdown-search__item--is-disabled"
-          data-test="ec-dropdown-search__item ec-dropdown-search__item--3"
-          mocked-tooltip-content="Random text"
-          mocked-tooltip-placement="right"
+          data-ec-tooltip-mock-content="Random text"
+          data-ec-tooltip-mock-placement="right"
+          data-test="ec-dropdown-search__item ec-dropdown-search__item--3 ec-mock ec-tooltip-mock"
           title="Item 4"
         >
           <div>
@@ -357,7 +357,7 @@ exports[`EcDropdownSearch should pass information whether an item is selected to
         </li>
         <li
           class="ec-dropdown-search__item"
-          data-test="ec-dropdown-search__item ec-dropdown-search__item--4"
+          data-test="ec-dropdown-search__item ec-dropdown-search__item--4 ec-mock ec-tooltip-mock"
           title="Item 5"
         >
           <div>
@@ -399,37 +399,37 @@ exports[`EcDropdownSearch should render all given items 1`] = `
    
   <li
     class="ec-dropdown-search__item"
-    data-test="ec-dropdown-search__item ec-dropdown-search__item--0"
+    data-test="ec-dropdown-search__item ec-dropdown-search__item--0 ec-mock ec-tooltip-mock"
     title="Item 1"
   >
     Item 1
   </li>
   <li
     class="ec-dropdown-search__item"
-    data-test="ec-dropdown-search__item ec-dropdown-search__item--1"
+    data-test="ec-dropdown-search__item ec-dropdown-search__item--1 ec-mock ec-tooltip-mock"
     title="Item 2"
   >
     Item 2
   </li>
   <li
     class="ec-dropdown-search__item"
-    data-test="ec-dropdown-search__item ec-dropdown-search__item--2"
+    data-test="ec-dropdown-search__item ec-dropdown-search__item--2 ec-mock ec-tooltip-mock"
     title="Item 3"
   >
     Item 3
   </li>
   <li
     class="ec-dropdown-search__item ec-dropdown-search__item--is-disabled"
-    data-test="ec-dropdown-search__item ec-dropdown-search__item--3"
-    mocked-tooltip-content="Random text"
-    mocked-tooltip-placement="right"
+    data-ec-tooltip-mock-content="Random text"
+    data-ec-tooltip-mock-placement="right"
+    data-test="ec-dropdown-search__item ec-dropdown-search__item--3 ec-mock ec-tooltip-mock"
     title="Item 4"
   >
     Item 4
   </li>
   <li
     class="ec-dropdown-search__item"
-    data-test="ec-dropdown-search__item ec-dropdown-search__item--4"
+    data-test="ec-dropdown-search__item ec-dropdown-search__item--4 ec-mock ec-tooltip-mock"
     title="Item 5"
   >
     Item 5
@@ -532,7 +532,7 @@ exports[`EcDropdownSearch should render given cta slot 1`] = `
          
         <li
           class="ec-dropdown-search__cta-area"
-          data-test="ec-dropdown-search__cta-area"
+          data-test="ec-dropdown-search__cta-area ec-mock ec-tooltip-mock"
         >
           <button>
             My CTA
@@ -541,37 +541,37 @@ exports[`EcDropdownSearch should render given cta slot 1`] = `
          
         <li
           class="ec-dropdown-search__item"
-          data-test="ec-dropdown-search__item ec-dropdown-search__item--0"
+          data-test="ec-dropdown-search__item ec-dropdown-search__item--0 ec-mock ec-tooltip-mock"
           title="Item 1"
         >
           Item 1
         </li>
         <li
           class="ec-dropdown-search__item"
-          data-test="ec-dropdown-search__item ec-dropdown-search__item--1"
+          data-test="ec-dropdown-search__item ec-dropdown-search__item--1 ec-mock ec-tooltip-mock"
           title="Item 2"
         >
           Item 2
         </li>
         <li
           class="ec-dropdown-search__item"
-          data-test="ec-dropdown-search__item ec-dropdown-search__item--2"
+          data-test="ec-dropdown-search__item ec-dropdown-search__item--2 ec-mock ec-tooltip-mock"
           title="Item 3"
         >
           Item 3
         </li>
         <li
           class="ec-dropdown-search__item ec-dropdown-search__item--is-disabled"
-          data-test="ec-dropdown-search__item ec-dropdown-search__item--3"
-          mocked-tooltip-content="Random text"
-          mocked-tooltip-placement="right"
+          data-ec-tooltip-mock-content="Random text"
+          data-ec-tooltip-mock-placement="right"
+          data-test="ec-dropdown-search__item ec-dropdown-search__item--3 ec-mock ec-tooltip-mock"
           title="Item 4"
         >
           Item 4
         </li>
         <li
           class="ec-dropdown-search__item"
-          data-test="ec-dropdown-search__item ec-dropdown-search__item--4"
+          data-test="ec-dropdown-search__item ec-dropdown-search__item--4 ec-mock ec-tooltip-mock"
           title="Item 5"
         >
           Item 5
@@ -623,9 +623,8 @@ exports[`EcDropdownSearch should render given cta slot with a tooltip 1`] = `
          
         <li
           class="ec-dropdown-search__cta-area"
-          data-test="ec-dropdown-search__cta-area"
-          mocked-tooltip-content="Random tooltip"
-          mocked-tooltip-placement=""
+          data-ec-tooltip-mock-content="Random tooltip"
+          data-test="ec-dropdown-search__cta-area ec-mock ec-tooltip-mock"
         >
           <button>
             My CTA
@@ -634,37 +633,37 @@ exports[`EcDropdownSearch should render given cta slot with a tooltip 1`] = `
          
         <li
           class="ec-dropdown-search__item"
-          data-test="ec-dropdown-search__item ec-dropdown-search__item--0"
+          data-test="ec-dropdown-search__item ec-dropdown-search__item--0 ec-mock ec-tooltip-mock"
           title="Item 1"
         >
           Item 1
         </li>
         <li
           class="ec-dropdown-search__item"
-          data-test="ec-dropdown-search__item ec-dropdown-search__item--1"
+          data-test="ec-dropdown-search__item ec-dropdown-search__item--1 ec-mock ec-tooltip-mock"
           title="Item 2"
         >
           Item 2
         </li>
         <li
           class="ec-dropdown-search__item"
-          data-test="ec-dropdown-search__item ec-dropdown-search__item--2"
+          data-test="ec-dropdown-search__item ec-dropdown-search__item--2 ec-mock ec-tooltip-mock"
           title="Item 3"
         >
           Item 3
         </li>
         <li
           class="ec-dropdown-search__item ec-dropdown-search__item--is-disabled"
-          data-test="ec-dropdown-search__item ec-dropdown-search__item--3"
-          mocked-tooltip-content="Random text"
-          mocked-tooltip-placement="right"
+          data-ec-tooltip-mock-content="Random text"
+          data-ec-tooltip-mock-placement="right"
+          data-test="ec-dropdown-search__item ec-dropdown-search__item--3 ec-mock ec-tooltip-mock"
           title="Item 4"
         >
           Item 4
         </li>
         <li
           class="ec-dropdown-search__item"
-          data-test="ec-dropdown-search__item ec-dropdown-search__item--4"
+          data-test="ec-dropdown-search__item ec-dropdown-search__item--4 ec-mock ec-tooltip-mock"
           title="Item 5"
         >
           Item 5
@@ -777,7 +776,7 @@ exports[`EcDropdownSearch should render given item slot 1`] = `
          
         <li
           class="ec-dropdown-search__item"
-          data-test="ec-dropdown-search__item ec-dropdown-search__item--0"
+          data-test="ec-dropdown-search__item ec-dropdown-search__item--0 ec-mock ec-tooltip-mock"
           title="Item 1"
         >
           <div>
@@ -789,7 +788,7 @@ exports[`EcDropdownSearch should render given item slot 1`] = `
         </li>
         <li
           class="ec-dropdown-search__item"
-          data-test="ec-dropdown-search__item ec-dropdown-search__item--1"
+          data-test="ec-dropdown-search__item ec-dropdown-search__item--1 ec-mock ec-tooltip-mock"
           title="Item 2"
         >
           <div>
@@ -801,7 +800,7 @@ exports[`EcDropdownSearch should render given item slot 1`] = `
         </li>
         <li
           class="ec-dropdown-search__item"
-          data-test="ec-dropdown-search__item ec-dropdown-search__item--2"
+          data-test="ec-dropdown-search__item ec-dropdown-search__item--2 ec-mock ec-tooltip-mock"
           title="Item 3"
         >
           <div>
@@ -813,9 +812,9 @@ exports[`EcDropdownSearch should render given item slot 1`] = `
         </li>
         <li
           class="ec-dropdown-search__item ec-dropdown-search__item--is-disabled"
-          data-test="ec-dropdown-search__item ec-dropdown-search__item--3"
-          mocked-tooltip-content="Random text"
-          mocked-tooltip-placement="right"
+          data-ec-tooltip-mock-content="Random text"
+          data-ec-tooltip-mock-placement="right"
+          data-test="ec-dropdown-search__item ec-dropdown-search__item--3 ec-mock ec-tooltip-mock"
           title="Item 4"
         >
           <div>
@@ -827,7 +826,7 @@ exports[`EcDropdownSearch should render given item slot 1`] = `
         </li>
         <li
           class="ec-dropdown-search__item"
-          data-test="ec-dropdown-search__item ec-dropdown-search__item--4"
+          data-test="ec-dropdown-search__item ec-dropdown-search__item--4 ec-mock ec-tooltip-mock"
           title="Item 5"
         >
           <div>
@@ -959,6 +958,73 @@ exports[`EcDropdownSearch should use and update the v-model 2`] = `
 >
   Item 3
 </li>
+`;
+
+exports[`EcDropdownSearch should use given list-data-test attribute 1`] = `
+<ul
+  class="ec-dropdown-search__item-list"
+  data-test="ec-dropdown-search__item-list my-test-list"
+>
+  <li
+    class="ec-dropdown-search__search-area"
+    data-test="ec-dropdown-search__search-area"
+  >
+    <svg
+      class="ec-dropdown-search__search-icon ec-icon"
+    >
+      <use
+        xlink:href="#ec-simple-search"
+      />
+    </svg>
+     
+    <input
+      autocomplete="off"
+      class="ec-dropdown-search__search-input"
+      data-test="ec-dropdown-search__search-input"
+      placeholder="Search..."
+    />
+  </li>
+   
+  <!---->
+   
+  <li
+    class="ec-dropdown-search__item"
+    data-test="ec-dropdown-search__item ec-dropdown-search__item--0 ec-mock ec-tooltip-mock"
+    title="Item 1"
+  >
+    Item 1
+  </li>
+  <li
+    class="ec-dropdown-search__item"
+    data-test="ec-dropdown-search__item ec-dropdown-search__item--1 ec-mock ec-tooltip-mock"
+    title="Item 2"
+  >
+    Item 2
+  </li>
+  <li
+    class="ec-dropdown-search__item"
+    data-test="ec-dropdown-search__item ec-dropdown-search__item--2 ec-mock ec-tooltip-mock"
+    title="Item 3"
+  >
+    Item 3
+  </li>
+  <li
+    class="ec-dropdown-search__item ec-dropdown-search__item--is-disabled"
+    data-ec-tooltip-mock-content="Random text"
+    data-ec-tooltip-mock-placement="right"
+    data-test="ec-dropdown-search__item ec-dropdown-search__item--3 ec-mock ec-tooltip-mock"
+    title="Item 4"
+  >
+    Item 4
+  </li>
+  <li
+    class="ec-dropdown-search__item"
+    data-test="ec-dropdown-search__item ec-dropdown-search__item--4 ec-mock ec-tooltip-mock"
+    title="Item 5"
+  >
+    Item 5
+  </li>
+</ul>
 `;
 
 exports[`EcDropdownSearch should use the placeholder for search input if given 1`] = `

--- a/src/components/ec-dropdown-search/ec-dropdown-search.spec.js
+++ b/src/components/ec-dropdown-search/ec-dropdown-search.spec.js
@@ -3,21 +3,8 @@ import EcDropdownSearch from './ec-dropdown-search.vue';
 import { withMockedConsole } from '../../../tests/utils/console';
 
 describe('EcDropdownSearch', () => {
-  const MockedEcTooltipDirective = {
-    bind(el, { value }) {
-      if (value.content) {
-        el.setAttribute('mocked-tooltip-content', value.content);
-        el.setAttribute('mocked-tooltip-placement', value.placement || '');
-      }
-    },
-  };
-
   function mountDropdownSearch(props, mountOpts) {
-    const localVue = createLocalVue();
-    localVue.directive('ec-tooltip', MockedEcTooltipDirective);
-
     return mount(EcDropdownSearch, {
-      localVue,
       propsData: { ...props },
       ...mountOpts,
     });
@@ -25,7 +12,6 @@ describe('EcDropdownSearch', () => {
 
   function mountAsTemplate(template, props, wrapperComponentOpts, mountOpts) {
     const localVue = createLocalVue();
-    localVue.directive('ec-tooltip', MockedEcTooltipDirective);
 
     const Component = localVue.extend({
       components: { EcDropdownSearch },
@@ -231,11 +217,11 @@ describe('EcDropdownSearch', () => {
 
     expect(wrapper.findByDataTest('ec-dropdown-search__item-list').element).toMatchSnapshot();
 
-    expect(wrapper.findByDataTest('ec-dropdown-search__item--0').attributes('mocked-tooltip-content')).toBeUndefined();
-    expect(wrapper.findByDataTest('ec-dropdown-search__item--1').attributes('mocked-tooltip-content')).toBeUndefined();
-    expect(wrapper.findByDataTest('ec-dropdown-search__item--2').attributes('mocked-tooltip-content')).toBeUndefined();
-    expect(wrapper.findByDataTest('ec-dropdown-search__item--3').attributes('mocked-tooltip-content')).toBe('Random text');
-    expect(wrapper.findByDataTest('ec-dropdown-search__item--4').attributes('mocked-tooltip-content')).toBeUndefined();
+    expect(wrapper.findByDataTest('ec-dropdown-search__item--0').attributes('data-ec-tooltip-mock-content')).toBeUndefined();
+    expect(wrapper.findByDataTest('ec-dropdown-search__item--1').attributes('data-ec-tooltip-mock-content')).toBeUndefined();
+    expect(wrapper.findByDataTest('ec-dropdown-search__item--2').attributes('data-ec-tooltip-mock-content')).toBeUndefined();
+    expect(wrapper.findByDataTest('ec-dropdown-search__item--3').attributes('data-ec-tooltip-mock-content')).toBe('Random text');
+    expect(wrapper.findByDataTest('ec-dropdown-search__item--4').attributes('data-ec-tooltip-mock-content')).toBeUndefined();
   });
 
   it('should merge given tooltipOptions and item.tooltip prop', () => {
@@ -273,6 +259,15 @@ describe('EcDropdownSearch', () => {
     });
 
     expect(defaultWrapper.element).toMatchDiffSnapshot(customizedWrapper.element);
+  });
+
+  it('should use given list-data-test attribute', () => {
+    const wrapper = mountDropdownSearch({ items }, {
+      attrs: {
+        'list-data-test': 'my-test-list',
+      },
+    });
+    expect(wrapper.findByDataTest('my-test-list').element).toMatchSnapshot();
   });
 
   describe('filtering', () => {

--- a/src/components/ec-dropdown-search/ec-dropdown-search.vue
+++ b/src/components/ec-dropdown-search/ec-dropdown-search.vue
@@ -2,7 +2,11 @@
   <div
     ref="popperWidthReference"
     class="ec-dropdown-search"
-    data-test="ec-dropdown-search"
+    v-bind="{
+      ...$attrs,
+      'data-test': $attrs['data-test'] ? `${$attrs['data-test']} ec-dropdown-search` : 'ec-dropdown-search',
+      'list-data-test': null,
+    }"
     @keydown.tab="onTabKeyDown"
     @keydown.enter.space.prevent="onEnterOrSpaceKeyDown"
     @keydown.up.prevent="onArrowUpKeyDown"
@@ -33,7 +37,7 @@
         <ul
           ref="itemsOverflowContainer"
           :class="listClasses"
-          data-test="ec-dropdown-search__item-list"
+          :data-test="`ec-dropdown-search__item-list ${$attrs['list-data-test'] || ''}`.trim()"
           @keydown.tab="onTabKeyDown"
           @keydown.up.prevent="onArrowUpKeyDown"
           @keydown.down.prevent="onArrowDownKeyDown"
@@ -146,6 +150,7 @@ export default {
   name: 'EcDropdownSearch',
   components: { EcPopover, EcIcon, EcLoading },
   directives: { EcTooltip },
+  inheritAttrs: false,
   model: {
     prop: 'selected',
     event: 'change',

--- a/src/components/ec-dropdown/__snapshots__/ec-dropdown.spec.js.snap
+++ b/src/components/ec-dropdown/__snapshots__/ec-dropdown.spec.js.snap
@@ -107,7 +107,7 @@ exports[`EcDropdown :props should enable search when isSearchEnabled is set to t
 exports[`EcDropdown :props should get disabled when disabled prop is set 1`] = `
 <div
   class="ec-dropdown-search ec-dropdown"
-  data-test="ec-dropdown"
+  data-test="ec-dropdown ec-dropdown-search"
 >
   <ec-stub
     class="ec-dropdown-search__trigger"
@@ -171,7 +171,7 @@ exports[`EcDropdown :props should get disabled when disabled prop is set 1`] = `
 exports[`EcDropdown :props should not show the items when the loading is set to true 1`] = `
 <div
   class="ec-dropdown-search ec-dropdown"
-  data-test="ec-dropdown"
+  data-test="ec-dropdown ec-dropdown-search"
 >
   <ec-stub
     class="ec-dropdown-search__trigger"
@@ -285,7 +285,7 @@ exports[`EcDropdown :props should pass label prop to the triggering input 1`] = 
 exports[`EcDropdown :props should render with a sensitive class when isSensitive prop is set to true 1`] = `
 <div
   class="ec-dropdown-search ec-dropdown"
-  data-test="ec-dropdown"
+  data-test="ec-dropdown ec-dropdown-search"
 >
   <ec-stub
     class="ec-dropdown-search__trigger"
@@ -380,7 +380,7 @@ exports[`EcDropdown :props should use searchPlaceholder prop if search is enable
 exports[`EcDropdown should render as expected 1`] = `
 <div
   class="ec-dropdown-search ec-dropdown"
-  data-test="ec-dropdown"
+  data-test="ec-dropdown ec-dropdown-search"
 >
   <ec-stub
     class="ec-dropdown-search__trigger"
@@ -448,4 +448,53 @@ exports[`EcDropdown should render readonly input as a trigger 1`] = `
   readonly="readonly"
   type="text"
 />
+`;
+
+exports[`EcDropdown should use given list-data-test attribute 1`] = `
+<ul
+  class="ec-dropdown-search__item-list"
+  data-test="ec-dropdown-search__item-list my-test-list"
+>
+  <!---->
+   
+  <!---->
+   
+  <li
+    class="ec-dropdown-search__item"
+    data-test="ec-dropdown-search__item ec-dropdown-search__item--0 ec-mock ec-tooltip-mock"
+    title="Item 1"
+  >
+    Item 1
+  </li>
+  <li
+    class="ec-dropdown-search__item"
+    data-test="ec-dropdown-search__item ec-dropdown-search__item--1 ec-mock ec-tooltip-mock"
+    title="Item 2"
+  >
+    Item 2
+  </li>
+  <li
+    class="ec-dropdown-search__item"
+    data-test="ec-dropdown-search__item ec-dropdown-search__item--2 ec-mock ec-tooltip-mock"
+    title="Item 3"
+  >
+    Item 3
+  </li>
+  <li
+    class="ec-dropdown-search__item ec-dropdown-search__item--is-disabled"
+    data-ec-tooltip-mock-content="Random text"
+    data-ec-tooltip-mock-placement="right"
+    data-test="ec-dropdown-search__item ec-dropdown-search__item--3 ec-mock ec-tooltip-mock"
+    title="Item 4"
+  >
+    Item 4
+  </li>
+  <li
+    class="ec-dropdown-search__item"
+    data-test="ec-dropdown-search__item ec-dropdown-search__item--4 ec-mock ec-tooltip-mock"
+    title="Item 5"
+  >
+    Item 5
+  </li>
+</ul>
 `;

--- a/src/components/ec-dropdown/ec-dropdown.spec.js
+++ b/src/components/ec-dropdown/ec-dropdown.spec.js
@@ -54,6 +54,15 @@ describe('EcDropdown', () => {
     expect(wrapper.findByDataTest('ec-dropdown-search__search-area').exists()).toBe(false);
   });
 
+  it('should use given list-data-test attribute', () => {
+    const wrapper = mountDropdown({ items }, {
+      attrs: {
+        'list-data-test': 'my-test-list',
+      },
+    });
+    expect(wrapper.findByDataTest('my-test-list').element).toMatchSnapshot();
+  });
+
   describe(':props', () => {
     it('should not render any label if prop is not given', () => {
       const wrapper = mountDropdown({ label: '' });


### PR DESCRIPTION
Selecting an item from a dropdown in tests is problematic when there are multiple dropdowns on the page. The dropdown uses ec-popover for displaying the dropdown list of items but these popovers stay in the document body for a couple of seconds after closed. This causes problems on how to select an item with specific text if that item exists in two dropdowns. We need to be able to specify a custom data-test attribute for the dropdown-list inside of the popover so I have added a new attribute for ec-dropdown and ec-dropdown-search called `list-data-test`. This will allow us to do something like this in EBO:
```
  <ec-dropdown
    v-model="beneficiaryModel"
    data-test="ebo-payees-information-beneficiaries-dropdown"
    :list-data-test="`ebo-payees-information-beneficiaries-dropdown__item-list-${currentIndex}`"
```

so we can select `ebo-payees-information-beneficiaries-dropdown__item-list-XX` in C&P payments list.