### PR TITLE
ONL-2866: feat: Added fetchArgs prop for ec-smart-table.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ebury/chameleon-components",
-      "version": "1.7.3",
+      "version": "1.7.4",
       "license": "MIT",
       "dependencies": {
         "clipboard-copy": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/components/ec-smart-table/ec-smart-table.spec.js
+++ b/src/components/ec-smart-table/ec-smart-table.spec.js
@@ -340,4 +340,57 @@ describe('EcSmartTable', () => {
       expect(wrapper.findByDataTest('ec-loading__icon').element).toMatchSnapshot('loading icon after loading filtered data');
     });
   });
+
+  describe('fetch arguments', () => {
+    it('should use given fetch arguments for fetching and re-fetching', async () => {
+      const resolvedDataSource = {
+        fetch: jest.fn().mockResolvedValue({}),
+      };
+
+      const fetchArgs = {
+        prop1: 'value1',
+        obj1: { prop2: 'value2' },
+        arr1: ['str1', 1],
+      };
+
+      const wrapper = mountEcSmartTable({
+        columns, isPaginationEnabled: true, dataSource: resolvedDataSource, fetchArgs,
+      });
+      await flushPromises();
+      wrapper.vm.$forceUpdate();
+
+      const expectedCancelToken = expect.anything();
+      expect(resolvedDataSource.fetch).toHaveBeenCalledTimes(1);
+      expect(resolvedDataSource.fetch).toHaveBeenCalledWith({
+        filter: {},
+        numberOfItems: 10,
+        page: 1,
+        sorts: [],
+        prop1: 'value1',
+        obj1: { prop2: 'value2' },
+        arr1: ['str1', 1],
+      }, expectedCancelToken);
+
+      resolvedDataSource.fetch.mockReset();
+
+      await wrapper.setProps({
+        fetchArgs: {
+          ...fetchArgs,
+          prop1: 'value3',
+        },
+      });
+      await flushPromises();
+
+      expect(resolvedDataSource.fetch).toHaveBeenCalledTimes(1);
+      expect(resolvedDataSource.fetch).toHaveBeenCalledWith({
+        filter: {},
+        numberOfItems: 10,
+        page: 1,
+        sorts: [],
+        prop1: 'value3',
+        obj1: { prop2: 'value2' },
+        arr1: ['str1', 1],
+      }, expectedCancelToken);
+    });
+  });
 });

--- a/src/components/ec-smart-table/ec-smart-table.story.js
+++ b/src/components/ec-smart-table/ec-smart-table.story.js
@@ -111,6 +111,9 @@ stories
       data: {
         default: object('data', data),
       },
+      fetchArgs: {
+        default: object('fetchArgs', { customProp: 'customValue' }),
+      },
       multiSort: {
         default: boolean('multiSort', false),
       },
@@ -170,6 +173,7 @@ stories
             page = 1,
             numberOfItems,
             filter,
+            ...args
           }, cancelToken) => {
             // use real service in a real application:
             // e.g.
@@ -178,11 +182,11 @@ stories
             // e.g.
             // getData: (sorts, page, numberOfItems, filter, cancelToken) => fetch('/my/url', { body: { sorts, page, numberOfItems, ...filter }, signal: cancelToken });
 
-            action('fetching')(sorts, page, numberOfItems, JSON.stringify(filter));
+            action('fetching')(sorts, page, numberOfItems, JSON.stringify(filter), JSON.stringify(args));
 
             return new Promise((resolve, reject) => {
               this.loadingTimeout = setTimeout(() => {
-                action('resolving data')(sorts, page, numberOfItems, JSON.stringify(filter));
+                action('resolving data')(sorts, page, numberOfItems, JSON.stringify(filter), JSON.stringify(args));
                 if (this.failOnFetch) {
                   reject(new Error('Random error'));
                 } else if (this.fetchEmptyList) {
@@ -219,6 +223,7 @@ stories
             :sorts="sorts"
             :multi-sort="multiSort"
             :data-source="dataSource"
+            :fetch-args="fetchArgs"
             :max-height="maxHeight"
             :sticky-column="stickyColumn || null"
             :error-message="errorMessage || undefined"

--- a/src/components/ec-smart-table/ec-smart-table.vue
+++ b/src/components/ec-smart-table/ec-smart-table.vue
@@ -72,7 +72,7 @@ const withEcSmartTableRenderer = (Component) => {
 
 const withEcSmartTableContainer = createHOCc({
   name: 'EcSmartTable',
-  props: ['sorts', 'page', 'numberOfItems', 'filter'],
+  props: ['sorts', 'page', 'numberOfItems', 'filter', 'fetchArgs'],
   computed: {
     dataSourceFetchArgs() {
       return {
@@ -80,6 +80,7 @@ const withEcSmartTableContainer = createHOCc({
         page: this.page,
         numberOfItems: this.numberOfItems,
         filter: this.filter,
+        ...this.fetchArgs,
       };
     },
   },


### PR DESCRIPTION
`fetchArgs` will allow to add custom arguments into the `datasource.fetch()` call and also allow to reload the ec-smart-table every time these fetchArgs change. It doesn't add any new functionality but only exposes/uses the existing fetchArgs from withAbortableFetch HoC.