### PR TITLE
ONL-6224: chore: Enabled require-await eslint rule.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
     'no-use-before-define': 'off',
     'no-multiple-empty-lines': ['error', { max: 1 }],
     'import/prefer-default-export': 'off',
+    'require-await': ['error'],
     'vue/attributes-order': ['error', {
       order: [
         'GLOBAL',

--- a/src/components/ec-inline-input-field/ec-inline-input-field.spec.js
+++ b/src/components/ec-inline-input-field/ec-inline-input-field.spec.js
@@ -23,7 +23,7 @@ describe('EcInlineInputField', () => {
   }
 
   describe('when component is non-editable', () => {
-    it('should render as expected', async () => {
+    it('should render as expected', () => {
       const wrapper = mountInlineInputField({ isEditable: false }, {
         slots: {
           default: '<a href="#">Link</a>',
@@ -33,7 +33,7 @@ describe('EcInlineInputField', () => {
       expect(wrapper.element).toMatchSnapshot();
     });
 
-    it('should render with a sensitive class when isSensitive prop is set to true', async () => {
+    it('should render with a sensitive class when isSensitive prop is set to true', () => {
       const wrapper = mountInlineInputField({ isEditable: false, isSensitive: true });
 
       expect(wrapper.element).toMatchSnapshot();
@@ -42,14 +42,14 @@ describe('EcInlineInputField', () => {
 
   describe('when component is editable', () => {
     describe('when the component is in its initial state', () => {
-      it('should render as expected', async () => {
+      it('should render as expected', () => {
         const wrapper = mountInlineInputField();
 
         expect(wrapper.element).toMatchSnapshot();
         expect(wrapper.findByDataTest('ec-inline-input-field-value-text').exists()).toBeTruthy();
       });
 
-      it('should render with a sensitive class when isSensitive prop is set to true when isSensitive prop is set to true', async () => {
+      it('should render with a sensitive class when isSensitive prop is set to true when isSensitive prop is set to true', () => {
         const wrapper = mountInlineInputField({ isSensitive: true });
 
         expect(wrapper.element).toMatchSnapshot();
@@ -74,7 +74,7 @@ describe('EcInlineInputField', () => {
     });
 
     describe('when the component is in editing mode', () => {
-      it('should render as expected', async () => {
+      it('should render as expected', () => {
         const wrapper = mountInlineInputField({ isEditing: true });
 
         expect(wrapper.element).toMatchSnapshot();
@@ -90,7 +90,7 @@ describe('EcInlineInputField', () => {
         focusSpy.mockRestore();
       });
 
-      it('should render with a sensitive class when isSensitive prop is set to true', async () => {
+      it('should render with a sensitive class when isSensitive prop is set to true', () => {
         const wrapper = mountInlineInputField(
           {
             isEditing: true,
@@ -102,7 +102,7 @@ describe('EcInlineInputField', () => {
         expect(wrapper.findByDataTest('ec-inline-input-field-edit').exists()).toBeTruthy();
       });
 
-      it('should render properly when the errorMessage prop is given', async () => {
+      it('should render properly when the errorMessage prop is given', () => {
         const wrapper = mountInlineInputField({ isEditing: true, errorMessage: 'error msg' });
 
         expect(wrapper.element).toMatchSnapshot();
@@ -161,14 +161,14 @@ describe('EcInlineInputField', () => {
     });
 
     describe('when the component is loading', () => {
-      it('should render as expected', async () => {
+      it('should render as expected', () => {
         const wrapper = mountInlineInputField({ isLoading: true });
 
         expect(wrapper.element).toMatchSnapshot();
         expect(wrapper.findByDataTest('ec-inline-input-field-loading').exists()).toBeTruthy();
       });
 
-      it('should render with a sensitive class when isSensitive prop is set to true', async () => {
+      it('should render with a sensitive class when isSensitive prop is set to true', () => {
         const wrapper = mountInlineInputField({ isLoading: true, isSensitive: true });
 
         expect(wrapper.element).toMatchSnapshot();
@@ -197,7 +197,7 @@ describe('EcInlineInputField', () => {
       expect(wrapper.element).toMatchSnapshot();
     });
 
-    it('should render as expected', async () => {
+    it('should render as expected', () => {
       const wrapper = mountInlineInputField(
         {
           isEditable: false,
@@ -211,7 +211,7 @@ describe('EcInlineInputField', () => {
       expect(wrapper.findByDataTest('ec-inline-input-field-copy').exists()).toBeTruthy();
     });
 
-    it('should render with a sensitive class when isSensitive prop is set to true', async () => {
+    it('should render with a sensitive class when isSensitive prop is set to true', () => {
       const wrapper = mountInlineInputField(
         {
           isEditable: false,

--- a/src/components/ec-multiple-values-selection/ec-multiple-values-selection.spec.js
+++ b/src/components/ec-multiple-values-selection/ec-multiple-values-selection.spec.js
@@ -113,27 +113,27 @@ describe('EcMultipleValuesSelection', () => {
     expect(wrapper.element).toMatchSnapshot();
   });
 
-  it('should set the empty state message', async () => {
+  it('should set the empty state message', () => {
     const wrapper = mountEcMultipleValuesSelection({ items: [], emptyMessage: 'No items' });
     expect(wrapper.element).toMatchSnapshot();
   });
 
-  it('should set the empty state icon', async () => {
+  it('should set the empty state icon', () => {
     const wrapper = mountEcMultipleValuesSelection({ items: [], emptyMessage: 'No items', emptyIcon: 'simple-check' });
     expect(wrapper.element).toMatchSnapshot();
   });
 
-  it('should set the error message', async () => {
+  it('should set the error message', () => {
     const wrapper = mountEcMultipleValuesSelection({ items: [], errorMessage: 'Error message' });
     expect(wrapper.element).toMatchSnapshot();
   });
 
-  it('should set the error icon', async () => {
+  it('should set the error icon', () => {
     const wrapper = mountEcMultipleValuesSelection({ items: [], errorMessage: 'Error message', errorIcon: 'simple-check' });
     expect(wrapper.element).toMatchSnapshot();
   });
 
-  it('should render loading state', async () => {
+  it('should render loading state', () => {
     const wrapper = mountEcMultipleValuesSelection({ items: [], isLoading: true });
     expect(wrapper.element).toMatchSnapshot();
   });

--- a/src/components/ec-table/ec-table.spec.js
+++ b/src/components/ec-table/ec-table.spec.js
@@ -169,7 +169,7 @@ describe('EcTable', () => {
     expect(wrapper.element).toMatchSnapshot();
   });
 
-  it('the tr should have class ec-table-row--is-clickable if we set the listener on row-click', async () => {
+  it('the tr should have class ec-table-row--is-clickable if we set the listener on row-click', () => {
     const onRowClick = jest.fn();
     const wrapper = mountTable(
       {

--- a/src/hocs/ec-with-abortable-fetch/ec-with-abortable-fetch.spec.js
+++ b/src/hocs/ec-with-abortable-fetch/ec-with-abortable-fetch.spec.js
@@ -125,7 +125,7 @@ describe('EcWithAbortableFetch', () => {
     expect(errorSpy).not.toHaveBeenCalled();
   });
 
-  it('should send the given fetch arguments', async () => {
+  it('should send the given fetch arguments', () => {
     const dataSource = {
       fetch: jest.fn(),
     };

--- a/src/hocs/ec-with-filters/ec-with-filters.spec.js
+++ b/src/hocs/ec-with-filters/ec-with-filters.spec.js
@@ -31,7 +31,7 @@ describe('EcWithFilters', () => {
     expect(hocWrapper.element).toMatchSnapshot();
   });
 
-  it('should bound given filters', async () => {
+  it('should bound given filters', () => {
     const filters = [{
       name: 'test1',
     }, {


### PR DESCRIPTION
We should not use async functions without await.