### PR TITLE
ONL-6255: use svg sprites without inlining

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,3 +1,3 @@
-<link href="/img/rounded-icons.svg" rel=preload as=fetch crossorigin>
-<link href="/img/simple-icons.svg" rel=preload as=fetch crossorigin>
-<link href="/img/currency-flags.svg" rel=preload as=fetch crossorigin>
+<link href="/img/rounded-icons.svg" rel="prefetch" as="image" type="image/svg+xml" crossorigin>
+<link href="/img/simple-icons.svg" rel="prefetch" as="image" type="image/svg+xml" crossorigin>
+<link href="/img/currency-flags.svg" rel="prefetch" as="image" type="image/svg+xml" crossorigin>

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,7 +2,6 @@
 import cssVars from 'css-vars-ponyfill';
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 import { withCssResources } from '@storybook/addon-cssresources';
-import { inlineSvgSprites } from '../src/icons/browser';
 import { getAllBackgrounds } from './backgrounds';
 
 /* eslint-disable import/no-webpack-loader-syntax */
@@ -40,4 +39,3 @@ export const parameters = {
 export const decorators = [withCssResources];
 
 cssVars();
-inlineSvgSprites(['rounded-icons', 'simple-icons', 'currency-flags'], '/img');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "1.8.5",
+  "version": "1.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ebury/chameleon-components",
-      "version": "1.8.5",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "clipboard-copy": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "1.8.5",
+  "version": "1.9.0",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/components/ec-alert/__snapshots__/ec-alert.spec.js.snap
+++ b/src/components/ec-alert/__snapshots__/ec-alert.spec.js.snap
@@ -11,7 +11,7 @@ exports[`EcAlert should display only with a title and the type given 1`] = `
     class="ec-alert__icon ec-icon"
   >
     <use
-      xlink:href="#ec-simple-info"
+      href="/img/simple-icons.svg#ec-simple-info"
     />
   </svg>
    
@@ -43,7 +43,7 @@ exports[`EcAlert should display with a button with the text given in the buttonT
     class="ec-alert__icon ec-icon"
   >
     <use
-      xlink:href="#ec-simple-info"
+      href="/img/simple-icons.svg#ec-simple-info"
     />
   </svg>
    
@@ -80,7 +80,7 @@ exports[`EcAlert should display with a subtitle given 1`] = `
     class="ec-alert__icon ec-icon ec-alert__icon--alert-has-subtitle"
   >
     <use
-      xlink:href="#ec-simple-info"
+      href="/img/simple-icons.svg#ec-simple-info"
     />
   </svg>
    
@@ -122,7 +122,7 @@ exports[`EcAlert should render the dismiss icon when is given the prop dismissab
       width="16"
     >
       <use
-        xlink:href="#ec-simple-close"
+        href="/img/simple-icons.svg#ec-simple-close"
       />
     </svg>
   </a>
@@ -131,7 +131,7 @@ exports[`EcAlert should render the dismiss icon when is given the prop dismissab
     class="ec-alert__icon ec-icon"
   >
     <use
-      xlink:href="#ec-simple-info"
+      href="/img/simple-icons.svg#ec-simple-info"
     />
   </svg>
    
@@ -163,7 +163,7 @@ exports[`EcAlert should render with the cta slot given 1`] = `
     class="ec-alert__icon ec-icon ec-alert__icon--alert-has-subtitle"
   >
     <use
-      xlink:href="#ec-simple-info"
+      href="/img/simple-icons.svg#ec-simple-info"
     />
   </svg>
    
@@ -204,7 +204,7 @@ exports[`EcAlert should render with the default slot given 1`] = `
     class="ec-alert__icon ec-icon ec-alert__icon--alert-has-subtitle"
   >
     <use
-      xlink:href="#ec-simple-info"
+      href="/img/simple-icons.svg#ec-simple-info"
     />
   </svg>
    
@@ -231,7 +231,7 @@ exports[`EcAlert should use the given type for the alert type and for the button
     class="ec-alert__icon ec-icon"
   >
     <use
-      xlink:href="#ec-simple-error"
+      href="/img/simple-icons.svg#ec-simple-error"
     />
   </svg>
    
@@ -268,7 +268,7 @@ exports[`EcAlert should use the type "error" 1`] = `
     class="ec-alert__icon ec-icon"
   >
     <use
-      xlink:href="#ec-simple-error"
+      href="/img/simple-icons.svg#ec-simple-error"
     />
   </svg>
    
@@ -300,7 +300,7 @@ exports[`EcAlert should use the type "info" 1`] = `
     class="ec-alert__icon ec-icon"
   >
     <use
-      xlink:href="#ec-simple-info"
+      href="/img/simple-icons.svg#ec-simple-info"
     />
   </svg>
    
@@ -332,7 +332,7 @@ exports[`EcAlert should use the type "success" 1`] = `
     class="ec-alert__icon ec-icon"
   >
     <use
-      xlink:href="#ec-simple-check"
+      href="/img/simple-icons.svg#ec-simple-check"
     />
   </svg>
    
@@ -364,7 +364,7 @@ exports[`EcAlert should use the type "warning" 1`] = `
     class="ec-alert__icon ec-icon"
   >
     <use
-      xlink:href="#ec-simple-error"
+      href="/img/simple-icons.svg#ec-simple-error"
     />
   </svg>
    

--- a/src/components/ec-amount-filter-input/__snapshots__/ec-amount-filter-input.spec.js.snap
+++ b/src/components/ec-amount-filter-input/__snapshots__/ec-amount-filter-input.spec.js.snap
@@ -32,7 +32,7 @@ exports[`EcAmountFilterInput :props should render the error tooltip when "errorT
     width="14"
   >
     <use
-      xlink:href="#ec-simple-error"
+      href="/img/simple-icons.svg#ec-simple-error"
     />
   </svg>
 </div>
@@ -140,7 +140,7 @@ exports[`EcAmountFilterInput :props should render with a sensitive class when is
               width="24"
             >
               <use
-                xlink:href="#ec-simple-arrow-drop-down"
+                href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
               />
             </svg>
           </div>
@@ -223,7 +223,7 @@ exports[`EcAmountFilterInput :props should render with a warning tooltip when th
     width="14"
   >
     <use
-      xlink:href="#ec-simple-error"
+      href="/img/simple-icons.svg#ec-simple-error"
     />
   </svg>
 </div>
@@ -277,7 +277,7 @@ exports[`EcAmountFilterInput should render properly 1`] = `
               width="24"
             >
               <use
-                xlink:href="#ec-simple-arrow-drop-down"
+                href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
               />
             </svg>
           </div>

--- a/src/components/ec-btn-dropdown/__snapshots__/ec-btn-dropdown.spec.js.snap
+++ b/src/components/ec-btn-dropdown/__snapshots__/ec-btn-dropdown.spec.js.snap
@@ -48,7 +48,7 @@ exports[`EcBtnDropdown should render as expected 1`] = `
           width="22"
         >
           <use
-            xlink:href="#ec-simple-arrow-drop-down"
+            href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
           />
         </svg>
          
@@ -121,7 +121,7 @@ exports[`EcBtnDropdown should render with a list of options on the dropdown sear
           width="22"
         >
           <use
-            xlink:href="#ec-simple-arrow-drop-down"
+            href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
           />
         </svg>
          
@@ -211,7 +211,7 @@ exports[`EcBtnDropdown should render with both buttons disabled 1`] = `
           width="22"
         >
           <use
-            xlink:href="#ec-simple-arrow-drop-down"
+            href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
           />
         </svg>
          

--- a/src/components/ec-btn/__snapshots__/ec-btn.spec.js.snap
+++ b/src/components/ec-btn/__snapshots__/ec-btn.spec.js.snap
@@ -50,7 +50,7 @@ exports[`EcBtn :props should render a button with a spinner loader if loading is
       width="22"
     >
       <use
-        xlink:href="#ec-simple-loading"
+        href="/img/simple-icons.svg#ec-simple-loading"
       />
     </svg>
   </div>
@@ -163,7 +163,7 @@ exports[`EcBtn :props should render a button with only a loading spinner when lo
       width="22"
     >
       <use
-        xlink:href="#ec-simple-loading"
+        href="/img/simple-icons.svg#ec-simple-loading"
       />
     </svg>
   </div>
@@ -183,7 +183,7 @@ exports[`EcBtn :props should render a button with only an icon when the "icon" i
     width="22"
   >
     <use
-      xlink:href="#ec-simple-check"
+      href="/img/simple-icons.svg#ec-simple-check"
     />
   </svg>
    
@@ -426,7 +426,7 @@ exports[`EcBtn :slots should render a button with "Click me!" text and an icon 1
     width="22"
   >
     <use
-      xlink:href="#ec-simple-check"
+      href="/img/simple-icons.svg#ec-simple-check"
     />
   </svg>
    
@@ -468,7 +468,7 @@ exports[`EcBtn :slots should render a button with a loading-text and a loading s
       width="22"
     >
       <use
-        xlink:href="#ec-simple-loading"
+        href="/img/simple-icons.svg#ec-simple-loading"
       />
     </svg>
   </div>

--- a/src/components/ec-currency-filter/__snapshots__/ec-currency-filter.spec.js.snap
+++ b/src/components/ec-currency-filter/__snapshots__/ec-currency-filter.spec.js.snap
@@ -28,7 +28,7 @@ exports[`EcCurrencyFilter should count every selected currency and the amount to
     width="16"
   >
     <use
-      xlink:href="#ec-simple-chevron-down"
+      href="/img/simple-icons.svg#ec-simple-chevron-down"
     />
   </svg>
 </div>
@@ -62,7 +62,7 @@ exports[`EcCurrencyFilter should count every selected currency in numberOfSelect
     width="16"
   >
     <use
-      xlink:href="#ec-simple-chevron-down"
+      href="/img/simple-icons.svg#ec-simple-chevron-down"
     />
   </svg>
 </div>
@@ -96,7 +96,7 @@ exports[`EcCurrencyFilter should count the amount as 1 in numberOfSelectedFilter
     width="16"
   >
     <use
-      xlink:href="#ec-simple-chevron-down"
+      href="/img/simple-icons.svg#ec-simple-chevron-down"
     />
   </svg>
 </div>
@@ -170,7 +170,7 @@ exports[`EcCurrencyFilter should pass down props required by ec-amount-filter-in
               width="24"
             >
               <use
-                xlink:href="#ec-simple-arrow-drop-down"
+                href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
               />
             </svg>
           </div>
@@ -327,7 +327,7 @@ exports[`EcCurrencyFilter should preselect given filters from the value prop 1`]
                   width="16"
                 >
                   <use
-                    xlink:href="#ec-simple-check"
+                    href="/img/simple-icons.svg#ec-simple-check"
                   />
                 </svg>
               </span>
@@ -382,7 +382,7 @@ exports[`EcCurrencyFilter should preselect given filters from the value prop 1`]
                   width="16"
                 >
                   <use
-                    xlink:href="#ec-simple-check"
+                    href="/img/simple-icons.svg#ec-simple-check"
                   />
                 </svg>
               </span>
@@ -613,7 +613,7 @@ exports[`EcCurrencyFilter should preselect given filters from the value prop 2`]
                 width="24"
               >
                 <use
-                  xlink:href="#ec-simple-arrow-drop-down"
+                  href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
                 />
               </svg>
             </div>
@@ -800,7 +800,7 @@ exports[`EcCurrencyFilter should render correctly 1`] = `
           width="16"
         >
           <use
-            xlink:href="#ec-simple-chevron-down"
+            href="/img/simple-icons.svg#ec-simple-chevron-down"
           />
         </svg>
       </div>
@@ -1211,7 +1211,7 @@ exports[`EcCurrencyFilter should render correctly 1`] = `
                           width="24"
                         >
                           <use
-                            xlink:href="#ec-simple-arrow-drop-down"
+                            href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
                           />
                         </svg>
                       </div>
@@ -1313,7 +1313,7 @@ exports[`EcCurrencyFilter should render currencies tab in empty state when curre
         width="32"
       >
         <use
-          xlink:href="#ec-simple-error"
+          href="/img/simple-icons.svg#ec-simple-error"
         />
       </svg>
        
@@ -1348,7 +1348,7 @@ exports[`EcCurrencyFilter should render currencies tab in error state when curre
         width="32"
       >
         <use
-          xlink:href="#ec-simple-error"
+          href="/img/simple-icons.svg#ec-simple-error"
         />
       </svg>
        
@@ -1383,7 +1383,7 @@ exports[`EcCurrencyFilter should render currencies tab in loading state when isL
         width="32"
       >
         <use
-          xlink:href="#ec-simple-loading"
+          href="/img/simple-icons.svg#ec-simple-loading"
         />
       </svg>
     </div>
@@ -1444,7 +1444,7 @@ exports[`EcCurrencyFilter v-model should clear the amount and comparison symbol 
                 width="24"
               >
                 <use
-                  xlink:href="#ec-simple-arrow-drop-down"
+                  href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
                 />
               </svg>
             </div>
@@ -1599,7 +1599,7 @@ exports[`EcCurrencyFilter v-model should update v-model every time a currency is
                   width="16"
                 >
                   <use
-                    xlink:href="#ec-simple-check"
+                    href="/img/simple-icons.svg#ec-simple-check"
                   />
                 </svg>
               </span>
@@ -2198,7 +2198,7 @@ exports[`EcCurrencyFilter v-model should update v-model every time a currency is
                   width="16"
                 >
                   <use
-                    xlink:href="#ec-simple-check"
+                    href="/img/simple-icons.svg#ec-simple-check"
                   />
                 </svg>
               </span>
@@ -2502,7 +2502,7 @@ exports[`EcCurrencyFilter v-model should update v-model every time a currency is
                   width="16"
                 >
                   <use
-                    xlink:href="#ec-simple-check"
+                    href="/img/simple-icons.svg#ec-simple-check"
                   />
                 </svg>
               </span>
@@ -2557,7 +2557,7 @@ exports[`EcCurrencyFilter v-model should update v-model every time a currency is
                   width="16"
                 >
                   <use
-                    xlink:href="#ec-simple-check"
+                    href="/img/simple-icons.svg#ec-simple-check"
                   />
                 </svg>
               </span>
@@ -3067,7 +3067,7 @@ exports[`EcCurrencyFilter v-model should update v-model if select all checkbox i
               width="16"
             >
               <use
-                xlink:href="#ec-simple-check"
+                href="/img/simple-icons.svg#ec-simple-check"
               />
             </svg>
           </span>
@@ -3117,7 +3117,7 @@ exports[`EcCurrencyFilter v-model should update v-model if select all checkbox i
                   width="16"
                 >
                   <use
-                    xlink:href="#ec-simple-check"
+                    href="/img/simple-icons.svg#ec-simple-check"
                   />
                 </svg>
               </span>
@@ -3172,7 +3172,7 @@ exports[`EcCurrencyFilter v-model should update v-model if select all checkbox i
                   width="16"
                 >
                   <use
-                    xlink:href="#ec-simple-check"
+                    href="/img/simple-icons.svg#ec-simple-check"
                   />
                 </svg>
               </span>
@@ -3227,7 +3227,7 @@ exports[`EcCurrencyFilter v-model should update v-model if select all checkbox i
                   width="16"
                 >
                   <use
-                    xlink:href="#ec-simple-check"
+                    href="/img/simple-icons.svg#ec-simple-check"
                   />
                 </svg>
               </span>
@@ -3282,7 +3282,7 @@ exports[`EcCurrencyFilter v-model should update v-model if select all checkbox i
                   width="16"
                 >
                   <use
-                    xlink:href="#ec-simple-check"
+                    href="/img/simple-icons.svg#ec-simple-check"
                   />
                 </svg>
               </span>
@@ -3337,7 +3337,7 @@ exports[`EcCurrencyFilter v-model should update v-model if select all checkbox i
                   width="16"
                 >
                   <use
-                    xlink:href="#ec-simple-check"
+                    href="/img/simple-icons.svg#ec-simple-check"
                   />
                 </svg>
               </span>

--- a/src/components/ec-currency-input/__snapshots__/ec-currency-input.spec.js.snap
+++ b/src/components/ec-currency-input/__snapshots__/ec-currency-input.spec.js.snap
@@ -35,7 +35,7 @@ exports[`EcCurrencyInput :props should render a loading state when currenciesLoa
         width="24"
       >
         <use
-          xlink:href="#ec-simple-arrow-drop-down"
+          href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
         />
       </svg>
     </div>
@@ -56,7 +56,7 @@ exports[`EcCurrencyInput :props should render a loading state when currenciesLoa
           class="ec-dropdown-search__search-icon ec-icon"
         >
           <use
-            xlink:href="#ec-simple-search"
+            href="/img/simple-icons.svg#ec-simple-search"
           />
         </svg>
          
@@ -86,7 +86,7 @@ exports[`EcCurrencyInput :props should render a loading state when currenciesLoa
               width="24"
             >
               <use
-                xlink:href="#ec-simple-loading"
+                href="/img/simple-icons.svg#ec-simple-loading"
               />
             </svg>
           </div>
@@ -148,7 +148,7 @@ exports[`EcCurrencyInput :props should render the non-results message passed as 
       class="ec-dropdown-search__search-icon ec-icon"
     >
       <use
-        xlink:href="#ec-simple-search"
+        href="/img/simple-icons.svg#ec-simple-search"
       />
     </svg>
      
@@ -229,7 +229,7 @@ exports[`EcCurrencyInput :props should render without any currencies if the curr
           width="24"
         >
           <use
-            xlink:href="#ec-simple-arrow-drop-down"
+            href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
           />
         </svg>
       </div>
@@ -250,7 +250,7 @@ exports[`EcCurrencyInput :props should render without any currencies if the curr
             class="ec-dropdown-search__search-icon ec-icon"
           >
             <use
-              xlink:href="#ec-simple-search"
+              href="/img/simple-icons.svg#ec-simple-search"
             />
           </svg>
            
@@ -324,7 +324,7 @@ exports[`EcCurrencyInput should render properly 1`] = `
               width="24"
             >
               <use
-                xlink:href="#ec-simple-arrow-drop-down"
+                href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
               />
             </svg>
           </div>
@@ -345,7 +345,7 @@ exports[`EcCurrencyInput should render properly 1`] = `
                 class="ec-dropdown-search__search-icon ec-icon"
               >
                 <use
-                  xlink:href="#ec-simple-search"
+                  href="/img/simple-icons.svg#ec-simple-search"
                 />
               </svg>
                
@@ -462,7 +462,7 @@ exports[`EcCurrencyInput should render with a sensitive class when isSensitive p
               width="24"
             >
               <use
-                xlink:href="#ec-simple-arrow-drop-down"
+                href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
               />
             </svg>
           </div>
@@ -483,7 +483,7 @@ exports[`EcCurrencyInput should render with a sensitive class when isSensitive p
                 class="ec-dropdown-search__search-icon ec-icon"
               >
                 <use
-                  xlink:href="#ec-simple-search"
+                  href="/img/simple-icons.svg#ec-simple-search"
                 />
               </svg>
                
@@ -570,7 +570,7 @@ exports[`EcCurrencyInput when the bottom note is defined and it is a warning not
     width="14"
   >
     <use
-      xlink:href="#ec-simple-error"
+      href="/img/simple-icons.svg#ec-simple-error"
     />
   </svg>
 </div>
@@ -653,7 +653,7 @@ exports[`EcCurrencyInput when the error message is defined and there is a toolti
     width="14"
   >
     <use
-      xlink:href="#ec-simple-error"
+      href="/img/simple-icons.svg#ec-simple-error"
     />
   </svg>
 </div>

--- a/src/components/ec-date-range-filter/__snapshots__/ec-date-range-filter.spec.js.snap
+++ b/src/components/ec-date-range-filter/__snapshots__/ec-date-range-filter.spec.js.snap
@@ -38,7 +38,7 @@ exports[`EcDateRangeFilter should render properly when all the props are given 1
         width="16"
       >
         <use
-          xlink:href="#ec-simple-chevron-down"
+          href="/img/simple-icons.svg#ec-simple-chevron-down"
         />
       </svg>
     </div>
@@ -175,7 +175,7 @@ exports[`EcDateRangeFilter should render properly with an error message when the
         width="16"
       >
         <use
-          xlink:href="#ec-simple-chevron-down"
+          href="/img/simple-icons.svg#ec-simple-chevron-down"
         />
       </svg>
     </div>
@@ -317,7 +317,7 @@ exports[`EcDateRangeFilter should render properly with an error message when the
         width="16"
       >
         <use
-          xlink:href="#ec-simple-chevron-down"
+          href="/img/simple-icons.svg#ec-simple-chevron-down"
         />
       </svg>
     </div>
@@ -461,7 +461,7 @@ exports[`EcDateRangeFilter should render properly with an error message when the
         width="16"
       >
         <use
-          xlink:href="#ec-simple-chevron-down"
+          href="/img/simple-icons.svg#ec-simple-chevron-down"
         />
       </svg>
     </div>
@@ -599,7 +599,7 @@ exports[`EcDateRangeFilter should return undefined if no dates are passed in val
         width="16"
       >
         <use
-          xlink:href="#ec-simple-chevron-down"
+          href="/img/simple-icons.svg#ec-simple-chevron-down"
         />
       </svg>
     </div>

--- a/src/components/ec-donut/__snapshots__/ec-donut.spec.js.snap
+++ b/src/components/ec-donut/__snapshots__/ec-donut.spec.js.snap
@@ -62,7 +62,7 @@ exports[`EcDonut should display empty with minus number in the used prop 1`] = `
         width="14"
       >
         <use
-          xlink:href="#ec-rounded-notification"
+          href="/img/rounded-icons.svg#ec-rounded-notification"
         />
       </svg>
        
@@ -78,7 +78,7 @@ exports[`EcDonut should display empty with minus number in the used prop 1`] = `
         width="14"
       >
         <use
-          xlink:href="#ec-rounded-notification"
+          href="/img/rounded-icons.svg#ec-rounded-notification"
         />
       </svg>
        
@@ -149,7 +149,7 @@ exports[`EcDonut should display only with a the used and amount are given 1`] = 
         width="14"
       >
         <use
-          xlink:href="#ec-rounded-notification"
+          href="/img/rounded-icons.svg#ec-rounded-notification"
         />
       </svg>
        
@@ -165,7 +165,7 @@ exports[`EcDonut should display only with a the used and amount are given 1`] = 
         width="14"
       >
         <use
-          xlink:href="#ec-rounded-notification"
+          href="/img/rounded-icons.svg#ec-rounded-notification"
         />
       </svg>
        
@@ -236,7 +236,7 @@ exports[`EcDonut should display with the empty used 1`] = `
         width="14"
       >
         <use
-          xlink:href="#ec-rounded-notification"
+          href="/img/rounded-icons.svg#ec-rounded-notification"
         />
       </svg>
        
@@ -252,7 +252,7 @@ exports[`EcDonut should display with the empty used 1`] = `
         width="14"
       >
         <use
-          xlink:href="#ec-rounded-notification"
+          href="/img/rounded-icons.svg#ec-rounded-notification"
         />
       </svg>
        
@@ -323,7 +323,7 @@ exports[`EcDonut should display with the full used 1`] = `
         width="14"
       >
         <use
-          xlink:href="#ec-rounded-notification"
+          href="/img/rounded-icons.svg#ec-rounded-notification"
         />
       </svg>
        
@@ -339,7 +339,7 @@ exports[`EcDonut should display with the full used 1`] = `
         width="14"
       >
         <use
-          xlink:href="#ec-rounded-notification"
+          href="/img/rounded-icons.svg#ec-rounded-notification"
         />
       </svg>
        
@@ -410,7 +410,7 @@ exports[`EcDonut should display with the full used when is more used than amount
         width="14"
       >
         <use
-          xlink:href="#ec-rounded-notification"
+          href="/img/rounded-icons.svg#ec-rounded-notification"
         />
       </svg>
        
@@ -426,7 +426,7 @@ exports[`EcDonut should display with the full used when is more used than amount
         width="14"
       >
         <use
-          xlink:href="#ec-rounded-notification"
+          href="/img/rounded-icons.svg#ec-rounded-notification"
         />
       </svg>
        
@@ -497,7 +497,7 @@ exports[`EcDonut should display with the half used 1`] = `
         width="14"
       >
         <use
-          xlink:href="#ec-rounded-notification"
+          href="/img/rounded-icons.svg#ec-rounded-notification"
         />
       </svg>
        
@@ -513,7 +513,7 @@ exports[`EcDonut should display with the half used 1`] = `
         width="14"
       >
         <use
-          xlink:href="#ec-rounded-notification"
+          href="/img/rounded-icons.svg#ec-rounded-notification"
         />
       </svg>
        
@@ -584,7 +584,7 @@ exports[`EcDonut should render slots as expected 1`] = `
         width="14"
       >
         <use
-          xlink:href="#ec-rounded-notification"
+          href="/img/rounded-icons.svg#ec-rounded-notification"
         />
       </svg>
        
@@ -603,7 +603,7 @@ exports[`EcDonut should render slots as expected 1`] = `
         width="14"
       >
         <use
-          xlink:href="#ec-rounded-notification"
+          href="/img/rounded-icons.svg#ec-rounded-notification"
         />
       </svg>
        

--- a/src/components/ec-dropdown-search/__snapshots__/ec-dropdown-search.spec.js.snap
+++ b/src/components/ec-dropdown-search/__snapshots__/ec-dropdown-search.spec.js.snap
@@ -43,7 +43,7 @@ exports[`EcDropdownSearch should add a tooltip for any disabled item 1`] = `
       class="ec-dropdown-search__search-icon ec-icon"
     >
       <use
-        xlink:href="#ec-simple-search"
+        href="/img/simple-icons.svg#ec-simple-search"
       />
     </svg>
      
@@ -121,7 +121,7 @@ exports[`EcDropdownSearch should disable the popover when disabled is set 1`] = 
           class="ec-dropdown-search__search-icon ec-icon"
         >
           <use
-            xlink:href="#ec-simple-search"
+            href="/img/simple-icons.svg#ec-simple-search"
           />
         </svg>
          
@@ -224,7 +224,7 @@ exports[`EcDropdownSearch should not show the items when the loading is set to t
             class="ec-dropdown-search__search-icon ec-icon"
           >
             <use
-              xlink:href="#ec-simple-search"
+              href="/img/simple-icons.svg#ec-simple-search"
             />
           </svg>
            
@@ -254,7 +254,7 @@ exports[`EcDropdownSearch should not show the items when the loading is set to t
                 width="24"
               >
                 <use
-                  xlink:href="#ec-simple-loading"
+                  href="/img/simple-icons.svg#ec-simple-loading"
                 />
               </svg>
             </div>
@@ -303,7 +303,7 @@ exports[`EcDropdownSearch should pass information whether an item is selected to
             class="ec-dropdown-search__search-icon ec-icon"
           >
             <use
-              xlink:href="#ec-simple-search"
+              href="/img/simple-icons.svg#ec-simple-search"
             />
           </svg>
            
@@ -383,7 +383,7 @@ exports[`EcDropdownSearch should render all given items 1`] = `
       class="ec-dropdown-search__search-icon ec-icon"
     >
       <use
-        xlink:href="#ec-simple-search"
+        href="/img/simple-icons.svg#ec-simple-search"
       />
     </svg>
      
@@ -464,7 +464,7 @@ exports[`EcDropdownSearch should render as expected 1`] = `
             class="ec-dropdown-search__search-icon ec-icon"
           >
             <use
-              xlink:href="#ec-simple-search"
+              href="/img/simple-icons.svg#ec-simple-search"
             />
           </svg>
            
@@ -518,7 +518,7 @@ exports[`EcDropdownSearch should render given cta slot 1`] = `
             class="ec-dropdown-search__search-icon ec-icon"
           >
             <use
-              xlink:href="#ec-simple-search"
+              href="/img/simple-icons.svg#ec-simple-search"
             />
           </svg>
            
@@ -609,7 +609,7 @@ exports[`EcDropdownSearch should render given cta slot with a tooltip 1`] = `
             class="ec-dropdown-search__search-icon ec-icon"
           >
             <use
-              xlink:href="#ec-simple-search"
+              href="/img/simple-icons.svg#ec-simple-search"
             />
           </svg>
            
@@ -706,7 +706,7 @@ exports[`EcDropdownSearch should render given default slot 1`] = `
             class="ec-dropdown-search__search-icon ec-icon"
           >
             <use
-              xlink:href="#ec-simple-search"
+              href="/img/simple-icons.svg#ec-simple-search"
             />
           </svg>
            
@@ -760,7 +760,7 @@ exports[`EcDropdownSearch should render given item slot 1`] = `
             class="ec-dropdown-search__search-icon ec-icon"
           >
             <use
-              xlink:href="#ec-simple-search"
+              href="/img/simple-icons.svg#ec-simple-search"
             />
           </svg>
            
@@ -869,7 +869,7 @@ exports[`EcDropdownSearch should render given items slot 1`] = `
             class="ec-dropdown-search__search-icon ec-icon"
           >
             <use
-              xlink:href="#ec-simple-search"
+              href="/img/simple-icons.svg#ec-simple-search"
             />
           </svg>
            
@@ -927,7 +927,7 @@ exports[`EcDropdownSearch should render the search by default 1`] = `
     class="ec-dropdown-search__search-icon ec-icon"
   >
     <use
-      xlink:href="#ec-simple-search"
+      href="/img/simple-icons.svg#ec-simple-search"
     />
   </svg>
    
@@ -973,7 +973,7 @@ exports[`EcDropdownSearch should use given list-data-test attribute 1`] = `
       class="ec-dropdown-search__search-icon ec-icon"
     >
       <use
-        xlink:href="#ec-simple-search"
+        href="/img/simple-icons.svg#ec-simple-search"
       />
     </svg>
      
@@ -1036,7 +1036,7 @@ exports[`EcDropdownSearch should use the placeholder for search input if given 1
     class="ec-dropdown-search__search-icon ec-icon"
   >
     <use
-      xlink:href="#ec-simple-search"
+      href="/img/simple-icons.svg#ec-simple-search"
     />
   </svg>
    

--- a/src/components/ec-dropdown/__snapshots__/ec-dropdown.spec.js.snap
+++ b/src/components/ec-dropdown/__snapshots__/ec-dropdown.spec.js.snap
@@ -121,7 +121,7 @@ exports[`EcDropdown :props renders properly when the labelTooltip prop is set 1`
           width="24"
         >
           <use
-            xlink:href="#ec-simple-arrow-drop-down"
+            href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
           />
         </svg>
       </div>
@@ -153,7 +153,7 @@ exports[`EcDropdown :props should enable search when isSearchEnabled is set to t
     class="ec-dropdown-search__search-icon ec-icon"
   >
     <use
-      xlink:href="#ec-simple-search"
+      href="/img/simple-icons.svg#ec-simple-search"
     />
   </svg>
    
@@ -207,7 +207,7 @@ exports[`EcDropdown :props should get disabled when disabled prop is set 1`] = `
           width="24"
         >
           <use
-            xlink:href="#ec-simple-arrow-drop-down"
+            href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
           />
         </svg>
       </div>
@@ -269,7 +269,7 @@ exports[`EcDropdown :props should not show the items when the loading is set to 
           width="24"
         >
           <use
-            xlink:href="#ec-simple-arrow-drop-down"
+            href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
           />
         </svg>
       </div>
@@ -302,7 +302,7 @@ exports[`EcDropdown :props should not show the items when the loading is set to 
                 width="24"
               >
                 <use
-                  xlink:href="#ec-simple-loading"
+                  href="/img/simple-icons.svg#ec-simple-loading"
                 />
               </svg>
             </div>
@@ -383,7 +383,7 @@ exports[`EcDropdown :props should render with a sensitive class when isSensitive
           width="24"
         >
           <use
-            xlink:href="#ec-simple-arrow-drop-down"
+            href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
           />
         </svg>
       </div>
@@ -426,7 +426,7 @@ exports[`EcDropdown :props should use searchPlaceholder prop if search is enable
     class="ec-dropdown-search__search-icon ec-icon"
   >
     <use
-      xlink:href="#ec-simple-search"
+      href="/img/simple-icons.svg#ec-simple-search"
     />
   </svg>
    
@@ -478,7 +478,7 @@ exports[`EcDropdown should render as expected 1`] = `
           width="24"
         >
           <use
-            xlink:href="#ec-simple-arrow-drop-down"
+            href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
           />
         </svg>
       </div>

--- a/src/components/ec-filter-popover/__snapshots__/ec-filter-popover.spec.js.snap
+++ b/src/components/ec-filter-popover/__snapshots__/ec-filter-popover.spec.js.snap
@@ -38,7 +38,7 @@ exports[`EcFilterPopover should display number of selected filters if the value 
         width="16"
       >
         <use
-          xlink:href="#ec-simple-chevron-down"
+          href="/img/simple-icons.svg#ec-simple-chevron-down"
         />
       </svg>
     </div>
@@ -82,7 +82,7 @@ exports[`EcFilterPopover should not display number of selected filters if the va
         width="16"
       >
         <use
-          xlink:href="#ec-simple-chevron-down"
+          href="/img/simple-icons.svg#ec-simple-chevron-down"
         />
       </svg>
     </div>
@@ -126,7 +126,7 @@ exports[`EcFilterPopover should render correctly the named slot 1`] = `
         width="16"
       >
         <use
-          xlink:href="#ec-simple-chevron-down"
+          href="/img/simple-icons.svg#ec-simple-chevron-down"
         />
       </svg>
     </div>
@@ -174,7 +174,7 @@ exports[`EcFilterPopover should render properly when isFullHeight is set 1`] = `
         width="16"
       >
         <use
-          xlink:href="#ec-simple-chevron-down"
+          href="/img/simple-icons.svg#ec-simple-chevron-down"
         />
       </svg>
     </div>
@@ -218,7 +218,7 @@ exports[`EcFilterPopover should render properly when label prop was given 1`] = 
         width="16"
       >
         <use
-          xlink:href="#ec-simple-chevron-down"
+          href="/img/simple-icons.svg#ec-simple-chevron-down"
         />
       </svg>
     </div>
@@ -262,7 +262,7 @@ exports[`EcFilterPopover should reset the open status of the popover 1`] = `
         width="16"
       >
         <use
-          xlink:href="#ec-simple-chevron-down"
+          href="/img/simple-icons.svg#ec-simple-chevron-down"
         />
       </svg>
     </div>
@@ -306,7 +306,7 @@ exports[`EcFilterPopover should set the open status of the popover 1`] = `
         width="16"
       >
         <use
-          xlink:href="#ec-simple-chevron-down"
+          href="/img/simple-icons.svg#ec-simple-chevron-down"
         />
       </svg>
     </div>

--- a/src/components/ec-icon/__snapshots__/ec-icon.spec.js.snap
+++ b/src/components/ec-icon/__snapshots__/ec-icon.spec.js.snap
@@ -1,11 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`EcIcon should allow to use any sprite url 1`] = `
+<svg
+  class="ec-icon"
+>
+  <use
+    href="/custom/sprite.svg#ec-random-icon"
+  />
+</svg>
+`;
+
+exports[`EcIcon should allow to use icon from inline sprite 1`] = `
+<svg
+  class="ec-icon"
+>
+  <use
+    href="#ec-random-icon"
+  />
+</svg>
+`;
+
 exports[`EcIcon should render properly when a name was given 1`] = `
 <svg
   class="ec-icon"
 >
   <use
-    xlink:href="#ec-random-icon"
+    href="/img/simple-icons.svg#ec-simple-random-icon"
   />
 </svg>
 `;
@@ -17,7 +37,37 @@ exports[`EcIcon should use the given size prop 1`] = `
   width="16"
 >
   <use
-    xlink:href="#ec-random-icon"
+    href="/img/simple-icons.svg#ec-simple-random-icon"
+  />
+</svg>
+`;
+
+exports[`EcIcon should use the icon from the sprite "currency" 1`] = `
+<svg
+  class="ec-icon"
+>
+  <use
+    href="/img/currency-flags.svg#ec-currency-random-icon"
+  />
+</svg>
+`;
+
+exports[`EcIcon should use the icon from the sprite "rounded" 1`] = `
+<svg
+  class="ec-icon"
+>
+  <use
+    href="/img/rounded-icons.svg#ec-rounded-random-icon"
+  />
+</svg>
+`;
+
+exports[`EcIcon should use the icon from the sprite "simple" 1`] = `
+<svg
+  class="ec-icon"
+>
+  <use
+    href="/img/simple-icons.svg#ec-simple-random-icon"
   />
 </svg>
 `;
@@ -27,7 +77,7 @@ exports[`EcIcon should use the type "error" 1`] = `
   class="ec-icon ec-icon--error"
 >
   <use
-    xlink:href="#ec-random-icon"
+    href="/img/simple-icons.svg#ec-simple-random-icon"
   />
 </svg>
 `;
@@ -37,7 +87,7 @@ exports[`EcIcon should use the type "info" 1`] = `
   class="ec-icon ec-icon--info"
 >
   <use
-    xlink:href="#ec-random-icon"
+    href="/img/simple-icons.svg#ec-simple-random-icon"
   />
 </svg>
 `;
@@ -47,7 +97,7 @@ exports[`EcIcon should use the type "success" 1`] = `
   class="ec-icon ec-icon--success"
 >
   <use
-    xlink:href="#ec-random-icon"
+    href="/img/simple-icons.svg#ec-simple-random-icon"
   />
 </svg>
 `;
@@ -57,7 +107,7 @@ exports[`EcIcon should use the type "warning" 1`] = `
   class="ec-icon ec-icon--warning"
 >
   <use
-    xlink:href="#ec-random-icon"
+    href="/img/simple-icons.svg#ec-simple-random-icon"
   />
 </svg>
 `;

--- a/src/components/ec-icon/ec-icon-sprite.js
+++ b/src/components/ec-icon/ec-icon-sprite.js
@@ -1,0 +1,29 @@
+import config from '../../config';
+
+const spriteSourceUrls = new Map([
+  ['rounded', '/rounded-icons.svg'],
+  ['simple', '/simple-icons.svg'],
+  ['currency', '/currency-flags.svg'],
+]);
+
+export function getSpriteSourceByName(iconFullName) {
+  /* istanbul ignore if */
+  if (!iconFullName) {
+    throw new Error('Missing iconFullName');
+  }
+
+  const [spriteName, iconName] = iconFullName.split('-');
+  if (!spriteName || !iconName) {
+    throw new Error(`Unable to determine the source of SVG sprite for icon with name: ${iconFullName}`);
+  }
+  return getSpriteUrl(spriteName);
+}
+
+function getSpriteUrl(spriteName) {
+  const spriteUrl = spriteSourceUrls.get(spriteName);
+  if (!spriteUrl) {
+    throw new Error(`The sprite "${spriteName}" doesn't exist.`);
+  }
+
+  return `${config.iconsPublicPath}${spriteUrl}`;
+}

--- a/src/components/ec-icon/ec-icon.spec.js
+++ b/src/components/ec-icon/ec-icon.spec.js
@@ -3,37 +3,79 @@ import EcIcon from './ec-icon.vue';
 import { withMockedConsole } from '../../../tests/utils/console';
 
 describe('EcIcon', () => {
+  function mountEcIcon(props, mountOpts) {
+    return mount(EcIcon, {
+      propsData: { ...props },
+      ...mountOpts,
+    });
+  }
+
   it('should throw if no props were given', () => {
     withMockedConsole((errorSpy) => {
-      mount(EcIcon);
+      mountEcIcon();
       expect(errorSpy).toHaveBeenCalledTimes(1);
       expect(errorSpy.mock.calls[0][0]).toContain('Missing required prop: "name"');
     });
   });
 
+  it('should throw if svg sprite does not exist', () => {
+    withMockedConsole((errorSpy) => {
+      expect(() => {
+        mountEcIcon({ name: 'random-icon' });
+      }).toThrowError('The sprite "random" doesn\'t exist');
+      expect(errorSpy).toHaveBeenCalledTimes(2);
+      expect(errorSpy.mock.calls[0][0]).toContain('The sprite "random" doesn\'t exist');
+      expect(errorSpy.mock.calls[1][0]).toEqual(new Error('The sprite "random" doesn\'t exist.'));
+    });
+  });
+
+  it('should throw if sprite cannot be determined from the icon\'s name', () => {
+    withMockedConsole((errorSpy) => {
+      expect(() => {
+        mountEcIcon({ name: 'random' });
+      }).toThrowError('Unable to determine the source of SVG sprite for icon with name: random');
+      expect(errorSpy).toHaveBeenCalledTimes(2);
+      expect(errorSpy.mock.calls[0][0]).toContain('Unable to determine the source of SVG sprite for icon with name: random');
+      expect(errorSpy.mock.calls[1][0]).toEqual(new Error('Unable to determine the source of SVG sprite for icon with name: random'));
+    });
+  });
+
   it('should render properly when a name was given', () => {
-    const wrapper = mount(EcIcon, { propsData: { name: 'random-icon' } });
+    const wrapper = mount(EcIcon, { propsData: { name: 'simple-random-icon' } });
 
     expect(wrapper.element).toMatchSnapshot();
   });
 
   it('should use the given size prop', () => {
-    const wrapper = mount(EcIcon, { propsData: { name: 'random-icon', size: 16 } });
-
+    const wrapper = mountEcIcon({ name: 'simple-random-icon', size: 16 });
     expect(wrapper.element).toMatchSnapshot();
   });
 
   it.each(['error', 'info', 'success', 'warning'])('should use the type "%s"', (type) => {
-    const wrapper = mount(EcIcon, { propsData: { name: 'random-icon', type } });
-
+    const wrapper = mountEcIcon({ name: 'simple-random-icon', type });
     expect(wrapper.element).toMatchSnapshot();
   });
 
   it('should throw an error if type is not valid', () => {
     withMockedConsole((errorSpy) => {
-      mount(EcIcon, { propsData: { name: 'random-icon', type: 'invalid-value' } });
+      mountEcIcon({ name: 'simple-random-icon', type: 'invalid-value' });
       expect(errorSpy).toHaveBeenCalledTimes(1);
       expect(errorSpy.mock.calls[0][0]).toContain('Invalid prop: custom validator check failed for prop "type"');
     });
+  });
+
+  it('should allow to use icon from inline sprite', () => {
+    const wrapper = mountEcIcon({ name: 'random-icon', spriteSource: 'inline' });
+    expect(wrapper.element).toMatchSnapshot();
+  });
+
+  it('should allow to use any sprite url', () => {
+    const wrapper = mountEcIcon({ name: 'random-icon', spriteSource: '/custom/sprite.svg' });
+    expect(wrapper.element).toMatchSnapshot();
+  });
+
+  it.each(['simple', 'rounded', 'currency'])('should use the icon from the sprite "%s"', (sprite) => {
+    const wrapper = mountEcIcon({ name: `${sprite}-random-icon` });
+    expect(wrapper.element).toMatchSnapshot();
   });
 });

--- a/src/components/ec-icon/ec-icon.vue
+++ b/src/components/ec-icon/ec-icon.vue
@@ -5,11 +5,13 @@
     :class="['ec-icon', typeClass]"
     v-on="$listeners"
   >
-    <use :xlink:href="`#ec-${name}`" />
+    <use :href="iconUrl" />
   </svg>
 </template>
 
 <script>
+import { getSpriteSourceByName } from './ec-icon-sprite';
+
 export default {
   name: 'EcIcon',
   props: {
@@ -26,8 +28,24 @@ export default {
         return ['error', 'info', 'success', 'warning', 'interactive'].includes(value);
       },
     },
+    spriteSource: {
+      type: String,
+      default: 'auto',
+    },
   },
   computed: {
+    iconUrl() {
+      if (!this.name) {
+        return null;
+      }
+
+      if (this.spriteSource === 'inline') {
+        return `#ec-${this.name}`;
+      }
+
+      const spriteUrl = this.spriteSource === 'auto' ? getSpriteSourceByName(this.name) : this.spriteSource;
+      return `${spriteUrl}#ec-${this.name}`;
+    },
     typeClass() {
       return this.type ? `ec-icon--${this.type}` : null;
     },

--- a/src/components/ec-inline-actions/__snapshots__/ec-inline-actions.spec.js.snap
+++ b/src/components/ec-inline-actions/__snapshots__/ec-inline-actions.spec.js.snap
@@ -258,7 +258,7 @@ exports[`EcInlineActions should render the item with an icon when a item was giv
             width="24"
           >
             <use
-              xlink:href="#ec-simple-block"
+              href="/img/simple-icons.svg#ec-simple-block"
             />
           </svg>
            
@@ -304,7 +304,7 @@ exports[`EcInlineActions should render the item with default popover options 1`]
             width="24"
           >
             <use
-              xlink:href="#ec-simple-block"
+              href="/img/simple-icons.svg#ec-simple-block"
             />
           </svg>
            
@@ -350,7 +350,7 @@ exports[`EcInlineActions should render the item with given popover options 1`] =
             width="24"
           >
             <use
-              xlink:href="#ec-simple-block"
+              href="/img/simple-icons.svg#ec-simple-block"
             />
           </svg>
            

--- a/src/components/ec-inline-input-field/__snapshots__/ec-inline-input-field.spec.js.snap
+++ b/src/components/ec-inline-input-field/__snapshots__/ec-inline-input-field.spec.js.snap
@@ -35,7 +35,7 @@ exports[`EcInlineInputField when component is copiable should render as expected
         width="16"
       >
         <use
-          xlink:href="#ec-simple-copy"
+          href="/img/simple-icons.svg#ec-simple-copy"
         />
       </svg>
     </button>
@@ -59,7 +59,7 @@ exports[`EcInlineInputField when component is copiable should render with a labe
       width="14"
     >
       <use
-        xlink:href="#ec-simple-info"
+        href="/img/simple-icons.svg#ec-simple-info"
       />
     </svg>
   </div>
@@ -87,7 +87,7 @@ exports[`EcInlineInputField when component is copiable should render with a labe
         width="16"
       >
         <use
-          xlink:href="#ec-simple-edit"
+          href="/img/simple-icons.svg#ec-simple-edit"
         />
       </svg>
     </button>
@@ -130,7 +130,7 @@ exports[`EcInlineInputField when component is copiable should render with a sens
         width="16"
       >
         <use
-          xlink:href="#ec-simple-copy"
+          href="/img/simple-icons.svg#ec-simple-copy"
         />
       </svg>
     </button>
@@ -190,7 +190,7 @@ exports[`EcInlineInputField when component is editable when the component is in 
             width="16"
           >
             <use
-              xlink:href="#ec-simple-check"
+              href="/img/simple-icons.svg#ec-simple-check"
             />
           </svg>
         </button>
@@ -206,7 +206,7 @@ exports[`EcInlineInputField when component is editable when the component is in 
             width="16"
           >
             <use
-              xlink:href="#ec-simple-close"
+              href="/img/simple-icons.svg#ec-simple-close"
             />
           </svg>
         </button>
@@ -275,7 +275,7 @@ exports[`EcInlineInputField when component is editable when the component is in 
             width="16"
           >
             <use
-              xlink:href="#ec-simple-check"
+              href="/img/simple-icons.svg#ec-simple-check"
             />
           </svg>
         </button>
@@ -291,7 +291,7 @@ exports[`EcInlineInputField when component is editable when the component is in 
             width="16"
           >
             <use
-              xlink:href="#ec-simple-close"
+              href="/img/simple-icons.svg#ec-simple-close"
             />
           </svg>
         </button>
@@ -353,7 +353,7 @@ exports[`EcInlineInputField when component is editable when the component is in 
             width="16"
           >
             <use
-              xlink:href="#ec-simple-check"
+              href="/img/simple-icons.svg#ec-simple-check"
             />
           </svg>
         </button>
@@ -369,7 +369,7 @@ exports[`EcInlineInputField when component is editable when the component is in 
             width="16"
           >
             <use
-              xlink:href="#ec-simple-close"
+              href="/img/simple-icons.svg#ec-simple-close"
             />
           </svg>
         </button>
@@ -413,7 +413,7 @@ exports[`EcInlineInputField when component is editable when the component is in 
         width="16"
       >
         <use
-          xlink:href="#ec-simple-edit"
+          href="/img/simple-icons.svg#ec-simple-edit"
         />
       </svg>
     </button>
@@ -437,7 +437,7 @@ exports[`EcInlineInputField when component is editable when the component is in 
       width="14"
     >
       <use
-        xlink:href="#ec-simple-info"
+        href="/img/simple-icons.svg#ec-simple-info"
       />
     </svg>
   </div>
@@ -465,7 +465,7 @@ exports[`EcInlineInputField when component is editable when the component is in 
         width="16"
       >
         <use
-          xlink:href="#ec-simple-edit"
+          href="/img/simple-icons.svg#ec-simple-edit"
         />
       </svg>
     </button>
@@ -507,7 +507,7 @@ exports[`EcInlineInputField when component is editable when the component is in 
         width="16"
       >
         <use
-          xlink:href="#ec-simple-edit"
+          href="/img/simple-icons.svg#ec-simple-edit"
         />
       </svg>
     </button>
@@ -555,7 +555,7 @@ exports[`EcInlineInputField when component is editable when the component is loa
           width="24"
         >
           <use
-            xlink:href="#ec-simple-loading"
+            href="/img/simple-icons.svg#ec-simple-loading"
           />
         </svg>
       </div>
@@ -572,7 +572,7 @@ exports[`EcInlineInputField when component is editable when the component is loa
         width="16"
       >
         <use
-          xlink:href="#ec-simple-check"
+          href="/img/simple-icons.svg#ec-simple-check"
         />
       </svg>
        
@@ -582,7 +582,7 @@ exports[`EcInlineInputField when component is editable when the component is loa
         width="16"
       >
         <use
-          xlink:href="#ec-simple-close"
+          href="/img/simple-icons.svg#ec-simple-close"
         />
       </svg>
     </div>
@@ -630,7 +630,7 @@ exports[`EcInlineInputField when component is editable when the component is loa
           width="24"
         >
           <use
-            xlink:href="#ec-simple-loading"
+            href="/img/simple-icons.svg#ec-simple-loading"
           />
         </svg>
       </div>
@@ -647,7 +647,7 @@ exports[`EcInlineInputField when component is editable when the component is loa
         width="16"
       >
         <use
-          xlink:href="#ec-simple-check"
+          href="/img/simple-icons.svg#ec-simple-check"
         />
       </svg>
        
@@ -657,7 +657,7 @@ exports[`EcInlineInputField when component is editable when the component is loa
         width="16"
       >
         <use
-          xlink:href="#ec-simple-close"
+          href="/img/simple-icons.svg#ec-simple-close"
         />
       </svg>
     </div>

--- a/src/components/ec-input-field/__snapshots__/ec-input-field.spec.js.snap
+++ b/src/components/ec-input-field/__snapshots__/ec-input-field.spec.js.snap
@@ -45,7 +45,7 @@ exports[`EcInputField renders properly the icon when disabled 1`] = `
       width="20"
     >
       <use
-        xlink:href="#ec-simple-check"
+        href="/img/simple-icons.svg#ec-simple-check"
       />
     </svg>
   </div>
@@ -138,7 +138,7 @@ exports[`EcInputField renders properly when is loading 1`] = `
       width="24"
     >
       <use
-        xlink:href="#ec-simple-loading"
+        href="/img/simple-icons.svg#ec-simple-loading"
       />
     </svg>
   </div>
@@ -170,7 +170,7 @@ exports[`EcInputField renders properly when the labelTooltip prop is set 1`] = `
         width="14"
       >
         <use
-          xlink:href="#ec-simple-info"
+          href="/img/simple-icons.svg#ec-simple-info"
         />
       </svg>
     </span>
@@ -692,7 +692,7 @@ exports[`EcInputField should render given icon 1`] = `
       width="20"
     >
       <use
-        xlink:href="#ec-simple-check"
+        href="/img/simple-icons.svg#ec-simple-check"
       />
     </svg>
   </div>
@@ -713,7 +713,7 @@ exports[`EcInputField should render given icon with given size 1`] = `
     width="40"
   >
     <use
-      xlink:href="#ec-simple-check"
+      href="/img/simple-icons.svg#ec-simple-check"
     />
   </svg>
 </div>

--- a/src/components/ec-loading-icon/__snapshots__/ec-loading-icon.spec.js.snap
+++ b/src/components/ec-loading-icon/__snapshots__/ec-loading-icon.spec.js.snap
@@ -8,7 +8,7 @@ exports[`EcLoadingIcon should render properly using the given size prop 1`] = `
   width="16"
 >
   <use
-    xlink:href="#ec-simple-loading"
+    href="/img/simple-icons.svg#ec-simple-loading"
   />
 </svg>
 `;

--- a/src/components/ec-loading/__snapshots__/ec-loading.spec.js.snap
+++ b/src/components/ec-loading/__snapshots__/ec-loading.spec.js.snap
@@ -30,7 +30,7 @@ exports[`EcLoading should render as expected 1`] = `
       width="48"
     >
       <use
-        xlink:href="#ec-simple-loading"
+        href="/img/simple-icons.svg#ec-simple-loading"
       />
     </svg>
   </div>
@@ -58,7 +58,7 @@ exports[`EcLoading should render the given slot 1`] = `
       width="48"
     >
       <use
-        xlink:href="#ec-simple-loading"
+        href="/img/simple-icons.svg#ec-simple-loading"
       />
     </svg>
   </div>
@@ -90,7 +90,7 @@ exports[`EcLoading should render the loading with a given icon size when the pro
       width="30"
     >
       <use
-        xlink:href="#ec-simple-loading"
+        href="/img/simple-icons.svg#ec-simple-loading"
       />
     </svg>
   </div>
@@ -132,7 +132,7 @@ exports[`EcLoading should render the loading without the content visible if the 
       width="48"
     >
       <use
-        xlink:href="#ec-simple-loading"
+        href="/img/simple-icons.svg#ec-simple-loading"
       />
     </svg>
   </div>

--- a/src/components/ec-menu/__snapshots__/ec-menu.spec.js.snap
+++ b/src/components/ec-menu/__snapshots__/ec-menu.spec.js.snap
@@ -21,7 +21,7 @@ exports[`EcMenu should attach custom listeners passed in the link definition 1`]
         width="24"
       >
         <use
-          xlink:href="#ec-foo-icon"
+          href="/img/simple-icons.svg#ec-simple-foo-icon"
         />
       </svg>
        
@@ -62,7 +62,7 @@ exports[`EcMenu should not render all items as compact when horizontal is not se
         width="24"
       >
         <use
-          xlink:href="#ec-foo-icon"
+          href="/img/simple-icons.svg#ec-simple-foo-icon"
         />
       </svg>
        
@@ -94,7 +94,7 @@ exports[`EcMenu should not render all items as compact when horizontal is not se
         width="24"
       >
         <use
-          xlink:href="#ec-baz-icon"
+          href="/img/simple-icons.svg#ec-simple-baz-icon"
         />
       </svg>
        
@@ -140,7 +140,7 @@ exports[`EcMenu should render all items as compact when is horizontal 1`] = `
         width="24"
       >
         <use
-          xlink:href="#ec-foo-icon"
+          href="/img/simple-icons.svg#ec-simple-foo-icon"
         />
       </svg>
        
@@ -172,7 +172,7 @@ exports[`EcMenu should render all items as compact when is horizontal 1`] = `
         width="24"
       >
         <use
-          xlink:href="#ec-baz-icon"
+          href="/img/simple-icons.svg#ec-simple-baz-icon"
         />
       </svg>
        
@@ -212,7 +212,7 @@ exports[`EcMenu should render as collapsed when isCollapsed is passed into 1`] =
         width="24"
       >
         <use
-          xlink:href="#ec-foo-icon"
+          href="/img/simple-icons.svg#ec-simple-foo-icon"
         />
       </svg>
        
@@ -245,7 +245,7 @@ exports[`EcMenu should render as collapsed when isCollapsed is passed into 1`] =
         width="24"
       >
         <use
-          xlink:href="#ec-baz-icon"
+          href="/img/simple-icons.svg#ec-simple-baz-icon"
         />
       </svg>
        
@@ -286,7 +286,7 @@ exports[`EcMenu should render as expanded by default 1`] = `
         width="24"
       >
         <use
-          xlink:href="#ec-foo-icon"
+          href="/img/simple-icons.svg#ec-simple-foo-icon"
         />
       </svg>
        
@@ -318,7 +318,7 @@ exports[`EcMenu should render as expanded by default 1`] = `
         width="24"
       >
         <use
-          xlink:href="#ec-baz-icon"
+          href="/img/simple-icons.svg#ec-simple-baz-icon"
         />
       </svg>
        
@@ -358,7 +358,7 @@ exports[`EcMenu should render as expected when set to horizontal 1`] = `
         width="24"
       >
         <use
-          xlink:href="#ec-foo-icon"
+          href="/img/simple-icons.svg#ec-simple-foo-icon"
         />
       </svg>
        
@@ -398,7 +398,7 @@ exports[`EcMenu should render only links with a url property 1`] = `
         width="24"
       >
         <use
-          xlink:href="#ec-foo-icon"
+          href="/img/simple-icons.svg#ec-simple-foo-icon"
         />
       </svg>
        
@@ -430,7 +430,7 @@ exports[`EcMenu should render only links with a url property 1`] = `
         width="24"
       >
         <use
-          xlink:href="#ec-baz-icon"
+          href="/img/simple-icons.svg#ec-simple-baz-icon"
         />
       </svg>
        

--- a/src/components/ec-menu/ec-menu.spec.js
+++ b/src/components/ec-menu/ec-menu.spec.js
@@ -4,23 +4,23 @@ import EcMenu from './ec-menu.vue';
 const links = [
   {
     url: '/foo',
-    iconName: 'foo-icon',
+    iconName: 'simple-foo-icon',
     text: 'Foo',
     dataTest: 'foo',
   },
   {
     link: '/bar',
-    iconName: 'bar-icon',
+    iconName: 'simple-bar-icon',
     text: 'Bar',
   },
   {
-    iconName: 'baz-icon',
+    iconName: 'simple-baz-icon',
     text: 'Baz',
     dataTest: 'baz',
   },
   {
     url: '/bat',
-    iconName: 'baz-icon',
+    iconName: 'simple-baz-icon',
     text: 'Bat',
   },
 ];

--- a/src/components/ec-metroline/__snapshots__/ec-metroline.spec.js.snap
+++ b/src/components/ec-metroline/__snapshots__/ec-metroline.spec.js.snap
@@ -306,7 +306,7 @@ exports[`EcMetroline order should have the correct next item order if we show, h
           width="14"
         >
           <use
-            xlink:href="#ec-simple-check"
+            href="/img/simple-icons.svg#ec-simple-check"
           />
         </svg>
       </div>
@@ -531,7 +531,7 @@ exports[`EcMetroline order should have the correct next item order if we show, h
           width="14"
         >
           <use
-            xlink:href="#ec-simple-check"
+            href="/img/simple-icons.svg#ec-simple-check"
           />
         </svg>
       </div>
@@ -613,7 +613,7 @@ exports[`EcMetroline order should have the correct next item order if we show, h
           width="14"
         >
           <use
-            xlink:href="#ec-simple-check"
+            href="/img/simple-icons.svg#ec-simple-check"
           />
         </svg>
       </div>
@@ -941,7 +941,7 @@ exports[`EcMetroline permissions should be able to go back to a previous item if
           width="14"
         >
           <use
-            xlink:href="#ec-simple-check"
+            href="/img/simple-icons.svg#ec-simple-check"
           />
         </svg>
       </div>
@@ -1305,7 +1305,7 @@ exports[`EcMetroline permissions should complete the metroline if we click on co
           width="14"
         >
           <use
-            xlink:href="#ec-simple-check"
+            href="/img/simple-icons.svg#ec-simple-check"
           />
         </svg>
       </div>
@@ -1410,7 +1410,7 @@ exports[`EcMetroline permissions should complete the metroline if we click on co
           width="14"
         >
           <use
-            xlink:href="#ec-simple-check"
+            href="/img/simple-icons.svg#ec-simple-check"
           />
         </svg>
       </div>
@@ -1512,7 +1512,7 @@ exports[`EcMetroline permissions should not be able to go back to a previous ite
           width="14"
         >
           <use
-            xlink:href="#ec-simple-check"
+            href="/img/simple-icons.svg#ec-simple-check"
           />
         </svg>
       </div>
@@ -1617,7 +1617,7 @@ exports[`EcMetroline permissions should not be able to go back to a previous ite
           width="14"
         >
           <use
-            xlink:href="#ec-simple-check"
+            href="/img/simple-icons.svg#ec-simple-check"
           />
         </svg>
       </div>
@@ -1719,7 +1719,7 @@ exports[`EcMetroline permissions should not go to next if we click continue on a
           width="14"
         >
           <use
-            xlink:href="#ec-simple-check"
+            href="/img/simple-icons.svg#ec-simple-check"
           />
         </svg>
       </div>
@@ -1920,7 +1920,7 @@ exports[`EcMetroline permissions should not go to next if we click continue on a
           width="14"
         >
           <use
-            xlink:href="#ec-simple-check"
+            href="/img/simple-icons.svg#ec-simple-check"
           />
         </svg>
       </div>

--- a/src/components/ec-modal/__snapshots__/ec-modal.spec.js.snap
+++ b/src/components/ec-modal/__snapshots__/ec-modal.spec.js.snap
@@ -22,7 +22,7 @@ exports[`EcModal should have the ec-modal--lg class 1`] = `
         width="24"
       >
         <use
-          xlink:href="#ec-simple-close"
+          href="/img/simple-icons.svg#ec-simple-close"
         />
       </svg>
     </a>
@@ -64,7 +64,7 @@ exports[`EcModal should have the style attribute z-index when the z-index props 
           width="24"
         >
           <use
-            xlink:href="#ec-simple-close"
+            href="/img/simple-icons.svg#ec-simple-close"
           />
         </svg>
       </a>
@@ -127,7 +127,7 @@ exports[`EcModal should render basic modal 1`] = `
             width="24"
           >
             <use
-              xlink:href="#ec-simple-close"
+              href="/img/simple-icons.svg#ec-simple-close"
             />
           </svg>
         </a>
@@ -166,7 +166,7 @@ exports[`EcModal should render close button 1`] = `
       width="24"
     >
       <use
-        xlink:href="#ec-simple-close"
+        href="/img/simple-icons.svg#ec-simple-close"
       />
     </svg>
   </a>
@@ -295,7 +295,7 @@ exports[`EcModal should render negative button with the loading status if slot i
         width="48"
       >
         <use
-          xlink:href="#ec-simple-loading"
+          href="/img/simple-icons.svg#ec-simple-loading"
         />
       </svg>
     </div>
@@ -431,7 +431,7 @@ exports[`EcModal should render positive button with the loading status if slot i
         width="48"
       >
         <use
-          xlink:href="#ec-simple-loading"
+          href="/img/simple-icons.svg#ec-simple-loading"
         />
       </svg>
     </div>
@@ -498,7 +498,7 @@ exports[`EcModal v-model should render the modal when we pass to model true 1`] 
             width="24"
           >
             <use
-              xlink:href="#ec-simple-close"
+              href="/img/simple-icons.svg#ec-simple-close"
             />
           </svg>
         </a>

--- a/src/components/ec-multiple-values-selection/__snapshots__/ec-multiple-values-selection.spec.js.snap
+++ b/src/components/ec-multiple-values-selection/__snapshots__/ec-multiple-values-selection.spec.js.snap
@@ -54,7 +54,7 @@ exports[`EcMultipleValuesSelection search should not have the search visible if 
                   width="24"
                 >
                   <use
-                    xlink:href="#ec-rounded-check"
+                    href="/img/rounded-icons.svg#ec-rounded-check"
                   />
                 </svg>
                  
@@ -109,7 +109,7 @@ exports[`EcMultipleValuesSelection search should not have the search visible if 
                   width="24"
                 >
                   <use
-                    xlink:href="#ec-rounded-partial"
+                    href="/img/rounded-icons.svg#ec-rounded-partial"
                   />
                 </svg>
                  
@@ -164,7 +164,7 @@ exports[`EcMultipleValuesSelection search should not have the search visible if 
                   width="24"
                 >
                   <use
-                    xlink:href="#ec-rounded-cancelled"
+                    href="/img/rounded-icons.svg#ec-rounded-cancelled"
                   />
                 </svg>
                  
@@ -200,7 +200,7 @@ exports[`EcMultipleValuesSelection search should render properly when isSearchab
       width="20"
     >
       <use
-        xlink:href="#ec-simple-search"
+        href="/img/simple-icons.svg#ec-simple-search"
       />
     </svg>
      
@@ -260,7 +260,7 @@ exports[`EcMultipleValuesSelection search should render properly when isSearchab
                   width="24"
                 >
                   <use
-                    xlink:href="#ec-rounded-check"
+                    href="/img/rounded-icons.svg#ec-rounded-check"
                   />
                 </svg>
                  
@@ -315,7 +315,7 @@ exports[`EcMultipleValuesSelection search should render properly when isSearchab
                   width="24"
                 >
                   <use
-                    xlink:href="#ec-rounded-partial"
+                    href="/img/rounded-icons.svg#ec-rounded-partial"
                   />
                 </svg>
                  
@@ -370,7 +370,7 @@ exports[`EcMultipleValuesSelection search should render properly when isSearchab
                   width="24"
                 >
                   <use
-                    xlink:href="#ec-rounded-cancelled"
+                    href="/img/rounded-icons.svg#ec-rounded-cancelled"
                   />
                 </svg>
                  
@@ -455,7 +455,7 @@ exports[`EcMultipleValuesSelection should render correctly if all the required p
                   width="24"
                 >
                   <use
-                    xlink:href="#ec-rounded-check"
+                    href="/img/rounded-icons.svg#ec-rounded-check"
                   />
                 </svg>
                  
@@ -510,7 +510,7 @@ exports[`EcMultipleValuesSelection should render correctly if all the required p
                   width="24"
                 >
                   <use
-                    xlink:href="#ec-rounded-partial"
+                    href="/img/rounded-icons.svg#ec-rounded-partial"
                   />
                 </svg>
                  
@@ -565,7 +565,7 @@ exports[`EcMultipleValuesSelection should render correctly if all the required p
                   width="24"
                 >
                   <use
-                    xlink:href="#ec-rounded-cancelled"
+                    href="/img/rounded-icons.svg#ec-rounded-cancelled"
                   />
                 </svg>
                  
@@ -603,7 +603,7 @@ exports[`EcMultipleValuesSelection should render loading state 1`] = `
       width="32"
     >
       <use
-        xlink:href="#ec-simple-loading"
+        href="/img/simple-icons.svg#ec-simple-loading"
       />
     </svg>
   </div>
@@ -627,7 +627,7 @@ exports[`EcMultipleValuesSelection should set the empty state icon 1`] = `
       width="32"
     >
       <use
-        xlink:href="#ec-simple-check"
+        href="/img/simple-icons.svg#ec-simple-check"
       />
     </svg>
      
@@ -657,7 +657,7 @@ exports[`EcMultipleValuesSelection should set the empty state message 1`] = `
       width="32"
     >
       <use
-        xlink:href="#ec-simple-error"
+        href="/img/simple-icons.svg#ec-simple-error"
       />
     </svg>
      
@@ -687,7 +687,7 @@ exports[`EcMultipleValuesSelection should set the error icon 1`] = `
       width="32"
     >
       <use
-        xlink:href="#ec-simple-check"
+        href="/img/simple-icons.svg#ec-simple-check"
       />
     </svg>
      
@@ -717,7 +717,7 @@ exports[`EcMultipleValuesSelection should set the error message 1`] = `
       width="32"
     >
       <use
-        xlink:href="#ec-simple-error"
+        href="/img/simple-icons.svg#ec-simple-error"
       />
     </svg>
      
@@ -763,7 +763,7 @@ exports[`EcMultipleValuesSelection should toggle (select/unselect) all options c
             width="16"
           >
             <use
-              xlink:href="#ec-simple-check"
+              href="/img/simple-icons.svg#ec-simple-check"
             />
           </svg>
         </span>
@@ -813,7 +813,7 @@ exports[`EcMultipleValuesSelection should toggle (select/unselect) all options c
                 width="16"
               >
                 <use
-                  xlink:href="#ec-simple-check"
+                  href="/img/simple-icons.svg#ec-simple-check"
                 />
               </svg>
             </span>
@@ -833,7 +833,7 @@ exports[`EcMultipleValuesSelection should toggle (select/unselect) all options c
                   width="24"
                 >
                   <use
-                    xlink:href="#ec-rounded-check"
+                    href="/img/rounded-icons.svg#ec-rounded-check"
                   />
                 </svg>
                  
@@ -876,7 +876,7 @@ exports[`EcMultipleValuesSelection should toggle (select/unselect) all options c
                 width="16"
               >
                 <use
-                  xlink:href="#ec-simple-check"
+                  href="/img/simple-icons.svg#ec-simple-check"
                 />
               </svg>
             </span>
@@ -896,7 +896,7 @@ exports[`EcMultipleValuesSelection should toggle (select/unselect) all options c
                   width="24"
                 >
                   <use
-                    xlink:href="#ec-rounded-partial"
+                    href="/img/rounded-icons.svg#ec-rounded-partial"
                   />
                 </svg>
                  
@@ -939,7 +939,7 @@ exports[`EcMultipleValuesSelection should toggle (select/unselect) all options c
                 width="16"
               >
                 <use
-                  xlink:href="#ec-simple-check"
+                  href="/img/simple-icons.svg#ec-simple-check"
                 />
               </svg>
             </span>
@@ -959,7 +959,7 @@ exports[`EcMultipleValuesSelection should toggle (select/unselect) all options c
                   width="24"
                 >
                   <use
-                    xlink:href="#ec-rounded-cancelled"
+                    href="/img/rounded-icons.svg#ec-rounded-cancelled"
                   />
                 </svg>
                  
@@ -1071,7 +1071,7 @@ exports[`EcMultipleValuesSelection should toggle (select/unselect) all options c
                   width="24"
                 >
                   <use
-                    xlink:href="#ec-rounded-check"
+                    href="/img/rounded-icons.svg#ec-rounded-check"
                   />
                 </svg>
                  
@@ -1126,7 +1126,7 @@ exports[`EcMultipleValuesSelection should toggle (select/unselect) all options c
                   width="24"
                 >
                   <use
-                    xlink:href="#ec-rounded-partial"
+                    href="/img/rounded-icons.svg#ec-rounded-partial"
                   />
                 </svg>
                  
@@ -1181,7 +1181,7 @@ exports[`EcMultipleValuesSelection should toggle (select/unselect) all options c
                   width="24"
                 >
                   <use
-                    xlink:href="#ec-rounded-cancelled"
+                    href="/img/rounded-icons.svg#ec-rounded-cancelled"
                   />
                 </svg>
                  

--- a/src/components/ec-navigation-link/__snapshots__/ec-navigation-link.spec.js.snap
+++ b/src/components/ec-navigation-link/__snapshots__/ec-navigation-link.spec.js.snap
@@ -13,7 +13,7 @@ exports[`EcNavigationLink as regular anchor should be active when isActive is pa
     width="24"
   >
     <use
-      xlink:href="#ec-single-check"
+      href="/img/simple-icons.svg#ec-simple-check"
     />
   </svg>
    
@@ -43,7 +43,7 @@ exports[`EcNavigationLink as regular anchor should be compact when isCompact is 
     width="24"
   >
     <use
-      xlink:href="#ec-single-check"
+      href="/img/simple-icons.svg#ec-simple-check"
     />
   </svg>
    
@@ -73,7 +73,7 @@ exports[`EcNavigationLink as regular anchor should be expanded by default 1`] = 
     width="24"
   >
     <use
-      xlink:href="#ec-single-check"
+      href="/img/simple-icons.svg#ec-simple-check"
     />
   </svg>
    
@@ -103,7 +103,7 @@ exports[`EcNavigationLink as regular anchor should hide the text when is collaps
     width="24"
   >
     <use
-      xlink:href="#ec-single-check"
+      href="/img/simple-icons.svg#ec-simple-check"
     />
   </svg>
    
@@ -134,7 +134,7 @@ exports[`EcNavigationLink as regular anchor should render as a normal <a> tag if
     width="24"
   >
     <use
-      xlink:href="#ec-single-check"
+      href="/img/simple-icons.svg#ec-simple-check"
     />
   </svg>
    
@@ -164,7 +164,7 @@ exports[`EcNavigationLink as regular anchor should show the text when is expande
     width="24"
   >
     <use
-      xlink:href="#ec-single-check"
+      href="/img/simple-icons.svg#ec-simple-check"
     />
   </svg>
    
@@ -195,7 +195,7 @@ exports[`EcNavigationLink as router-link should be active when isActive is passe
     width="24"
   >
     <use
-      xlink:href="#ec-single-check"
+      href="/img/simple-icons.svg#ec-simple-check"
     />
   </svg>
    
@@ -226,7 +226,7 @@ exports[`EcNavigationLink as router-link should be compact when isCompact is pas
     width="24"
   >
     <use
-      xlink:href="#ec-single-check"
+      href="/img/simple-icons.svg#ec-simple-check"
     />
   </svg>
    
@@ -257,7 +257,7 @@ exports[`EcNavigationLink as router-link should be expanded by default 1`] = `
     width="24"
   >
     <use
-      xlink:href="#ec-single-check"
+      href="/img/simple-icons.svg#ec-simple-check"
     />
   </svg>
    
@@ -288,7 +288,7 @@ exports[`EcNavigationLink as router-link should hide the text when is collapsed 
     width="24"
   >
     <use
-      xlink:href="#ec-single-check"
+      href="/img/simple-icons.svg#ec-simple-check"
     />
   </svg>
    
@@ -320,7 +320,7 @@ exports[`EcNavigationLink as router-link should render as a router link if isRou
     width="24"
   >
     <use
-      xlink:href="#ec-single-check"
+      href="/img/simple-icons.svg#ec-simple-check"
     />
   </svg>
    
@@ -351,7 +351,7 @@ exports[`EcNavigationLink as router-link should show the text when is expanded 1
     width="24"
   >
     <use
-      xlink:href="#ec-single-check"
+      href="/img/simple-icons.svg#ec-simple-check"
     />
   </svg>
    

--- a/src/components/ec-navigation-link/ec-navigation-link.spec.js
+++ b/src/components/ec-navigation-link/ec-navigation-link.spec.js
@@ -27,7 +27,7 @@ describe('EcNavigationLink', () => {
     function mountAsRouterLink(opts, mountOpts) {
       const propsData = {
         text: 'Link',
-        iconName: 'single-check',
+        iconName: 'simple-check',
         url: '/balances',
         isRouterLink: true,
         ...opts,
@@ -79,7 +79,7 @@ describe('EcNavigationLink', () => {
     function mountAsAnchor(opts, mountOpts) {
       const propsData = {
         text: 'Link',
-        iconName: 'single-check',
+        iconName: 'simple-check',
         url: '/balances',
         isRouterLink: false,
         ...opts,

--- a/src/components/ec-panel/__snapshots__/ec-panel.spec.js.snap
+++ b/src/components/ec-panel/__snapshots__/ec-panel.spec.js.snap
@@ -27,7 +27,7 @@ exports[`EcPanel #slots #footer - should render footer slot section if slot is p
           width="24"
         >
           <use
-            xlink:href="#ec-simple-close"
+            href="/img/simple-icons.svg#ec-simple-close"
           />
         </svg>
       </button>
@@ -83,7 +83,7 @@ exports[`EcPanel #slots #header - should render header slot section if slot is p
           width="24"
         >
           <use
-            xlink:href="#ec-simple-close"
+            href="/img/simple-icons.svg#ec-simple-close"
           />
         </svg>
       </button>
@@ -139,7 +139,7 @@ exports[`EcPanel #slots #main - should render main slot section if slot is passe
           width="24"
         >
           <use
-            xlink:href="#ec-simple-close"
+            href="/img/simple-icons.svg#ec-simple-close"
           />
         </svg>
       </button>
@@ -194,7 +194,7 @@ exports[`EcPanel :props :show - should render the panel when is true 1`] = `
           width="24"
         >
           <use
-            xlink:href="#ec-simple-close"
+            href="/img/simple-icons.svg#ec-simple-close"
           />
         </svg>
       </button>
@@ -243,7 +243,7 @@ exports[`EcPanel @events @back should not render back button when event handler 
           width="24"
         >
           <use
-            xlink:href="#ec-simple-close"
+            href="/img/simple-icons.svg#ec-simple-close"
           />
         </svg>
       </button>
@@ -290,7 +290,7 @@ exports[`EcPanel @events @back should render back button when event handler attr
           width="24"
         >
           <use
-            xlink:href="#ec-simple-arrow-left"
+            href="/img/simple-icons.svg#ec-simple-arrow-left"
           />
         </svg>
       </button>
@@ -307,7 +307,7 @@ exports[`EcPanel @events @back should render back button when event handler attr
           width="24"
         >
           <use
-            xlink:href="#ec-simple-close"
+            href="/img/simple-icons.svg#ec-simple-close"
           />
         </svg>
       </button>
@@ -358,7 +358,7 @@ exports[`EcPanel v-model should render the panel when we pass to model true 1`] 
           width="24"
         >
           <use
-            xlink:href="#ec-simple-close"
+            href="/img/simple-icons.svg#ec-simple-close"
           />
         </svg>
       </button>

--- a/src/components/ec-smart-table/__snapshots__/ec-smart-table.spec.js.snap
+++ b/src/components/ec-smart-table/__snapshots__/ec-smart-table.spec.js.snap
@@ -218,7 +218,7 @@ exports[`EcSmartTable #slots should render in loading state by default with the 
           width="48"
         >
           <use
-            xlink:href="#ec-simple-loading"
+            href="/img/simple-icons.svg#ec-simple-loading"
           />
         </svg>
       </div>
@@ -318,7 +318,7 @@ exports[`EcSmartTable #slots should render resolved data properly with the heade
                         width="16"
                       >
                         <use
-                          xlink:href="#ec-simple-arrow-up-down"
+                          href="/img/simple-icons.svg#ec-simple-arrow-up-down"
                         />
                       </svg>
                        
@@ -378,7 +378,7 @@ exports[`EcSmartTable #slots should render resolved data properly with the heade
                         width="16"
                       >
                         <use
-                          xlink:href="#ec-simple-arrow-up-down"
+                          href="/img/simple-icons.svg#ec-simple-arrow-up-down"
                         />
                       </svg>
                        
@@ -452,7 +452,7 @@ exports[`EcSmartTable filtering should handle changes in filters and reload the 
   width="48"
 >
   <use
-    xlink:href="#ec-simple-loading"
+    href="/img/simple-icons.svg#ec-simple-loading"
   />
 </svg>
 `;
@@ -533,7 +533,7 @@ exports[`EcSmartTable filtering should reset the page after changes in filters a
             width="24"
           >
             <use
-              xlink:href="#ec-simple-chevron-down"
+              href="/img/simple-icons.svg#ec-simple-chevron-down"
             />
           </svg>
         </button>
@@ -615,7 +615,7 @@ exports[`EcSmartTable filtering should reset the page after changes in filters a
         width="24"
       >
         <use
-          xlink:href="#ec-simple-chevron-left"
+          href="/img/simple-icons.svg#ec-simple-chevron-left"
         />
       </svg>
     </button>
@@ -631,7 +631,7 @@ exports[`EcSmartTable filtering should reset the page after changes in filters a
         width="24"
       >
         <use
-          xlink:href="#ec-simple-chevron-right"
+          href="/img/simple-icons.svg#ec-simple-chevron-right"
         />
       </svg>
     </button>
@@ -679,7 +679,7 @@ exports[`EcSmartTable filtering should reset the page after changes in filters a
             width="24"
           >
             <use
-              xlink:href="#ec-simple-chevron-down"
+              href="/img/simple-icons.svg#ec-simple-chevron-down"
             />
           </svg>
         </button>
@@ -760,7 +760,7 @@ exports[`EcSmartTable filtering should reset the page after changes in filters a
         width="24"
       >
         <use
-          xlink:href="#ec-simple-chevron-left"
+          href="/img/simple-icons.svg#ec-simple-chevron-left"
         />
       </svg>
     </button>
@@ -776,7 +776,7 @@ exports[`EcSmartTable filtering should reset the page after changes in filters a
         width="24"
       >
         <use
-          xlink:href="#ec-simple-chevron-right"
+          href="/img/simple-icons.svg#ec-simple-chevron-right"
         />
       </svg>
     </button>
@@ -805,7 +805,7 @@ exports[`EcSmartTable pagination should re-fetch the data when next page is sele
   width="48"
 >
   <use
-    xlink:href="#ec-simple-loading"
+    href="/img/simple-icons.svg#ec-simple-loading"
   />
 </svg>
 `;
@@ -850,7 +850,7 @@ exports[`EcSmartTable pagination should re-fetch the data when next page is sele
             width="24"
           >
             <use
-              xlink:href="#ec-simple-chevron-down"
+              href="/img/simple-icons.svg#ec-simple-chevron-down"
             />
           </svg>
         </button>
@@ -931,7 +931,7 @@ exports[`EcSmartTable pagination should re-fetch the data when next page is sele
         width="24"
       >
         <use
-          xlink:href="#ec-simple-chevron-left"
+          href="/img/simple-icons.svg#ec-simple-chevron-left"
         />
       </svg>
     </button>
@@ -947,7 +947,7 @@ exports[`EcSmartTable pagination should re-fetch the data when next page is sele
         width="24"
       >
         <use
-          xlink:href="#ec-simple-chevron-right"
+          href="/img/simple-icons.svg#ec-simple-chevron-right"
         />
       </svg>
     </button>
@@ -965,7 +965,7 @@ exports[`EcSmartTable pagination should re-fetch the data when page size is chan
   width="48"
 >
   <use
-    xlink:href="#ec-simple-loading"
+    href="/img/simple-icons.svg#ec-simple-loading"
   />
 </svg>
 `;
@@ -1010,7 +1010,7 @@ exports[`EcSmartTable pagination should re-fetch the data when page size is chan
             width="24"
           >
             <use
-              xlink:href="#ec-simple-chevron-down"
+              href="/img/simple-icons.svg#ec-simple-chevron-down"
             />
           </svg>
         </button>
@@ -1092,7 +1092,7 @@ exports[`EcSmartTable pagination should re-fetch the data when page size is chan
         width="24"
       >
         <use
-          xlink:href="#ec-simple-chevron-left"
+          href="/img/simple-icons.svg#ec-simple-chevron-left"
         />
       </svg>
     </button>
@@ -1109,7 +1109,7 @@ exports[`EcSmartTable pagination should re-fetch the data when page size is chan
         width="24"
       >
         <use
-          xlink:href="#ec-simple-chevron-right"
+          href="/img/simple-icons.svg#ec-simple-chevron-right"
         />
       </svg>
     </button>
@@ -1157,7 +1157,7 @@ exports[`EcSmartTable pagination should re-fetch the data when prev page is sele
             width="24"
           >
             <use
-              xlink:href="#ec-simple-chevron-down"
+              href="/img/simple-icons.svg#ec-simple-chevron-down"
             />
           </svg>
         </button>
@@ -1238,7 +1238,7 @@ exports[`EcSmartTable pagination should re-fetch the data when prev page is sele
         width="24"
       >
         <use
-          xlink:href="#ec-simple-chevron-left"
+          href="/img/simple-icons.svg#ec-simple-chevron-left"
         />
       </svg>
     </button>
@@ -1254,7 +1254,7 @@ exports[`EcSmartTable pagination should re-fetch the data when prev page is sele
         width="24"
       >
         <use
-          xlink:href="#ec-simple-chevron-right"
+          href="/img/simple-icons.svg#ec-simple-chevron-right"
         />
       </svg>
     </button>
@@ -1272,7 +1272,7 @@ exports[`EcSmartTable pagination should re-fetch the data when prev page is sele
   width="48"
 >
   <use
-    xlink:href="#ec-simple-loading"
+    href="/img/simple-icons.svg#ec-simple-loading"
   />
 </svg>
 `;
@@ -1317,7 +1317,7 @@ exports[`EcSmartTable pagination should re-fetch the data when prev page is sele
             width="24"
           >
             <use
-              xlink:href="#ec-simple-chevron-down"
+              href="/img/simple-icons.svg#ec-simple-chevron-down"
             />
           </svg>
         </button>
@@ -1399,7 +1399,7 @@ exports[`EcSmartTable pagination should re-fetch the data when prev page is sele
         width="24"
       >
         <use
-          xlink:href="#ec-simple-chevron-left"
+          href="/img/simple-icons.svg#ec-simple-chevron-left"
         />
       </svg>
     </button>
@@ -1415,7 +1415,7 @@ exports[`EcSmartTable pagination should re-fetch the data when prev page is sele
         width="24"
       >
         <use
-          xlink:href="#ec-simple-chevron-right"
+          href="/img/simple-icons.svg#ec-simple-chevron-right"
         />
       </svg>
     </button>
@@ -1475,7 +1475,7 @@ exports[`EcSmartTable pagination should render footer slot inside of the paginat
                     width="24"
                   >
                     <use
-                      xlink:href="#ec-simple-chevron-down"
+                      href="/img/simple-icons.svg#ec-simple-chevron-down"
                     />
                   </svg>
                 </button>
@@ -1561,7 +1561,7 @@ exports[`EcSmartTable pagination should render footer slot inside of the paginat
                 width="24"
               >
                 <use
-                  xlink:href="#ec-simple-chevron-left"
+                  href="/img/simple-icons.svg#ec-simple-chevron-left"
                 />
               </svg>
             </button>
@@ -1577,7 +1577,7 @@ exports[`EcSmartTable pagination should render footer slot inside of the paginat
                 width="24"
               >
                 <use
-                  xlink:href="#ec-simple-chevron-right"
+                  href="/img/simple-icons.svg#ec-simple-chevron-right"
                 />
               </svg>
             </button>
@@ -1651,7 +1651,7 @@ exports[`EcSmartTable pagination should render pagination when it's enabled 1`] 
             width="24"
           >
             <use
-              xlink:href="#ec-simple-chevron-down"
+              href="/img/simple-icons.svg#ec-simple-chevron-down"
             />
           </svg>
         </button>
@@ -1733,7 +1733,7 @@ exports[`EcSmartTable pagination should render pagination when it's enabled 1`] 
         width="24"
       >
         <use
-          xlink:href="#ec-simple-chevron-left"
+          href="/img/simple-icons.svg#ec-simple-chevron-left"
         />
       </svg>
     </button>
@@ -1749,7 +1749,7 @@ exports[`EcSmartTable pagination should render pagination when it's enabled 1`] 
         width="24"
       >
         <use
-          xlink:href="#ec-simple-chevron-right"
+          href="/img/simple-icons.svg#ec-simple-chevron-right"
         />
       </svg>
     </button>
@@ -1813,7 +1813,7 @@ exports[`EcSmartTable should render in loading state by default 1`] = `
           width="48"
         >
           <use
-            xlink:href="#ec-simple-loading"
+            href="/img/simple-icons.svg#ec-simple-loading"
           />
         </svg>
       </div>
@@ -1899,7 +1899,7 @@ exports[`EcSmartTable should render it's own title instead of using the one insi
                         width="16"
                       >
                         <use
-                          xlink:href="#ec-simple-arrow-up-down"
+                          href="/img/simple-icons.svg#ec-simple-arrow-up-down"
                         />
                       </svg>
                        
@@ -1959,7 +1959,7 @@ exports[`EcSmartTable should render it's own title instead of using the one insi
                         width="16"
                       >
                         <use
-                          xlink:href="#ec-simple-arrow-up-down"
+                          href="/img/simple-icons.svg#ec-simple-arrow-up-down"
                         />
                       </svg>
                        
@@ -2071,7 +2071,7 @@ exports[`EcSmartTable should render resolved data properly 1`] = `
                         width="16"
                       >
                         <use
-                          xlink:href="#ec-simple-arrow-up-down"
+                          href="/img/simple-icons.svg#ec-simple-arrow-up-down"
                         />
                       </svg>
                        
@@ -2131,7 +2131,7 @@ exports[`EcSmartTable should render resolved data properly 1`] = `
                         width="16"
                       >
                         <use
-                          xlink:href="#ec-simple-arrow-up-down"
+                          href="/img/simple-icons.svg#ec-simple-arrow-up-down"
                         />
                       </svg>
                        
@@ -2214,7 +2214,7 @@ exports[`EcSmartTable sorting multi sort should allow sorting multiple columns: 
             width="16"
           >
             <use
-              xlink:href="#ec-simple-arrow-drop-down"
+              href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
             />
           </svg>
            
@@ -2278,7 +2278,7 @@ exports[`EcSmartTable sorting multi sort should allow sorting multiple columns: 
             width="16"
           >
             <use
-              xlink:href="#ec-simple-arrow-drop-down"
+              href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
             />
           </svg>
            
@@ -2331,7 +2331,7 @@ exports[`EcSmartTable sorting multi sort should allow sorting multiple columns: 
             width="16"
           >
             <use
-              xlink:href="#ec-simple-arrow-drop-down"
+              href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
             />
           </svg>
            
@@ -2395,7 +2395,7 @@ exports[`EcSmartTable sorting multi sort should allow sorting multiple columns: 
             width="16"
           >
             <use
-              xlink:href="#ec-simple-arrow-drop-down"
+              href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
             />
           </svg>
            
@@ -2448,7 +2448,7 @@ exports[`EcSmartTable sorting multi sort should allow sorting multiple columns: 
             width="16"
           >
             <use
-              xlink:href="#ec-simple-arrow-drop-down"
+              href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
             />
           </svg>
            
@@ -2512,7 +2512,7 @@ exports[`EcSmartTable sorting multi sort should allow sorting multiple columns: 
             width="16"
           >
             <use
-              xlink:href="#ec-simple-arrow-up-down"
+              href="/img/simple-icons.svg#ec-simple-arrow-up-down"
             />
           </svg>
            
@@ -2556,7 +2556,7 @@ exports[`EcSmartTable sorting multi sort should sort column: ASC -> DESC 1`] = `
         width="16"
       >
         <use
-          xlink:href="#ec-simple-arrow-drop-down"
+          href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
         />
       </svg>
        
@@ -2602,7 +2602,7 @@ exports[`EcSmartTable sorting multi sort should sort column: ASC 1`] = `
         width="16"
       >
         <use
-          xlink:href="#ec-simple-arrow-drop-down"
+          href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
         />
       </svg>
        
@@ -2648,7 +2648,7 @@ exports[`EcSmartTable sorting multi sort should sort column: DESC -> not sorted 
         width="16"
       >
         <use
-          xlink:href="#ec-simple-arrow-up-down"
+          href="/img/simple-icons.svg#ec-simple-arrow-up-down"
         />
       </svg>
        
@@ -2690,7 +2690,7 @@ exports[`EcSmartTable sorting multi sort should sort column: not sorted -> ASC 1
         width="16"
       >
         <use
-          xlink:href="#ec-simple-arrow-drop-down"
+          href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
         />
       </svg>
        
@@ -2741,7 +2741,7 @@ exports[`EcSmartTable sorting should render sortable columns 1`] = `
             width="16"
           >
             <use
-              xlink:href="#ec-simple-arrow-up-down"
+              href="/img/simple-icons.svg#ec-simple-arrow-up-down"
             />
           </svg>
            
@@ -2801,7 +2801,7 @@ exports[`EcSmartTable sorting should render sortable columns 1`] = `
             width="16"
           >
             <use
-              xlink:href="#ec-simple-arrow-up-down"
+              href="/img/simple-icons.svg#ec-simple-arrow-up-down"
             />
           </svg>
            
@@ -2850,7 +2850,7 @@ exports[`EcSmartTable sorting should render sorted columns 1`] = `
             width="16"
           >
             <use
-              xlink:href="#ec-simple-arrow-drop-down"
+              href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
             />
           </svg>
            
@@ -2914,7 +2914,7 @@ exports[`EcSmartTable sorting should render sorted columns 1`] = `
             width="16"
           >
             <use
-              xlink:href="#ec-simple-arrow-drop-down"
+              href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
             />
           </svg>
            
@@ -2967,7 +2967,7 @@ exports[`EcSmartTable sorting single sort should allow sorting only one column: 
             width="16"
           >
             <use
-              xlink:href="#ec-simple-arrow-drop-down"
+              href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
             />
           </svg>
            
@@ -3031,7 +3031,7 @@ exports[`EcSmartTable sorting single sort should allow sorting only one column: 
             width="16"
           >
             <use
-              xlink:href="#ec-simple-arrow-up-down"
+              href="/img/simple-icons.svg#ec-simple-arrow-up-down"
             />
           </svg>
            
@@ -3080,7 +3080,7 @@ exports[`EcSmartTable sorting single sort should allow sorting only one column: 
             width="16"
           >
             <use
-              xlink:href="#ec-simple-arrow-up-down"
+              href="/img/simple-icons.svg#ec-simple-arrow-up-down"
             />
           </svg>
            
@@ -3140,7 +3140,7 @@ exports[`EcSmartTable sorting single sort should allow sorting only one column: 
             width="16"
           >
             <use
-              xlink:href="#ec-simple-arrow-drop-down"
+              href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
             />
           </svg>
            
@@ -3193,7 +3193,7 @@ exports[`EcSmartTable sorting single sort should allow sorting only one column: 
             width="16"
           >
             <use
-              xlink:href="#ec-simple-arrow-drop-down"
+              href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
             />
           </svg>
            
@@ -3257,7 +3257,7 @@ exports[`EcSmartTable sorting single sort should allow sorting only one column: 
             width="16"
           >
             <use
-              xlink:href="#ec-simple-arrow-up-down"
+              href="/img/simple-icons.svg#ec-simple-arrow-up-down"
             />
           </svg>
            
@@ -3301,7 +3301,7 @@ exports[`EcSmartTable sorting single sort should sort column: ASC -> DESC 1`] = 
         width="16"
       >
         <use
-          xlink:href="#ec-simple-arrow-drop-down"
+          href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
         />
       </svg>
        
@@ -3347,7 +3347,7 @@ exports[`EcSmartTable sorting single sort should sort column: ASC 1`] = `
         width="16"
       >
         <use
-          xlink:href="#ec-simple-arrow-drop-down"
+          href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
         />
       </svg>
        
@@ -3393,7 +3393,7 @@ exports[`EcSmartTable sorting single sort should sort column: DESC -> not sorted
         width="16"
       >
         <use
-          xlink:href="#ec-simple-arrow-up-down"
+          href="/img/simple-icons.svg#ec-simple-arrow-up-down"
         />
       </svg>
        
@@ -3435,7 +3435,7 @@ exports[`EcSmartTable sorting single sort should sort column: not sorted -> ASC 
         width="16"
       >
         <use
-          xlink:href="#ec-simple-arrow-drop-down"
+          href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
         />
       </svg>
        

--- a/src/components/ec-sync-multiple-values-filter/__snapshots__/ec-sync-multiple-values-filter.spec.js.snap
+++ b/src/components/ec-sync-multiple-values-filter/__snapshots__/ec-sync-multiple-values-filter.spec.js.snap
@@ -36,7 +36,7 @@ exports[`EcSyncMultipleValuesFilter should be able to search in items by their t
           width="16"
         >
           <use
-            xlink:href="#ec-simple-chevron-down"
+            href="/img/simple-icons.svg#ec-simple-chevron-down"
           />
         </svg>
       </div>
@@ -58,7 +58,7 @@ exports[`EcSyncMultipleValuesFilter should be able to search in items by their t
               width="20"
             >
               <use
-                xlink:href="#ec-simple-search"
+                href="/img/simple-icons.svg#ec-simple-search"
               />
             </svg>
              
@@ -118,7 +118,7 @@ exports[`EcSyncMultipleValuesFilter should be able to search in items by their t
                           width="24"
                         >
                           <use
-                            xlink:href="#ec-rounded-partial"
+                            href="/img/rounded-icons.svg#ec-rounded-partial"
                           />
                         </svg>
                          
@@ -179,7 +179,7 @@ exports[`EcSyncMultipleValuesFilter should be able to search in items by their t
           width="16"
         >
           <use
-            xlink:href="#ec-simple-chevron-down"
+            href="/img/simple-icons.svg#ec-simple-chevron-down"
           />
         </svg>
       </div>
@@ -201,7 +201,7 @@ exports[`EcSyncMultipleValuesFilter should be able to search in items by their t
               width="20"
             >
               <use
-                xlink:href="#ec-simple-search"
+                href="/img/simple-icons.svg#ec-simple-search"
               />
             </svg>
              
@@ -261,7 +261,7 @@ exports[`EcSyncMultipleValuesFilter should be able to search in items by their t
                           width="24"
                         >
                           <use
-                            xlink:href="#ec-rounded-check"
+                            href="/img/rounded-icons.svg#ec-rounded-check"
                           />
                         </svg>
                          
@@ -322,7 +322,7 @@ exports[`EcSyncMultipleValuesFilter should display Select all checkbox if isSele
           width="16"
         >
           <use
-            xlink:href="#ec-simple-chevron-down"
+            href="/img/simple-icons.svg#ec-simple-chevron-down"
           />
         </svg>
       </div>
@@ -418,7 +418,7 @@ exports[`EcSyncMultipleValuesFilter should display Select all checkbox if isSele
                           width="24"
                         >
                           <use
-                            xlink:href="#ec-rounded-check"
+                            href="/img/rounded-icons.svg#ec-rounded-check"
                           />
                         </svg>
                          
@@ -479,7 +479,7 @@ exports[`EcSyncMultipleValuesFilter should display an empty message when items a
           width="16"
         >
           <use
-            xlink:href="#ec-simple-chevron-down"
+            href="/img/simple-icons.svg#ec-simple-chevron-down"
           />
         </svg>
       </div>
@@ -503,7 +503,7 @@ exports[`EcSyncMultipleValuesFilter should display an empty message when items a
               width="32"
             >
               <use
-                xlink:href="#ec-simple-error"
+                href="/img/simple-icons.svg#ec-simple-error"
               />
             </svg>
              
@@ -556,7 +556,7 @@ exports[`EcSyncMultipleValuesFilter should display custom label for Select all c
           width="16"
         >
           <use
-            xlink:href="#ec-simple-chevron-down"
+            href="/img/simple-icons.svg#ec-simple-chevron-down"
           />
         </svg>
       </div>
@@ -652,7 +652,7 @@ exports[`EcSyncMultipleValuesFilter should display custom label for Select all c
                           width="24"
                         >
                           <use
-                            xlink:href="#ec-rounded-check"
+                            href="/img/rounded-icons.svg#ec-rounded-check"
                           />
                         </svg>
                          
@@ -713,7 +713,7 @@ exports[`EcSyncMultipleValuesFilter should display empty state if searched value
           width="16"
         >
           <use
-            xlink:href="#ec-simple-chevron-down"
+            href="/img/simple-icons.svg#ec-simple-chevron-down"
           />
         </svg>
       </div>
@@ -735,7 +735,7 @@ exports[`EcSyncMultipleValuesFilter should display empty state if searched value
               width="20"
             >
               <use
-                xlink:href="#ec-simple-search"
+                href="/img/simple-icons.svg#ec-simple-search"
               />
             </svg>
              
@@ -758,7 +758,7 @@ exports[`EcSyncMultipleValuesFilter should display empty state if searched value
               width="32"
             >
               <use
-                xlink:href="#ec-simple-error"
+                href="/img/simple-icons.svg#ec-simple-error"
               />
             </svg>
              
@@ -811,7 +811,7 @@ exports[`EcSyncMultipleValuesFilter should display error state properly 1`] = `
           width="16"
         >
           <use
-            xlink:href="#ec-simple-chevron-down"
+            href="/img/simple-icons.svg#ec-simple-chevron-down"
           />
         </svg>
       </div>
@@ -835,7 +835,7 @@ exports[`EcSyncMultipleValuesFilter should display error state properly 1`] = `
               width="32"
             >
               <use
-                xlink:href="#ec-simple-error"
+                href="/img/simple-icons.svg#ec-simple-error"
               />
             </svg>
              
@@ -888,7 +888,7 @@ exports[`EcSyncMultipleValuesFilter should display loading state properly 1`] = 
           width="16"
         >
           <use
-            xlink:href="#ec-simple-chevron-down"
+            href="/img/simple-icons.svg#ec-simple-chevron-down"
           />
         </svg>
       </div>
@@ -912,7 +912,7 @@ exports[`EcSyncMultipleValuesFilter should display loading state properly 1`] = 
               width="32"
             >
               <use
-                xlink:href="#ec-simple-loading"
+                href="/img/simple-icons.svg#ec-simple-loading"
               />
             </svg>
           </div>
@@ -959,7 +959,7 @@ exports[`EcSyncMultipleValuesFilter should ignore empty message when items are g
           width="16"
         >
           <use
-            xlink:href="#ec-simple-chevron-down"
+            href="/img/simple-icons.svg#ec-simple-chevron-down"
           />
         </svg>
       </div>
@@ -1020,7 +1020,7 @@ exports[`EcSyncMultipleValuesFilter should ignore empty message when items are g
                           width="24"
                         >
                           <use
-                            xlink:href="#ec-rounded-check"
+                            href="/img/rounded-icons.svg#ec-rounded-check"
                           />
                         </svg>
                          
@@ -1075,7 +1075,7 @@ exports[`EcSyncMultipleValuesFilter should ignore empty message when items are g
                           width="24"
                         >
                           <use
-                            xlink:href="#ec-rounded-partial"
+                            href="/img/rounded-icons.svg#ec-rounded-partial"
                           />
                         </svg>
                          
@@ -1130,7 +1130,7 @@ exports[`EcSyncMultipleValuesFilter should ignore empty message when items are g
                           width="24"
                         >
                           <use
-                            xlink:href="#ec-rounded-cancelled"
+                            href="/img/rounded-icons.svg#ec-rounded-cancelled"
                           />
                         </svg>
                          
@@ -1191,7 +1191,7 @@ exports[`EcSyncMultipleValuesFilter should ignore only whitespace in the search 
           width="16"
         >
           <use
-            xlink:href="#ec-simple-chevron-down"
+            href="/img/simple-icons.svg#ec-simple-chevron-down"
           />
         </svg>
       </div>
@@ -1213,7 +1213,7 @@ exports[`EcSyncMultipleValuesFilter should ignore only whitespace in the search 
               width="20"
             >
               <use
-                xlink:href="#ec-simple-search"
+                href="/img/simple-icons.svg#ec-simple-search"
               />
             </svg>
              
@@ -1273,7 +1273,7 @@ exports[`EcSyncMultipleValuesFilter should ignore only whitespace in the search 
                           width="24"
                         >
                           <use
-                            xlink:href="#ec-rounded-check"
+                            href="/img/rounded-icons.svg#ec-rounded-check"
                           />
                         </svg>
                          
@@ -1328,7 +1328,7 @@ exports[`EcSyncMultipleValuesFilter should ignore only whitespace in the search 
                           width="24"
                         >
                           <use
-                            xlink:href="#ec-rounded-partial"
+                            href="/img/rounded-icons.svg#ec-rounded-partial"
                           />
                         </svg>
                          
@@ -1383,7 +1383,7 @@ exports[`EcSyncMultipleValuesFilter should ignore only whitespace in the search 
                           width="24"
                         >
                           <use
-                            xlink:href="#ec-rounded-cancelled"
+                            href="/img/rounded-icons.svg#ec-rounded-cancelled"
                           />
                         </svg>
                          
@@ -1450,7 +1450,7 @@ exports[`EcSyncMultipleValuesFilter should not display selected values in the em
           width="16"
         >
           <use
-            xlink:href="#ec-simple-chevron-down"
+            href="/img/simple-icons.svg#ec-simple-chevron-down"
           />
         </svg>
       </div>
@@ -1472,7 +1472,7 @@ exports[`EcSyncMultipleValuesFilter should not display selected values in the em
               width="20"
             >
               <use
-                xlink:href="#ec-simple-search"
+                href="/img/simple-icons.svg#ec-simple-search"
               />
             </svg>
              
@@ -1495,7 +1495,7 @@ exports[`EcSyncMultipleValuesFilter should not display selected values in the em
               width="32"
             >
               <use
-                xlink:href="#ec-simple-error"
+                href="/img/simple-icons.svg#ec-simple-error"
               />
             </svg>
              
@@ -1548,7 +1548,7 @@ exports[`EcSyncMultipleValuesFilter should render as full height if isFullHeight
           width="16"
         >
           <use
-            xlink:href="#ec-simple-chevron-down"
+            href="/img/simple-icons.svg#ec-simple-chevron-down"
           />
         </svg>
       </div>
@@ -1609,7 +1609,7 @@ exports[`EcSyncMultipleValuesFilter should render as full height if isFullHeight
                           width="24"
                         >
                           <use
-                            xlink:href="#ec-rounded-check"
+                            href="/img/rounded-icons.svg#ec-rounded-check"
                           />
                         </svg>
                          
@@ -1670,7 +1670,7 @@ exports[`EcSyncMultipleValuesFilter should render correctly if all the required 
           width="16"
         >
           <use
-            xlink:href="#ec-simple-chevron-down"
+            href="/img/simple-icons.svg#ec-simple-chevron-down"
           />
         </svg>
       </div>
@@ -1731,7 +1731,7 @@ exports[`EcSyncMultipleValuesFilter should render correctly if all the required 
                           width="24"
                         >
                           <use
-                            xlink:href="#ec-rounded-check"
+                            href="/img/rounded-icons.svg#ec-rounded-check"
                           />
                         </svg>
                          
@@ -1786,7 +1786,7 @@ exports[`EcSyncMultipleValuesFilter should render correctly if all the required 
                           width="24"
                         >
                           <use
-                            xlink:href="#ec-rounded-partial"
+                            href="/img/rounded-icons.svg#ec-rounded-partial"
                           />
                         </svg>
                          
@@ -1841,7 +1841,7 @@ exports[`EcSyncMultipleValuesFilter should render correctly if all the required 
                           width="24"
                         >
                           <use
-                            xlink:href="#ec-rounded-cancelled"
+                            href="/img/rounded-icons.svg#ec-rounded-cancelled"
                           />
                         </svg>
                          
@@ -1912,7 +1912,7 @@ exports[`EcSyncMultipleValuesFilter should render search if isSearchable is set 
           width="16"
         >
           <use
-            xlink:href="#ec-simple-chevron-down"
+            href="/img/simple-icons.svg#ec-simple-chevron-down"
           />
         </svg>
       </div>
@@ -1934,7 +1934,7 @@ exports[`EcSyncMultipleValuesFilter should render search if isSearchable is set 
               width="20"
             >
               <use
-                xlink:href="#ec-simple-search"
+                href="/img/simple-icons.svg#ec-simple-search"
               />
             </svg>
              
@@ -1994,7 +1994,7 @@ exports[`EcSyncMultipleValuesFilter should render search if isSearchable is set 
                           width="24"
                         >
                           <use
-                            xlink:href="#ec-rounded-check"
+                            href="/img/rounded-icons.svg#ec-rounded-check"
                           />
                         </svg>
                          
@@ -2061,7 +2061,7 @@ exports[`EcSyncMultipleValuesFilter should update the number of items selected i
           width="16"
         >
           <use
-            xlink:href="#ec-simple-chevron-down"
+            href="/img/simple-icons.svg#ec-simple-chevron-down"
           />
         </svg>
       </div>
@@ -2108,7 +2108,7 @@ exports[`EcSyncMultipleValuesFilter should update the number of items selected i
                         width="16"
                       >
                         <use
-                          xlink:href="#ec-simple-check"
+                          href="/img/simple-icons.svg#ec-simple-check"
                         />
                       </svg>
                     </span>
@@ -2128,7 +2128,7 @@ exports[`EcSyncMultipleValuesFilter should update the number of items selected i
                           width="24"
                         >
                           <use
-                            xlink:href="#ec-rounded-check"
+                            href="/img/rounded-icons.svg#ec-rounded-check"
                           />
                         </svg>
                          
@@ -2186,7 +2186,7 @@ exports[`EcSyncMultipleValuesFilter should update the number of items selected i
                           width="24"
                         >
                           <use
-                            xlink:href="#ec-rounded-partial"
+                            href="/img/rounded-icons.svg#ec-rounded-partial"
                           />
                         </svg>
                          
@@ -2241,7 +2241,7 @@ exports[`EcSyncMultipleValuesFilter should update the number of items selected i
                           width="24"
                         >
                           <use
-                            xlink:href="#ec-rounded-cancelled"
+                            href="/img/rounded-icons.svg#ec-rounded-cancelled"
                           />
                         </svg>
                          

--- a/src/components/ec-table-filter/__snapshots__/ec-table-filter.spec.js.snap
+++ b/src/components/ec-table-filter/__snapshots__/ec-table-filter.spec.js.snap
@@ -40,7 +40,7 @@ exports[`EcTableFilter should hide the clear filters button if there isn't any p
             width="16"
           >
             <use
-              xlink:href="#ec-simple-chevron-down"
+              href="/img/simple-icons.svg#ec-simple-chevron-down"
             />
           </svg>
         </div>
@@ -245,7 +245,7 @@ exports[`EcTableFilter should hide the clear filters button if there isn't any p
             width="16"
           >
             <use
-              xlink:href="#ec-simple-chevron-down"
+              href="/img/simple-icons.svg#ec-simple-chevron-down"
             />
           </svg>
         </div>
@@ -399,7 +399,7 @@ exports[`EcTableFilter should hide the clear filters button if there isn't any p
           width="16"
         >
           <use
-            xlink:href="#ec-simple-chevron-down"
+            href="/img/simple-icons.svg#ec-simple-chevron-down"
           />
         </svg>
       </div>
@@ -540,7 +540,7 @@ exports[`EcTableFilter should hide the clear filters button when the user desele
             width="16"
           >
             <use
-              xlink:href="#ec-simple-chevron-down"
+              href="/img/simple-icons.svg#ec-simple-chevron-down"
             />
           </svg>
         </div>
@@ -745,7 +745,7 @@ exports[`EcTableFilter should hide the clear filters button when the user desele
             width="16"
           >
             <use
-              xlink:href="#ec-simple-chevron-down"
+              href="/img/simple-icons.svg#ec-simple-chevron-down"
             />
           </svg>
         </div>
@@ -899,7 +899,7 @@ exports[`EcTableFilter should hide the clear filters button when the user desele
           width="16"
         >
           <use
-            xlink:href="#ec-simple-chevron-down"
+            href="/img/simple-icons.svg#ec-simple-chevron-down"
           />
         </svg>
       </div>
@@ -1040,7 +1040,7 @@ exports[`EcTableFilter should render correctly if all the required props are pas
             width="16"
           >
             <use
-              xlink:href="#ec-simple-chevron-down"
+              href="/img/simple-icons.svg#ec-simple-chevron-down"
             />
           </svg>
         </div>
@@ -1245,7 +1245,7 @@ exports[`EcTableFilter should render correctly if all the required props are pas
             width="16"
           >
             <use
-              xlink:href="#ec-simple-chevron-down"
+              href="/img/simple-icons.svg#ec-simple-chevron-down"
             />
           </svg>
         </div>
@@ -1399,7 +1399,7 @@ exports[`EcTableFilter should render correctly if all the required props are pas
           width="16"
         >
           <use
-            xlink:href="#ec-simple-chevron-down"
+            href="/img/simple-icons.svg#ec-simple-chevron-down"
           />
         </svg>
       </div>
@@ -1540,7 +1540,7 @@ exports[`EcTableFilter should render with pre-selected filters if the value prop
             width="16"
           >
             <use
-              xlink:href="#ec-simple-chevron-down"
+              href="/img/simple-icons.svg#ec-simple-chevron-down"
             />
           </svg>
         </div>
@@ -1751,7 +1751,7 @@ exports[`EcTableFilter should render with pre-selected filters if the value prop
             width="16"
           >
             <use
-              xlink:href="#ec-simple-chevron-down"
+              href="/img/simple-icons.svg#ec-simple-chevron-down"
             />
           </svg>
         </div>
@@ -1798,7 +1798,7 @@ exports[`EcTableFilter should render with pre-selected filters if the value prop
                           width="16"
                         >
                           <use
-                            xlink:href="#ec-simple-check"
+                            href="/img/simple-icons.svg#ec-simple-check"
                           />
                         </svg>
                       </span>
@@ -1914,7 +1914,7 @@ exports[`EcTableFilter should render with pre-selected filters if the value prop
           width="16"
         >
           <use
-            xlink:href="#ec-simple-chevron-down"
+            href="/img/simple-icons.svg#ec-simple-chevron-down"
           />
         </svg>
       </div>

--- a/src/components/ec-table-head/__snapshots__/ec-table-head.spec.js.snap
+++ b/src/components/ec-table-head/__snapshots__/ec-table-head.spec.js.snap
@@ -254,7 +254,7 @@ exports[`EcTableHead should render info icon with a tooltip as expected 1`] = `
           width="16"
         >
           <use
-            xlink:href="#ec-simple-info"
+            href="/img/simple-icons.svg#ec-simple-info"
           />
         </svg>
          
@@ -286,7 +286,7 @@ exports[`EcTableHead should render info icon with a tooltip as expected 1`] = `
           width="16"
         >
           <use
-            xlink:href="#ec-simple-info"
+            href="/img/simple-icons.svg#ec-simple-info"
           />
         </svg>
          
@@ -317,7 +317,7 @@ exports[`EcTableHead should render info icon with a tooltip as expected 1`] = `
           width="16"
         >
           <use
-            xlink:href="#ec-simple-info"
+            href="/img/simple-icons.svg#ec-simple-info"
           />
         </svg>
          
@@ -365,7 +365,7 @@ exports[`EcTableHead should render sorting as expected 1`] = `
             width="16"
           >
             <use
-              xlink:href="#ec-simple-arrow-drop-down"
+              href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
             />
           </svg>
            
@@ -409,7 +409,7 @@ exports[`EcTableHead should render sorting as expected 1`] = `
             width="16"
           >
             <use
-              xlink:href="#ec-simple-arrow-drop-down"
+              href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
             />
           </svg>
            
@@ -452,7 +452,7 @@ exports[`EcTableHead should render sorting as expected 1`] = `
             width="16"
           >
             <use
-              xlink:href="#ec-simple-arrow-up-down"
+              href="/img/simple-icons.svg#ec-simple-arrow-up-down"
             />
           </svg>
            

--- a/src/components/ec-table-pagination/__snapshots__/ec-table-pagination.spec.js.snap
+++ b/src/components/ec-table-pagination/__snapshots__/ec-table-pagination.spec.js.snap
@@ -69,7 +69,7 @@ exports[`EcTablePagination should display next and prev buttons disabled if pagi
       width="24"
     >
       <use
-        xlink:href="#ec-simple-chevron-left"
+        href="/img/simple-icons.svg#ec-simple-chevron-left"
       />
     </svg>
   </button>
@@ -86,7 +86,7 @@ exports[`EcTablePagination should display next and prev buttons disabled if pagi
       width="24"
     >
       <use
-        xlink:href="#ec-simple-chevron-right"
+        href="/img/simple-icons.svg#ec-simple-chevron-right"
       />
     </svg>
   </button>
@@ -109,7 +109,7 @@ exports[`EcTablePagination should display next and prev buttons enabled if pagin
       width="24"
     >
       <use
-        xlink:href="#ec-simple-chevron-left"
+        href="/img/simple-icons.svg#ec-simple-chevron-left"
       />
     </svg>
   </button>
@@ -125,7 +125,7 @@ exports[`EcTablePagination should display next and prev buttons enabled if pagin
       width="24"
     >
       <use
-        xlink:href="#ec-simple-chevron-right"
+        href="/img/simple-icons.svg#ec-simple-chevron-right"
       />
     </svg>
   </button>
@@ -148,7 +148,7 @@ exports[`EcTablePagination should display only next button disabled if paginatio
       width="24"
     >
       <use
-        xlink:href="#ec-simple-chevron-left"
+        href="/img/simple-icons.svg#ec-simple-chevron-left"
       />
     </svg>
   </button>
@@ -165,7 +165,7 @@ exports[`EcTablePagination should display only next button disabled if paginatio
       width="24"
     >
       <use
-        xlink:href="#ec-simple-chevron-right"
+        href="/img/simple-icons.svg#ec-simple-chevron-right"
       />
     </svg>
   </button>
@@ -189,7 +189,7 @@ exports[`EcTablePagination should display only prev button disabled if paginatio
       width="24"
     >
       <use
-        xlink:href="#ec-simple-chevron-left"
+        href="/img/simple-icons.svg#ec-simple-chevron-left"
       />
     </svg>
   </button>
@@ -205,7 +205,7 @@ exports[`EcTablePagination should display only prev button disabled if paginatio
       width="24"
     >
       <use
-        xlink:href="#ec-simple-chevron-right"
+        href="/img/simple-icons.svg#ec-simple-chevron-right"
       />
     </svg>
   </button>
@@ -293,7 +293,7 @@ exports[`EcTablePagination should display the page size dropdown with preselecte
           width="24"
         >
           <use
-            xlink:href="#ec-simple-chevron-down"
+            href="/img/simple-icons.svg#ec-simple-chevron-down"
           />
         </svg>
       </button>
@@ -382,7 +382,7 @@ exports[`EcTablePagination should render as expected 1`] = `
             width="24"
           >
             <use
-              xlink:href="#ec-simple-chevron-down"
+              href="/img/simple-icons.svg#ec-simple-chevron-down"
             />
           </svg>
         </button>
@@ -464,7 +464,7 @@ exports[`EcTablePagination should render as expected 1`] = `
         width="24"
       >
         <use
-          xlink:href="#ec-simple-chevron-left"
+          href="/img/simple-icons.svg#ec-simple-chevron-left"
         />
       </svg>
     </button>
@@ -481,7 +481,7 @@ exports[`EcTablePagination should render as expected 1`] = `
         width="24"
       >
         <use
-          xlink:href="#ec-simple-chevron-right"
+          href="/img/simple-icons.svg#ec-simple-chevron-right"
         />
       </svg>
     </button>

--- a/src/components/ec-table-sort/__snapshots__/ec-table-sort.spec.js.snap
+++ b/src/components/ec-table-sort/__snapshots__/ec-table-sort.spec.js.snap
@@ -14,7 +14,7 @@ exports[`EcTableSort #slots should render default slot 1`] = `
     width="16"
   >
     <use
-      xlink:href="#ec-simple-arrow-up-down"
+      href="/img/simple-icons.svg#ec-simple-arrow-up-down"
     />
   </svg>
    
@@ -36,7 +36,7 @@ exports[`EcTableSort :props should render with direction set to ASC 1`] = `
     width="16"
   >
     <use
-      xlink:href="#ec-simple-arrow-drop-down"
+      href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
     />
   </svg>
    
@@ -62,7 +62,7 @@ exports[`EcTableSort :props should render with direction set to DESC 1`] = `
     width="16"
   >
     <use
-      xlink:href="#ec-simple-arrow-drop-down"
+      href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
     />
   </svg>
    
@@ -88,7 +88,7 @@ exports[`EcTableSort :props should render with direction set to empty string 1`]
     width="16"
   >
     <use
-      xlink:href="#ec-simple-arrow-up-down"
+      href="/img/simple-icons.svg#ec-simple-arrow-up-down"
     />
   </svg>
    
@@ -110,7 +110,7 @@ exports[`EcTableSort :props should render with no direction 1`] = `
     width="16"
   >
     <use
-      xlink:href="#ec-simple-arrow-up-down"
+      href="/img/simple-icons.svg#ec-simple-arrow-up-down"
     />
   </svg>
    
@@ -132,7 +132,7 @@ exports[`EcTableSort should render as expected 1`] = `
     width="16"
   >
     <use
-      xlink:href="#ec-simple-arrow-up-down"
+      href="/img/simple-icons.svg#ec-simple-arrow-up-down"
     />
   </svg>
    

--- a/src/components/ec-table/__snapshots__/ec-table.spec.js.snap
+++ b/src/components/ec-table/__snapshots__/ec-table.spec.js.snap
@@ -903,7 +903,7 @@ exports[`EcTable should render sorting as expected 1`] = `
             width="16"
           >
             <use
-              xlink:href="#ec-simple-arrow-drop-down"
+              href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
             />
           </svg>
            
@@ -946,7 +946,7 @@ exports[`EcTable should render sorting as expected 1`] = `
             width="16"
           >
             <use
-              xlink:href="#ec-simple-arrow-drop-down"
+              href="/img/simple-icons.svg#ec-simple-arrow-drop-down"
             />
           </svg>
            

--- a/src/components/ec-textarea/__snapshots__/ec-textarea.spec.js.snap
+++ b/src/components/ec-textarea/__snapshots__/ec-textarea.spec.js.snap
@@ -137,7 +137,7 @@ exports[`EcTextarea :props should render with a labelTooltip 1`] = `
         width="14"
       >
         <use
-          xlink:href="#ec-simple-info"
+          href="/img/simple-icons.svg#ec-simple-info"
         />
       </svg>
     </span>

--- a/src/components/ec-toaster/__snapshots__/ec-toaster.spec.js.snap
+++ b/src/components/ec-toaster/__snapshots__/ec-toaster.spec.js.snap
@@ -42,7 +42,7 @@ exports[`EcToaster messages prop should render a toaster if the messages prop is
             width="16"
           >
             <use
-              xlink:href="#ec-simple-close"
+              href="/img/simple-icons.svg#ec-simple-close"
             />
           </svg>
         </a>
@@ -51,7 +51,7 @@ exports[`EcToaster messages prop should render a toaster if the messages prop is
           class="ec-alert__icon ec-icon ec-alert__icon--alert-has-subtitle"
         >
           <use
-            xlink:href="#ec-simple-error"
+            href="/img/simple-icons.svg#ec-simple-error"
           />
         </svg>
          
@@ -95,7 +95,7 @@ exports[`EcToaster messages prop should render a toaster if the messages prop is
             width="16"
           >
             <use
-              xlink:href="#ec-simple-close"
+              href="/img/simple-icons.svg#ec-simple-close"
             />
           </svg>
         </a>
@@ -104,7 +104,7 @@ exports[`EcToaster messages prop should render a toaster if the messages prop is
           class="ec-alert__icon ec-icon ec-alert__icon--alert-has-subtitle"
         >
           <use
-            xlink:href="#ec-simple-check"
+            href="/img/simple-icons.svg#ec-simple-check"
           />
         </svg>
          
@@ -148,7 +148,7 @@ exports[`EcToaster messages prop should render a toaster if the messages prop is
             width="16"
           >
             <use
-              xlink:href="#ec-simple-close"
+              href="/img/simple-icons.svg#ec-simple-close"
             />
           </svg>
         </a>
@@ -157,7 +157,7 @@ exports[`EcToaster messages prop should render a toaster if the messages prop is
           class="ec-alert__icon ec-icon ec-alert__icon--alert-has-subtitle"
         >
           <use
-            xlink:href="#ec-simple-info"
+            href="/img/simple-icons.svg#ec-simple-info"
           />
         </svg>
          
@@ -201,7 +201,7 @@ exports[`EcToaster messages prop should render a toaster if the messages prop is
             width="16"
           >
             <use
-              xlink:href="#ec-simple-close"
+              href="/img/simple-icons.svg#ec-simple-close"
             />
           </svg>
         </a>
@@ -210,7 +210,7 @@ exports[`EcToaster messages prop should render a toaster if the messages prop is
           class="ec-alert__icon ec-icon ec-alert__icon--alert-has-subtitle"
         >
           <use
-            xlink:href="#ec-simple-error"
+            href="/img/simple-icons.svg#ec-simple-error"
           />
         </svg>
          
@@ -259,7 +259,7 @@ exports[`EcToaster should not contain initially a class of "ec-toaster__item--sw
         width="16"
       >
         <use
-          xlink:href="#ec-simple-close"
+          href="/img/simple-icons.svg#ec-simple-close"
         />
       </svg>
     </a>
@@ -268,7 +268,7 @@ exports[`EcToaster should not contain initially a class of "ec-toaster__item--sw
       class="ec-alert__icon ec-icon ec-alert__icon--alert-has-subtitle"
     >
       <use
-        xlink:href="#ec-simple-check"
+        href="/img/simple-icons.svg#ec-simple-check"
       />
     </svg>
      

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,7 @@
 let sensitiveClass = '';
 
 export default {
+  iconsPublicPath: '/img',
   get sensitiveClass() {
     if (!sensitiveClass) {
       throw new Error('sensitiveClass is required');

--- a/src/hocs/ec-with-loading/__snapshots__/ec-with-loading.spec.js.snap
+++ b/src/hocs/ec-with-loading/__snapshots__/ec-with-loading.spec.js.snap
@@ -34,7 +34,7 @@ exports[`EcWithLoading :props should not render transparent when isLoadingTransp
       width="48"
     >
       <use
-        xlink:href="#ec-simple-loading"
+        href="/img/simple-icons.svg#ec-simple-loading"
       />
     </svg>
   </div>
@@ -66,7 +66,7 @@ exports[`EcWithLoading :props should pass rest of the props to the wrapped compo
       width="48"
     >
       <use
-        xlink:href="#ec-simple-loading"
+        href="/img/simple-icons.svg#ec-simple-loading"
       />
     </svg>
   </div>
@@ -98,7 +98,7 @@ exports[`EcWithLoading :props should render transparent by default 1`] = `
       width="48"
     >
       <use
-        xlink:href="#ec-simple-loading"
+        href="/img/simple-icons.svg#ec-simple-loading"
       />
     </svg>
   </div>
@@ -130,7 +130,7 @@ exports[`EcWithLoading :props should render transparent when isLoadingTransparen
       width="48"
     >
       <use
-        xlink:href="#ec-simple-loading"
+        href="/img/simple-icons.svg#ec-simple-loading"
       />
     </svg>
   </div>
@@ -162,7 +162,7 @@ exports[`EcWithLoading :props should show loading when isLoading prop is set to 
       width="48"
     >
       <use
-        xlink:href="#ec-simple-loading"
+        href="/img/simple-icons.svg#ec-simple-loading"
       />
     </svg>
   </div>
@@ -215,7 +215,7 @@ exports[`EcWithLoading :props should use iconSize prop 1`] = `
       width="64"
     >
       <use
-        xlink:href="#ec-simple-loading"
+        href="/img/simple-icons.svg#ec-simple-loading"
       />
     </svg>
   </div>


### PR DESCRIPTION
Because of limitations in SVG support in IE11 we had to load the SVG sprites via AJAX using `inlineSvgSprites` function. This has lots of disadvantages like caching and also issues with CORS requests when serving them from CF domains. Also the preload/prefetch mechanism has never worked for those even if `as` attribute was set to `fetch` or `image`.