### PR TITLE
[ONL-6745] Migrated ec-navigation-link

### DIFF
--- a/src/components/ec-menu/__snapshots__/ec-menu.spec.js.snap
+++ b/src/components/ec-menu/__snapshots__/ec-menu.spec.js.snap
@@ -11,9 +11,8 @@ exports[`EcMenu should attach custom listeners passed in the link definition 1`]
     data-test="ec-menu__item"
   >
     <a
-      class="ec-navigation-link ec-navigation-link--is-collapsed ec-menu__link"
-      data-test="ec-menu__link foo"
-      datatest="foo"
+      class="ec-menu__link ec-navigation-link ec-navigation-link--is-collapsed"
+      data-test="ec-menu__link foo ec-navigation-link"
       href="/foo"
     >
       <svg
@@ -52,9 +51,8 @@ exports[`EcMenu should not render all items as compact when horizontal is not se
     data-test="ec-menu__item"
   >
     <a
-      class="ec-navigation-link ec-menu__link"
-      data-test="ec-menu__link foo"
-      datatest="foo"
+      class="ec-menu__link ec-navigation-link"
+      data-test="ec-menu__link foo ec-navigation-link"
       href="/foo"
     >
       <svg
@@ -82,8 +80,8 @@ exports[`EcMenu should not render all items as compact when horizontal is not se
     data-test="ec-menu__item"
   >
     <a
-      class="ec-navigation-link ec-menu__link"
-      data-test="ec-menu__link"
+      class="ec-menu__link ec-navigation-link"
+      data-test="ec-menu__link ec-navigation-link"
       href="/bat"
     >
       <svg
@@ -127,9 +125,8 @@ exports[`EcMenu should render all items as compact when is horizontal 1`] = `
     data-test="ec-menu__item"
   >
     <a
-      class="ec-navigation-link ec-navigation-link--is-compact ec-menu__link"
-      data-test="ec-menu__link foo"
-      datatest="foo"
+      class="ec-menu__link ec-navigation-link ec-navigation-link--is-compact"
+      data-test="ec-menu__link foo ec-navigation-link"
       href="/foo"
     >
       <svg
@@ -157,8 +154,8 @@ exports[`EcMenu should render all items as compact when is horizontal 1`] = `
     data-test="ec-menu__item"
   >
     <a
-      class="ec-navigation-link ec-navigation-link--is-compact ec-menu__link"
-      data-test="ec-menu__link"
+      class="ec-menu__link ec-navigation-link ec-navigation-link--is-compact"
+      data-test="ec-menu__link ec-navigation-link"
       href="/bat"
     >
       <svg
@@ -196,9 +193,8 @@ exports[`EcMenu should render as collapsed when isCollapsed is passed into 1`] =
     data-test="ec-menu__item"
   >
     <a
-      class="ec-navigation-link ec-navigation-link--is-collapsed ec-menu__link"
-      data-test="ec-menu__link foo"
-      datatest="foo"
+      class="ec-menu__link ec-navigation-link ec-navigation-link--is-collapsed"
+      data-test="ec-menu__link foo ec-navigation-link"
       href="/foo"
     >
       <svg
@@ -227,8 +223,8 @@ exports[`EcMenu should render as collapsed when isCollapsed is passed into 1`] =
     data-test="ec-menu__item"
   >
     <a
-      class="ec-navigation-link ec-navigation-link--is-collapsed ec-menu__link"
-      data-test="ec-menu__link"
+      class="ec-menu__link ec-navigation-link ec-navigation-link--is-collapsed"
+      data-test="ec-menu__link ec-navigation-link"
       href="/bat"
     >
       <svg
@@ -267,9 +263,8 @@ exports[`EcMenu should render as expanded by default 1`] = `
     data-test="ec-menu__item"
   >
     <a
-      class="ec-navigation-link ec-menu__link"
-      data-test="ec-menu__link foo"
-      datatest="foo"
+      class="ec-menu__link ec-navigation-link"
+      data-test="ec-menu__link foo ec-navigation-link"
       href="/foo"
     >
       <svg
@@ -297,8 +292,8 @@ exports[`EcMenu should render as expanded by default 1`] = `
     data-test="ec-menu__item"
   >
     <a
-      class="ec-navigation-link ec-menu__link"
-      data-test="ec-menu__link"
+      class="ec-menu__link ec-navigation-link"
+      data-test="ec-menu__link ec-navigation-link"
       href="/bat"
     >
       <svg
@@ -336,9 +331,8 @@ exports[`EcMenu should render as expected when set to horizontal 1`] = `
     data-test="ec-menu__item"
   >
     <a
-      class="ec-navigation-link ec-navigation-link--is-compact ec-menu__link"
-      data-test="ec-menu__link foo"
-      datatest="foo"
+      class="ec-menu__link ec-navigation-link ec-navigation-link--is-compact"
+      data-test="ec-menu__link foo ec-navigation-link"
       href="/foo"
     >
       <svg
@@ -376,9 +370,8 @@ exports[`EcMenu should render only links with a url property 1`] = `
     data-test="ec-menu__item"
   >
     <a
-      class="ec-navigation-link ec-menu__link"
-      data-test="ec-menu__link foo"
-      datatest="foo"
+      class="ec-menu__link ec-navigation-link"
+      data-test="ec-menu__link foo ec-navigation-link"
       href="/foo"
     >
       <svg
@@ -406,8 +399,8 @@ exports[`EcMenu should render only links with a url property 1`] = `
     data-test="ec-menu__item"
   >
     <a
-      class="ec-navigation-link ec-menu__link"
-      data-test="ec-menu__link"
+      class="ec-menu__link ec-navigation-link"
+      data-test="ec-menu__link ec-navigation-link"
       href="/bat"
     >
       <svg

--- a/src/components/ec-menu/ec-menu.vue
+++ b/src/components/ec-menu/ec-menu.vue
@@ -12,11 +12,11 @@
       data-test="ec-menu__item"
     >
       <ec-navigation-link
+        v-bind="{ ...link, on: null, dataTest: null, 'data-test': getLinkDataTest(link) }"
         class="ec-menu__link"
-        v-bind="{ ...link, on: null, 'data-test': getLinkDataTest(link) }"
         :is-collapsed="isCollapsed"
         :is-compact="horizontal"
-        v-on="link.on"
+        v-on="link.on || {}"
       />
     </li>
   </ul>

--- a/src/components/ec-navigation-link/__snapshots__/ec-navigation-link.spec.js.snap
+++ b/src/components/ec-navigation-link/__snapshots__/ec-navigation-link.spec.js.snap
@@ -109,6 +109,34 @@ exports[`EcNavigationLink as regular anchor should hide the text when is collaps
 </a>
 `;
 
+exports[`EcNavigationLink as regular anchor should pass custom attributes 1`] = `
+<a
+  class="my-custom-class ec-navigation-link"
+  data-test="my-custom-link ec-navigation-link"
+  href="/balances"
+  id="my-link"
+>
+  <svg
+    class="ec-icon ec-navigation-link__icon"
+    data-test="ec-navigation-link__icon"
+    height="24"
+    width="24"
+  >
+    <use
+      xlink:href="#ec-single-check"
+    />
+  </svg>
+  <transition-stub>
+    <span
+      class="ec-navigation-link__text"
+      data-test="ec-navigation-link__text"
+    >
+      Link
+    </span>
+  </transition-stub>
+</a>
+`;
+
 exports[`EcNavigationLink as regular anchor should render as a normal <a> tag if isRouterLink is set to false 1`] = `
 <a
   class="ec-navigation-link"
@@ -276,6 +304,37 @@ exports[`EcNavigationLink as router-link should hide the text when is collapsed 
       class="ec-navigation-link__text"
       data-test="ec-navigation-link__text"
       style="display: none;"
+    >
+      Link
+    </span>
+  </transition-stub>
+  
+</ec-stub>
+`;
+
+exports[`EcNavigationLink as router-link should pass custom attributes 1`] = `
+<ec-stub
+  active-class="ec-navigation-link--is-active"
+  class="my-custom-class ec-navigation-link"
+  data-test="my-custom-link ec-navigation-link ec-stub router-link-stub"
+  id="my-link"
+  to="/balances"
+>
+  
+  <svg
+    class="ec-icon ec-navigation-link__icon"
+    data-test="ec-navigation-link__icon"
+    height="24"
+    width="24"
+  >
+    <use
+      xlink:href="#ec-single-check"
+    />
+  </svg>
+  <transition-stub>
+    <span
+      class="ec-navigation-link__text"
+      data-test="ec-navigation-link__text"
     >
       Link
     </span>

--- a/src/components/ec-navigation-link/ec-navigation-link.spec.js
+++ b/src/components/ec-navigation-link/ec-navigation-link.spec.js
@@ -7,7 +7,7 @@ describe('EcNavigationLink', () => {
   it('should throw an error if prop text was not given', () => {
     withMockedConsole((errorSpy, warnSpy) => {
       mount(EcNavigationLink);
-      expect(warnSpy).toHaveBeenCalledTimes(5);
+      expect(warnSpy).toHaveBeenCalledTimes(4);
       expect(warnSpy.mock.calls[1][0]).toContain('Missing required prop: "text"');
     });
   });
@@ -19,7 +19,7 @@ describe('EcNavigationLink', () => {
           text: 'Random text',
         },
       });
-      expect(warnSpy).toHaveBeenCalledTimes(3);
+      expect(warnSpy).toHaveBeenCalledTimes(2);
       expect(warnSpy.mock.calls[0][0]).toContain('Missing required prop: "url"');
     });
   });
@@ -73,6 +73,28 @@ describe('EcNavigationLink', () => {
       const wrapper = mountAsRouterLink({ isCompact: true });
       expect(wrapper.element).toMatchSnapshot();
       expect(wrapper.classes('ec-navigation-link--is-compact')).toBe(true);
+    });
+
+    it('should pass listeners from parent to the root', () => {
+      const clickSpy = jest.fn();
+      const wrapper = mountAsRouterLink({}, {
+        attrs: { onClick: clickSpy },
+      });
+
+      wrapper.trigger('click');
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should pass custom attributes', () => {
+      const wrapper = mountAsRouterLink(
+        {
+          id: 'my-link',
+          'data-test': 'my-custom-link',
+          class: 'my-custom-class',
+        },
+      );
+
+      expect(wrapper.element).toMatchSnapshot();
     });
   });
 
@@ -135,6 +157,18 @@ describe('EcNavigationLink', () => {
 
       wrapper.trigger('click');
       expect(clickSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('should pass custom attributes', () => {
+      const wrapper = mountAsAnchor(
+        {
+          id: 'my-link',
+          'data-test': 'my-custom-link',
+          class: 'my-custom-class',
+        },
+      );
+
+      expect(wrapper.element).toMatchSnapshot();
     });
   });
 });

--- a/src/components/ec-navigation-link/ec-navigation-link.vue
+++ b/src/components/ec-navigation-link/ec-navigation-link.vue
@@ -2,17 +2,18 @@
   <!-- If it is a router link -->
   <router-link
     v-if="isRouterLink"
+    v-bind="{
+      ...$attrs,
+      'data-test': $attrs['data-test'] ? `${$attrs['data-test']} ec-navigation-link` : 'ec-navigation-link',
+    }"
     active-class="ec-navigation-link--is-active"
     class="ec-navigation-link"
-    data-test="ec-navigation-link"
     :class="{
       'ec-navigation-link--is-active': isActive,
       'ec-navigation-link--is-compact': isCompact,
       'ec-navigation-link--is-collapsed': isCollapsed
     }"
-    :exact="isExact"
     :to="url"
-    v-on="$listeners"
   >
     <ec-icon
       class="ec-navigation-link__icon"
@@ -33,8 +34,11 @@
   <!-- If is a normal link that directs you outside the SPA -->
   <a
     v-else
+    v-bind="{
+      ...$attrs,
+      'data-test': $attrs['data-test'] ? `${$attrs['data-test']} ec-navigation-link` : 'ec-navigation-link',
+    }"
     class="ec-navigation-link"
-    data-test="ec-navigation-link"
     :class="{
       'ec-navigation-link--is-active': isActive,
       'ec-navigation-link--is-compact': isCompact,
@@ -42,7 +46,6 @@
     }"
     :href="url"
     :target="target"
-    v-on="$listeners"
   >
     <ec-icon
       class="ec-navigation-link__icon"
@@ -64,9 +67,13 @@
 import EcIcon from '../ec-icon/ec-icon.vue';
 
 export default {
+  compatConfig: {
+    MODE: 3,
+  },
   components: {
     EcIcon,
   },
+  inheritAttrs: false,
   props: {
     text: {
       type: String,
@@ -80,10 +87,6 @@ export default {
     url: {
       type: String,
       required: true,
-    },
-    isExact: {
-      type: Boolean,
-      default: false,
     },
     isRouterLink: {
       type: Boolean,

--- a/tests/stubs/router-link.stub.js
+++ b/tests/stubs/router-link.stub.js
@@ -2,6 +2,12 @@ import { defineComponent } from 'vue';
 
 const RouterLinkStub = defineComponent({
   name: 'RouterLinkStub',
+  compatConfig: {
+    MODE: 3,
+  },
+  compilerOptions: {
+    whitespace: 'condense',
+  },
   inheritAttrs: false,
   template: `
   <ec-stub

--- a/tests/stubs/router-view.stub.js
+++ b/tests/stubs/router-view.stub.js
@@ -2,6 +2,12 @@ import { defineComponent } from 'vue';
 
 const RouterViewStub = defineComponent({
   name: 'RouterViewStub',
+  compatConfig: {
+    MODE: 3,
+  },
+  compilerOptions: {
+    whitespace: 'condense',
+  },
   inheritAttrs: false,
   template: `
   <ec-stub


### PR DESCRIPTION
Removed `isExact` prop from navigation link because it's no longer supported by vue-router@4 (https://router.vuejs.org/api/index.html#router-link-props).

This prop existed in version 3 (https://v3.router.vuejs.org/api/#exact) but it's no longer needed because the exact class is now determined always by the router.