### PR TITLE
ONL-6465: Disable typing disabled dates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ebury/chameleon-components",
-      "version": "1.13.2",
+      "version": "1.13.3",
       "license": "MIT",
       "dependencies": {
         "clipboard-copy": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/components/ec-datepicker/__snapshots__/ec-datepicker.spec.js.snap
+++ b/src/components/ec-datepicker/__snapshots__/ec-datepicker.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`Datepicker :props should have disabled a specific date: calendar 1`] = `
 <div
   class="flatpickr-calendar animate"
-  data-rel-data-test="undefined ec-datepicker"
+  data-rel-data-test="ec-datepicker"
   data-test="ec-datepicker__calendar"
   tabindex="-1"
 >
@@ -555,7 +555,7 @@ exports[`Datepicker :props should have disabled a specific date: calendar 1`] = 
 exports[`Datepicker :props should have disabled weekends: calendar 1`] = `
 <div
   class="flatpickr-calendar animate"
-  data-rel-data-test="undefined ec-datepicker"
+  data-rel-data-test="ec-datepicker"
   data-test="ec-datepicker__calendar"
   tabindex="-1"
 >
@@ -1142,7 +1142,7 @@ exports[`Datepicker :props should render as disabled 1`] = `
 exports[`Datepicker :props should render with Spanish locale: calendar 1`] = `
 <div
   class="flatpickr-calendar animate"
-  data-rel-data-test="undefined ec-datepicker"
+  data-rel-data-test="ec-datepicker"
   data-test="ec-datepicker__calendar"
   tabindex="-1"
 >
@@ -1948,7 +1948,7 @@ exports[`Datepicker :props should render with an error message 1`] = `
 exports[`Datepicker :props should validate if the level prop("level-1") is on the allowed array of strings 1`] = `
 <div
   class="flatpickr-calendar animate flatpickr-calendar--level-1"
-  data-rel-data-test="undefined ec-datepicker"
+  data-rel-data-test="ec-datepicker"
   data-test="ec-datepicker__calendar"
   tabindex="-1"
 >
@@ -2499,7 +2499,7 @@ exports[`Datepicker :props should validate if the level prop("level-1") is on th
 exports[`Datepicker :props should validate if the level prop("level-2") is on the allowed array of strings 1`] = `
 <div
   class="flatpickr-calendar animate flatpickr-calendar--level-2"
-  data-rel-data-test="undefined ec-datepicker"
+  data-rel-data-test="ec-datepicker"
   data-test="ec-datepicker__calendar"
   tabindex="-1"
 >
@@ -3050,7 +3050,7 @@ exports[`Datepicker :props should validate if the level prop("level-2") is on th
 exports[`Datepicker :props should validate if the level prop("level-3") is on the allowed array of strings 1`] = `
 <div
   class="flatpickr-calendar animate flatpickr-calendar--level-3"
-  data-rel-data-test="undefined ec-datepicker"
+  data-rel-data-test="ec-datepicker"
   data-test="ec-datepicker__calendar"
   tabindex="-1"
 >
@@ -3601,7 +3601,7 @@ exports[`Datepicker :props should validate if the level prop("level-3") is on th
 exports[`Datepicker :props should validate if the level prop("modal") is on the allowed array of strings 1`] = `
 <div
   class="flatpickr-calendar animate flatpickr-calendar--modal"
-  data-rel-data-test="undefined ec-datepicker"
+  data-rel-data-test="ec-datepicker"
   data-test="ec-datepicker__calendar"
   tabindex="-1"
 >
@@ -4152,7 +4152,7 @@ exports[`Datepicker :props should validate if the level prop("modal") is on the 
 exports[`Datepicker :props should validate if the level prop("notification") is on the allowed array of strings 1`] = `
 <div
   class="flatpickr-calendar animate flatpickr-calendar--notification"
-  data-rel-data-test="undefined ec-datepicker"
+  data-rel-data-test="ec-datepicker"
   data-test="ec-datepicker__calendar"
   tabindex="-1"
 >
@@ -4703,7 +4703,7 @@ exports[`Datepicker :props should validate if the level prop("notification") is 
 exports[`Datepicker :props should validate if the level prop("tooltip") is on the allowed array of strings 1`] = `
 <div
   class="flatpickr-calendar animate flatpickr-calendar--tooltip"
-  data-rel-data-test="undefined ec-datepicker"
+  data-rel-data-test="ec-datepicker"
   data-test="ec-datepicker__calendar"
   tabindex="-1"
 >
@@ -5254,7 +5254,7 @@ exports[`Datepicker :props should validate if the level prop("tooltip") is on th
 exports[`Datepicker should open the calendar when we click on the input icon 1`] = `
 <div
   class="flatpickr-calendar animate open"
-  data-rel-data-test="undefined ec-datepicker"
+  data-rel-data-test="ec-datepicker"
   data-test="ec-datepicker__calendar"
   tabindex="-1"
 >
@@ -5875,7 +5875,7 @@ exports[`Datepicker should render properly 1`] = `
 exports[`Datepicker watchers should update the locale: calendar 1`] = `
 <div
   class="flatpickr-calendar animate"
-  data-rel-data-test="undefined ec-datepicker"
+  data-rel-data-test="ec-datepicker"
   data-test="ec-datepicker__calendar"
   tabindex="-1"
 >
@@ -6426,7 +6426,7 @@ exports[`Datepicker watchers should update the locale: calendar 1`] = `
 exports[`Datepicker watchers should update the locale: calendar 2`] = `
 <div
   class="flatpickr-calendar animate"
-  data-rel-data-test="undefined ec-datepicker"
+  data-rel-data-test="ec-datepicker"
   data-test="ec-datepicker__calendar"
   tabindex="-1"
 >

--- a/src/components/ec-datepicker/ec-datepicker.spec.js
+++ b/src/components/ec-datepicker/ec-datepicker.spec.js
@@ -582,6 +582,26 @@ describe('Datepicker', () => {
       expect(inputWrapper.vm.model).toBe(null);
     });
 
+    it('should not allow to type a bank holiday', async () => {
+      const { inputWrapper } = mountDatepickerAsTemplate(
+        '<ec-datepicker v-model="model" :disabled-dates="disabledDates"/>',
+        {},
+        {
+          data() {
+            return {
+              model: null,
+              disabledDates: {
+                '2022-02-22': 'Bank holiday',
+              },
+            };
+          },
+        },
+      );
+
+      await setDatepickerInputValue(inputWrapper, '2022-02-22');
+      expect(inputWrapper.vm.model).toBe(null);
+    });
+
     it('should not allow to select a weekend', () => {
       const { inputWrapper, calendarWrapper } = mountDatepickerAsTemplate(
         '<ec-datepicker v-model="model" :are-weekends-disabled="areWeekendsDisabled"/>',

--- a/src/components/ec-datepicker/ec-datepicker.spec.js
+++ b/src/components/ec-datepicker/ec-datepicker.spec.js
@@ -490,7 +490,7 @@ describe('Datepicker', () => {
 
     it('should not allow to type a date smaller than the minDate', async () => {
       const { inputWrapper } = mountDatepickerAsTemplate(
-        '<ec-datepicker v-model="model" />',
+        '<ec-datepicker v-model="model" :options="options"/>',
         {},
         {
           data() {
@@ -536,6 +536,104 @@ describe('Datepicker', () => {
         .trigger('click');
 
       expect(inputWrapper.vm.model.getTime()).toBe(new Date(2022, 1, 22).getTime());
+    });
+
+    it('should not allow to type a date bigger than the maxDate', async () => {
+      const { inputWrapper } = mountDatepickerAsTemplate(
+        '<ec-datepicker v-model="model" :options="options"/>',
+        {},
+        {
+          data() {
+            return {
+              model: null,
+              options: {
+                maxDate: '2022-02-22',
+              },
+            };
+          },
+        },
+      );
+
+      await setDatepickerInputValue(inputWrapper, '2022-02-23');
+
+      expect(inputWrapper.vm.model).toBe(null);
+    });
+
+    it('should not allow to select a bank holiday', () => {
+      const { inputWrapper, calendarWrapper } = mountDatepickerAsTemplate(
+        '<ec-datepicker v-model="model" :disabled-dates="disabledDates"/>',
+        {},
+        {
+          data() {
+            return {
+              model: null,
+              disabledDates: {
+                '2022-02-22': 'Bank holiday',
+              },
+            };
+          },
+        },
+      );
+
+      calendarWrapper
+        .findByDataTest('ec-datepicker__calendar-day--2022-02-22')
+        .trigger('click');
+
+      expect(inputWrapper.vm.model).toBe(null);
+    });
+
+    it('should not allow to select a weekend', () => {
+      const { inputWrapper, calendarWrapper } = mountDatepickerAsTemplate(
+        '<ec-datepicker v-model="model" :are-weekends-disabled="areWeekendsDisabled"/>',
+        {},
+        {
+          data() {
+            return {
+              model: null,
+              areWeekendsDisabled: true,
+            };
+          },
+        },
+      );
+
+      const saturday = 'ec-datepicker__calendar-day--2022-02-19';
+      const sunday = 'ec-datepicker__calendar-day--2022-02-20';
+
+      calendarWrapper
+        .findByDataTest(saturday)
+        .trigger('click');
+
+      expect(inputWrapper.vm.model).toBe(null);
+
+      calendarWrapper
+        .findByDataTest(sunday)
+        .trigger('click');
+
+      expect(inputWrapper.vm.model).toBe(null);
+    });
+
+    it('should not allow to type a weekend', async () => {
+      const { inputWrapper } = mountDatepickerAsTemplate(
+        '<ec-datepicker v-model="model" :are-weekends-disabled="areWeekendsDisabled"/>',
+        {},
+        {
+          data() {
+            return {
+              model: null,
+              areWeekendsDisabled: true,
+            };
+          },
+        },
+      );
+
+      const saturday = '2022-02-19';
+      const sunday = '2022-02-20';
+
+      await setDatepickerInputValue(inputWrapper, saturday);
+      expect(inputWrapper.vm.model).toBe(null);
+
+      await setDatepickerInputValue(inputWrapper, sunday);
+      expect(inputWrapper.vm.model).toBe(null);
     });
   });
 });

--- a/src/components/ec-datepicker/ec-datepicker.spec.js
+++ b/src/components/ec-datepicker/ec-datepicker.spec.js
@@ -459,7 +459,7 @@ describe('Datepicker', () => {
       expect(inputWrapper.vm.model.getTime()).toBe(new Date(2022, 1, 24).getTime());
     });
 
-    it('should not allow to set a date smaller than the minDate', () => {
+    it('should not allow to select a date smaller than the minDate', () => {
       const { inputWrapper, calendarWrapper } = mountDatepickerAsTemplate(
         '<ec-datepicker v-model="model" :options="options" />',
         {},
@@ -488,7 +488,28 @@ describe('Datepicker', () => {
       expect(inputWrapper.vm.model.getTime()).toBe(new Date(2022, 1, 22).getTime());
     });
 
-    it('should not allow to set a date bigger than the maxDate', () => {
+    it('should not allow to type a date smaller than the minDate', async () => {
+      const { inputWrapper } = mountDatepickerAsTemplate(
+        '<ec-datepicker v-model="model" />',
+        {},
+        {
+          data() {
+            return {
+              model: null,
+              options: {
+                minDate: '2022-02-22',
+              },
+            };
+          },
+        },
+      );
+
+      await setDatepickerInputValue(inputWrapper, '2022-02-18');
+
+      expect(inputWrapper.vm.model).toBe(null);
+    });
+
+    it('should not allow to select a date bigger than the maxDate', () => {
       const { inputWrapper, calendarWrapper } = mountDatepickerAsTemplate(
         '<ec-datepicker v-model="model" :options="options" />',
         {},

--- a/src/components/ec-datepicker/ec-datepicker.vue
+++ b/src/components/ec-datepicker/ec-datepicker.vue
@@ -218,7 +218,7 @@ export default {
           if (d) {
             const isoDate = this.isoDate(d);
 
-            if (this.disabledDatesMap.has(isoDate)) {
+            if (this.disabledDatesMap?.has(isoDate)) {
               this.clearInput();
               return;
             }

--- a/src/components/ec-datepicker/ec-datepicker.vue
+++ b/src/components/ec-datepicker/ec-datepicker.vue
@@ -216,7 +216,7 @@ export default {
         onChange: (selectedDates, dateStr) => {
           const date = selectedDates[0];
           if (date) {
-            const isoDate = this.isoDate(date);
+            const isoDate = this.toIsoDate(date);
 
             if (this.disabledDatesMap?.has(isoDate)) {
               this.flatpickrInstance.clear();
@@ -255,7 +255,7 @@ export default {
     setDisabledClass(dayElement) {
       dayElement.className = `${dayElement.className} flatpickr-disabled`;
     },
-    isoDate(dateObj) {
+    toIsoDate(dateObj) {
       const isoDateTime = new Date(Date.UTC(dateObj.getFullYear(), dateObj.getMonth(), dateObj.getDate())).toISOString();
       const [isoDate] = isoDateTime.split('T');
 
@@ -270,15 +270,8 @@ export default {
       return isSaturday || isSunday;
     },
     disableWeekends(dayElement) {
-      if (this.areWeekendsDisabled) {
-        const day = dayElement.dateObj.getDay();
-
-        const isSaturday = day === 6;
-        const isSunday = day === 0;
-
-        if (isSaturday || isSunday) {
-          this.setDisabledClass(dayElement);
-        }
+      if (this.areWeekendsDisabled && this.isWeekendDay(dayElement.dateObj)) {
+        this.setDisabledClass(dayElement);
       }
     },
     disableSpecificDates(dayElement, isoDate) {
@@ -292,7 +285,7 @@ export default {
     },
     onDayCreate(selectedDate, selectedDateFormatted, flatpickrInstance, dayElement) {
       const date = dayElement.dateObj;
-      const isoDate = this.isoDate(date);
+      const isoDate = this.toIsoDate(date);
 
       this.disableWeekends(dayElement);
       if (this.disabledDatesMap?.size) {

--- a/src/components/ec-datepicker/ec-datepicker.vue
+++ b/src/components/ec-datepicker/ec-datepicker.vue
@@ -171,7 +171,7 @@ export default {
     /* istanbul ignore next */
     if (this.flatpickrInstance.calendarContainer) {
       this.flatpickrInstance.calendarContainer.dataset.test = 'ec-datepicker__calendar';
-      this.flatpickrInstance.calendarContainer.dataset.relDataTest = `${this.$attrs['data-test']} ec-datepicker`.trim();
+      this.flatpickrInstance.calendarContainer.dataset.relDataTest = `${this.$attrs['data-test'] ?? ''} ec-datepicker`.trim();
       if (this.level) {
         this.flatpickrInstance.calendarContainer.classList.add(`flatpickr-calendar--${this.level}`);
       }

--- a/src/components/ec-datepicker/ec-datepicker.vue
+++ b/src/components/ec-datepicker/ec-datepicker.vue
@@ -214,6 +214,21 @@ export default {
           this.$emit('ready');
         }],
         onChange: (selectedDates, dateStr) => {
+          const d = selectedDates[0];
+          if (d) {
+            const isoDate = this.isoDate(d);
+
+            if (this.disabledDatesMap.has(isoDate)) {
+              this.clearInput();
+              return;
+            }
+
+            if (this.areWeekendsDisabled && this.isWeekendDay(selectedDates)) {
+              this.clearInput();
+              return;
+            }
+          }
+
           this.formattedValue = dateStr;
           this.$emit('value-change', selectedDates[0] ?? null);
         },
@@ -240,13 +255,33 @@ export default {
     setDisabledClass(dayElement) {
       dayElement.className = `${dayElement.className} flatpickr-disabled`;
     },
+    isSaturday(day) {
+      return day === 6;
+    },
+    isSunday(day) {
+      return day === 0;
+    },
+    clearInput() {
+      this.formattedValue = '';
+      this.$emit('value-change', null);
+    },
+    isoDate(dateObj) {
+      const isoDateTime = new Date(Date.UTC(dateObj.getFullYear(), dateObj.getMonth(), dateObj.getDate())).toISOString();
+      const [isoDate] = isoDateTime.split('T');
+
+      return isoDate;
+    },
+    isWeekendDay(selectedDates) {
+      const d = selectedDates[0];
+      const day = d.getDay();
+
+      return this.isSaturday(day) || this.isSunday(day);
+    },
     disableWeekends(dayElement) {
       if (this.areWeekendsDisabled) {
         const day = dayElement.dateObj.getDay();
-        const isSaturday = day === 6;
-        const isSunday = day === 0;
 
-        if (isSaturday || isSunday) {
+        if (this.isSaturday(day) || this.isSunday(day)) {
           this.setDisabledClass(dayElement);
         }
       }
@@ -262,8 +297,7 @@ export default {
     },
     onDayCreate(selectedDate, selectedDateFormatted, flatpickrInstance, dayElement) {
       const d = dayElement.dateObj;
-      const isoDateTime = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate())).toISOString();
-      const [isoDate] = isoDateTime.split('T');
+      const isoDate = this.isoDate(d);
 
       this.disableWeekends(dayElement);
       if (this.disabledDatesMap?.size) {

--- a/src/components/ec-datepicker/ec-datepicker.vue
+++ b/src/components/ec-datepicker/ec-datepicker.vue
@@ -214,17 +214,17 @@ export default {
           this.$emit('ready');
         }],
         onChange: (selectedDates, dateStr) => {
-          const d = selectedDates[0];
-          if (d) {
-            const isoDate = this.isoDate(d);
+          const date = selectedDates[0];
+          if (date) {
+            const isoDate = this.isoDate(date);
 
             if (this.disabledDatesMap?.has(isoDate)) {
-              this.clearInput();
+              this.flatpickrInstance.clear();
               return;
             }
 
-            if (this.areWeekendsDisabled && this.isWeekendDay(selectedDates)) {
-              this.clearInput();
+            if (this.areWeekendsDisabled && this.isWeekendDay(date)) {
+              this.flatpickrInstance.clear();
               return;
             }
           }
@@ -255,33 +255,28 @@ export default {
     setDisabledClass(dayElement) {
       dayElement.className = `${dayElement.className} flatpickr-disabled`;
     },
-    isSaturday(day) {
-      return day === 6;
-    },
-    isSunday(day) {
-      return day === 0;
-    },
-    clearInput() {
-      this.formattedValue = '';
-      this.$emit('value-change', null);
-    },
     isoDate(dateObj) {
       const isoDateTime = new Date(Date.UTC(dateObj.getFullYear(), dateObj.getMonth(), dateObj.getDate())).toISOString();
       const [isoDate] = isoDateTime.split('T');
 
       return isoDate;
     },
-    isWeekendDay(selectedDates) {
-      const d = selectedDates[0];
-      const day = d.getDay();
+    isWeekendDay(dateObj) {
+      const day = dateObj.getDay();
 
-      return this.isSaturday(day) || this.isSunday(day);
+      const isSaturday = day === 6;
+      const isSunday = day === 0;
+
+      return isSaturday || isSunday;
     },
     disableWeekends(dayElement) {
       if (this.areWeekendsDisabled) {
         const day = dayElement.dateObj.getDay();
 
-        if (this.isSaturday(day) || this.isSunday(day)) {
+        const isSaturday = day === 6;
+        const isSunday = day === 0;
+
+        if (isSaturday || isSunday) {
           this.setDisabledClass(dayElement);
         }
       }
@@ -296,8 +291,8 @@ export default {
       }
     },
     onDayCreate(selectedDate, selectedDateFormatted, flatpickrInstance, dayElement) {
-      const d = dayElement.dateObj;
-      const isoDate = this.isoDate(d);
+      const date = dayElement.dateObj;
+      const isoDate = this.isoDate(date);
 
       this.disableWeekends(dayElement);
       if (this.disabledDatesMap?.size) {


### PR DESCRIPTION
At the EcDatepicker component we have 3 types of disabled dates
- Days before min date limit and days after max date limit (we don't allow to type or select)
- Bank holidays/specific days (we don't allow to select)
- Weekends (we don't allow to select)

All 3 types should have a unified behavior and we should not be able to select them or directly type a disabled date.
When we type a disabled date it should default to an empty input.

This PR is for expanding the behavior that we currently have for min/max dates where we are not allow to type a disabled date to also cover the bank holidays and weekends.