### PR TITLE
ONL-6464: chore: Expose flatpickr so we can access its setDefaults() method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ebury/chameleon-components",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "license": "MIT",
       "dependencies": {
         "clipboard-copy": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,8 @@ import * as SortDirectionCycle from './enums/sort-direction-cycle';
 
 export { SortDirection, SortDirectionCycle };
 
+export { default as flatpickr } from 'flatpickr';
+
 export { DEFAULT_PAGE_SIZE, PAGE_SIZES } from './enums/pagination';
 
 export { default as config } from './config';


### PR DESCRIPTION
This allows us to get the `flatpickr.setDefaults` function in EBO.