### PR TITLE
[ONL-6386] Removing finally block in EcWithAbortableFetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "1.9.6",
+  "version": "1.9.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ebury/chameleon-components",
-      "version": "1.9.6",
+      "version": "1.9.7",
       "license": "MIT",
       "dependencies": {
         "clipboard-copy": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "1.9.6",
+  "version": "1.9.7",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/hocs/ec-with-abortable-fetch/__snapshots__/ec-with-abortable-fetch.spec.js.snap
+++ b/src/hocs/ec-with-abortable-fetch/__snapshots__/ec-with-abortable-fetch.spec.js.snap
@@ -254,7 +254,7 @@ exports[`EcWithAbortableFetch should stop fetching and keep the state intact if 
 Object {
   "data": null,
   "error": null,
-  "loading": false,
+  "loading": true,
 }
 `;
 

--- a/src/hocs/ec-with-abortable-fetch/ec-with-abortable-fetch.js
+++ b/src/hocs/ec-with-abortable-fetch/ec-with-abortable-fetch.js
@@ -56,14 +56,15 @@ const withAbortableFetch = (Component, {
       this.fetchAbortController = new global.AbortController();
       try {
         this.fetchedData = await this.dataSource.fetch(fetchArgs, this.fetchAbortController.signal);
+        this.isFetching = false;
+        this.fetchAbortController = null;
       } catch (err) {
         if (err && err.name !== 'AbortError') {
           this.$emit('error', err);
           this.fetchError = err;
+          this.isFetching = false;
+          this.fetchAbortController = null;
         }
-      } finally {
-        this.fetchAbortController = null;
-        this.isFetching = false;
       }
     },
   },


### PR DESCRIPTION
From now on, `this.fetchAbortController` and `this.isFetching` will be in the _try_ and _catch_ blocks. The _finally_ block is removed.