### PR TITLE
[ONL-6886] fix: Fixed linters in Circle CI are running in fix mode.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
           command: CYPRESS_INSTALL_BINARY=0 npm ci
       - run:
           name: lint
-          command: npm run lint
+          command: npm run lint:no-fix
       - run:
           name: test
           command: npm run test -- --max-workers=2

--- a/package.json
+++ b/package.json
@@ -16,8 +16,11 @@
   "scripts": {
     "icons": "webpack --config ./src/icons/webpack.config.js --mode=production",
     "lint": "npm run lint:js && npm run lint:style",
-    "lint:js": "vue-cli-service lint -- ./",
+    "lint:no-fix": "npm run lint:js:no-fix && npm run lint:style:no-fix",
+    "lint:js": "vue-cli-service lint ./",
+    "lint:js:no-fix": "vue-cli-service lint --no-fix ./",
     "lint:style": "stylelint ./src/**/*.{css,vue} --fix",
+    "lint:style:no-fix": "stylelint ./src/**/*.{css,vue}",
     "test": "vue-cli-service test:unit",
     "test:watch": "vue-cli-service test:unit --watch",
     "test:visual": "cypress open",

--- a/src/composables/use-ec-pagination/use-ec-pagination.spec.js
+++ b/src/composables/use-ec-pagination/use-ec-pagination.spec.js
@@ -26,7 +26,7 @@ describe('useEcPagination', () => {
       useEcPagination({
         initialNumberOfItems: 42,
       });
-    }).toThrowError(`Invalid number of items: 42. Expecting one of: ${PAGE_SIZES}`);
+    }).toThrow(`Invalid number of items: 42. Expecting one of: ${PAGE_SIZES}`);
   });
 
   it('should update the pagination when paginate is called', () => {

--- a/src/composables/use-ec-sorting/use-ec-sorting.spec.js
+++ b/src/composables/use-ec-sorting/use-ec-sorting.spec.js
@@ -27,7 +27,7 @@ describe('useEcSorting', () => {
       useEcSorting({
         sortCycle: ['HI', 'LO'],
       });
-    }).toThrowError('Invalid sortCycle: HI,LO');
+    }).toThrow('Invalid sortCycle: HI,LO');
   });
 
   describe('multi sort', () => {

--- a/src/directives/ec-amount/ec-amount.spec.js
+++ b/src/directives/ec-amount/ec-amount.spec.js
@@ -55,7 +55,7 @@ describe('EcAmount', () => {
 
   it('should throw an error if the directive is not attached to an input', () => {
     withMockedConsole((errorSpy, warnSpy) => {
-      expect(() => mountTemplate('<div v-ec-amount="{}"></div>')).toThrowError(new TypeError('v-ec-amount requires 1 input'));
+      expect(() => mountTemplate('<div v-ec-amount="{}"></div>')).toThrow(new TypeError('v-ec-amount requires 1 input'));
       expect(warnSpy).toHaveBeenCalledTimes(1);
       expect(warnSpy.mock.calls[0][0]).toContain('Unhandled error during execution of directive hook');
     });

--- a/src/utils/countdown.spec.js
+++ b/src/utils/countdown.spec.js
@@ -41,8 +41,8 @@ describe('Countdown', () => {
     countdown.start(20);
     clock.tick(20000);
 
-    expect(timeExpiredMock).toBeCalledTimes(1);
-    expect(timeUpdatedMock).toBeCalledTimes(20);
+    expect(timeExpiredMock).toHaveBeenCalledTimes(1);
+    expect(timeUpdatedMock).toHaveBeenCalledTimes(20);
     expect(clock.countTimers()).toBe(0);
   });
 });

--- a/src/utils/mask.spec.js
+++ b/src/utils/mask.spec.js
@@ -32,21 +32,21 @@ describe('Utils', () => {
     it('should throw if no text is provided', () => {
       const textToBeMasked = null;
 
-      expect(() => mask(textToBeMasked)).toThrowError(new Error('Text is required'));
+      expect(() => mask(textToBeMasked)).toThrow(new Error('Text is required'));
     });
 
     it('should throw if no mask symbol is provided', () => {
       const textToBeMasked = 'lorem';
       const maskSybol = null;
 
-      expect(() => mask(textToBeMasked, maskSybol)).toThrowError(new Error('Mask symbol cannot be empty'));
+      expect(() => mask(textToBeMasked, maskSybol)).toThrow(new Error('Mask symbol cannot be empty'));
     });
 
     it('should throw if no mask symbol is provided', () => {
       const textToBeMasked = 'lorem';
       const maskSybol = null;
 
-      expect(() => mask(textToBeMasked, maskSybol)).toThrowError(new Error('Mask symbol cannot be empty'));
+      expect(() => mask(textToBeMasked, maskSybol)).toThrow(new Error('Mask symbol cannot be empty'));
     });
 
     it('should throw if visibleChars is not provided', () => {
@@ -54,7 +54,7 @@ describe('Utils', () => {
       const maskSybol = '#';
       const visibleChars = null;
 
-      expect(() => mask(textToBeMasked, maskSybol, visibleChars)).toThrowError(new Error('Visible characters must be a number greater than zero'));
+      expect(() => mask(textToBeMasked, maskSybol, visibleChars)).toThrow(new Error('Visible characters must be a number greater than zero'));
     });
 
     it('should throw if visibleChars is negative', () => {
@@ -62,7 +62,7 @@ describe('Utils', () => {
       const maskSybol = '#';
       const visibleChars = -1;
 
-      expect(() => mask(textToBeMasked, maskSybol, visibleChars)).toThrowError(new Error('Visible characters must be a number greater than zero'));
+      expect(() => mask(textToBeMasked, maskSybol, visibleChars)).toThrow(new Error('Visible characters must be a number greater than zero'));
     });
   });
 });


### PR DESCRIPTION
When linting the code in Circle CI, we should always run them without fixing the errors. The linters should fail the build instead.

I have fixed all linting issues that have happened recently after dependabot updated some eslint dependencies. They were not reported by the build, but fixed.

Screenshot from master build shows that there are eslint errors but they were fixed instead:
![Screenshot from 2022-09-08 18-03-29](https://user-images.githubusercontent.com/5777410/189182672-7d6e81a0-a971-4150-93c8-17141d6ef56f.png)
