### PR TITLE
[ONL-6861] fix: Fixed webpack cache when deploying to prod.

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -34,7 +34,7 @@ module.exports = {
       },
     },
   ],
-  webpackFinal: (config) => {
+  webpackFinal: (config, { configType }) => {
     // enable @vue/compat for stories
     config.resolve.alias = {
       ...config.resolve.alias,
@@ -88,6 +88,11 @@ module.exports = {
       }
       return resourceAssetsFilename;
     };
+
+    if (configType === 'PRODUCTION') {
+      config.cache = false;
+      babelRule.use[0].options.cacheDirectory = false;
+    }
 
     return config;
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",
   "license": "MIT",
-  "homepage": "https://chameleon.ebury.now.sh/",
+  "homepage": "https://chameleon-ebury.vercel.app/",
   "repository": {
     "type": "git",
     "url": "https://github.com/ebury/chameleon.git"


### PR DESCRIPTION
When developing the fix for Main container responsivness, we have noticed that the styles in vercel preview has not been updated. It could be because webpack and babel cache everything on the filesystem in the node_modules. If vercel reuses the same node_modules for each build, it may not pick up changes done in the branch. This PR fixes that and disables the caching when running the production build.

This issue started after migrating Storybook to Webpack 5 when adding Vue 3.