### PR TITLE
ONL-6219: feat: Added ability to pass custom transform fns to withAbortableFetch

### DIFF
--- a/src/hocs/ec-with-abortable-fetch/__snapshots__/ec-with-abortable-fetch.spec.js.snap
+++ b/src/hocs/ec-with-abortable-fetch/__snapshots__/ec-with-abortable-fetch.spec.js.snap
@@ -413,3 +413,111 @@ found in
   ],
 }
 `;
+
+exports[`EcWithAbortableFetch should transform props using given data transform function and pass them to given custom data prop: after fetch 1`] = `
+Object {
+  "dataCustom": Object {
+    "result": 1,
+  },
+  "error": null,
+  "loading": false,
+}
+`;
+
+exports[`EcWithAbortableFetch should transform props using given data transform function and pass them to given custom data prop: while loading 1`] = `
+Object {
+  "dataCustom": Object {
+    "result": 0,
+  },
+  "error": null,
+  "loading": true,
+}
+`;
+
+exports[`EcWithAbortableFetch should transform props using given data transform function: after fetch 1`] = `
+Object {
+  "data": Object {
+    "result": 1,
+  },
+  "error": null,
+  "loading": false,
+}
+`;
+
+exports[`EcWithAbortableFetch should transform props using given data transform function: while loading 1`] = `
+Object {
+  "data": Object {
+    "result": 0,
+  },
+  "error": null,
+  "loading": true,
+}
+`;
+
+exports[`EcWithAbortableFetch should transform props using given error transform function and pass them to given custom error prop: after fetch 1`] = `
+Object {
+  "data": null,
+  "errorCustom": "Custom error message (Random error)",
+  "loading": false,
+}
+`;
+
+exports[`EcWithAbortableFetch should transform props using given error transform function and pass them to given custom error prop: while loading 1`] = `
+Object {
+  "data": null,
+  "errorCustom": null,
+  "loading": true,
+}
+`;
+
+exports[`EcWithAbortableFetch should transform props using given error transform function: after fetch 1`] = `
+Object {
+  "data": null,
+  "error": "Custom error message (Random error)",
+  "loading": false,
+}
+`;
+
+exports[`EcWithAbortableFetch should transform props using given error transform function: while loading 1`] = `
+Object {
+  "data": null,
+  "error": null,
+  "loading": true,
+}
+`;
+
+exports[`EcWithAbortableFetch should transform props using given loading transform function and pass them to given custom loading prop: after fetch 1`] = `
+Object {
+  "data": Object {
+    "result": 1,
+  },
+  "error": null,
+  "loadingCustom": true,
+}
+`;
+
+exports[`EcWithAbortableFetch should transform props using given loading transform function and pass them to given custom loading prop: while loading 1`] = `
+Object {
+  "data": null,
+  "error": null,
+  "loadingCustom": false,
+}
+`;
+
+exports[`EcWithAbortableFetch should transform props using given loading transform function: after fetch 1`] = `
+Object {
+  "data": Object {
+    "result": 1,
+  },
+  "error": null,
+  "loading": true,
+}
+`;
+
+exports[`EcWithAbortableFetch should transform props using given loading transform function: while loading 1`] = `
+Object {
+  "data": null,
+  "error": null,
+  "loading": false,
+}
+`;

--- a/src/hocs/ec-with-abortable-fetch/ec-with-abortable-fetch.js
+++ b/src/hocs/ec-with-abortable-fetch/ec-with-abortable-fetch.js
@@ -1,6 +1,15 @@
 import { createHOC } from 'vue-hoc';
 
-const withAbortableFetch = (Component, { dataProp = 'data', loadingProp = 'loading', errorProp = 'error' } = {}) => createHOC(Component, {
+const identity = arg => arg;
+
+const withAbortableFetch = (Component, {
+  dataProp = 'data',
+  loadingProp = 'loading',
+  errorProp = 'error',
+  dataTransform = identity,
+  errorTransform = identity,
+  loadingTransform = identity,
+} = {}) => createHOC(Component, {
   name: 'EcWithAbortableFetch',
   props: {
     dataSource: {
@@ -64,9 +73,9 @@ const withAbortableFetch = (Component, { dataProp = 'data', loadingProp = 'loadi
       ...props,
       dataSource: null,
       fetchArgs: null,
-      [loadingProp]: this.isFetching,
-      [errorProp]: this.fetchError,
-      [dataProp]: this.fetchedData,
+      [loadingProp]: loadingTransform(this.isFetching),
+      [errorProp]: errorTransform(this.fetchError),
+      [dataProp]: dataTransform(this.fetchedData),
     };
   },
 });


### PR DESCRIPTION
The problem this solves is that I cannot wrap withAbortableFetch around EcCurrencyFilter because the data prop of EcCurrencyFilter is of type Array. withAbortableFetch passes `null` to that prop while loading the data and that throws an exceptions. Same problem is also with currenciesErrorMessage which expects string but withAbortableFetch passes a whole error object into it. This PR allows us to make corrections and transform the data when passing them from withAbortableFetch down to the wrapped component. 

The usage in EBO would look like this:
```
const EboAsyncCurrencyFilter = ecWithAbortableFetch(EcCurrencyFilter, {
  dataProp: 'currencyItems',
  loadingProp: 'isLoadingCurrencies',
  errorProp: 'currenciesErrorMessage',
  errorTransform: error => (error ? $gettext('Unable to retrieve list of available currencies') : null),
  dataTransform: data => data ?? [],
});
```