### PR TITLE
[ONL-6912] Added complementary colors to chameleon and gradients that are using them

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ebury/chameleon-components",
-      "version": "2.1.8",
+      "version": "2.1.9",
       "license": "MIT",
       "dependencies": {
         "@vueuse/core": "9.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/styles/settings/colors/colors.story.js
+++ b/src/styles/settings/colors/colors.story.js
@@ -1,8 +1,6 @@
 import { createEventHook } from '@vueuse/core';
 import Color from 'color';
-import {
-  getCurrentInstance, onBeforeMount, onBeforeUnmount,
-} from 'vue';
+import { getCurrentInstance, onBeforeUnmount, onMounted } from 'vue';
 
 export default {
   title: 'CSS/Colors',
@@ -13,7 +11,7 @@ function useCssResourceAddonSync({ global, document }) {
 
   let mutationObserver;
 
-  onBeforeMount(() => {
+  onMounted(() => {
     if (global.MutationObserver) {
       mutationObserver = new global.MutationObserver((ev) => {
         onChanged.trigger(ev);

--- a/src/styles/settings/colors/complementary-color-scale.css
+++ b/src/styles/settings/colors/complementary-color-scale.css
@@ -1,0 +1,4 @@
+:root {
+  --ec-complementary-color-level-1: var(--ec-theme-complementary-color-level-1, var(--ec-key-color-level-4));
+  --ec-complementary-color-level-2: var(--ec-theme-complementary-color-level-2, var(--ec-key-color-level-2));
+}

--- a/src/styles/settings/colors/index.css
+++ b/src/styles/settings/colors/index.css
@@ -2,3 +2,4 @@
 @import 'key-color-scale';
 @import 'gray-color-scale';
 @import 'reserved-color-scale';
+@import 'complementary-color-scale';

--- a/src/styles/themes/b-w.css
+++ b/src/styles/themes/b-w.css
@@ -15,4 +15,6 @@
   --ec-theme-gray-color-level-6: 0, 0%, 88%;
   --ec-theme-gray-color-level-7: 0, 0%, 96%;
   --ec-theme-gray-color-level-8: 0, 0%, 100%;
+  --ec-theme-complementary-color-level-1: initial;
+  --ec-theme-complementary-color-level-2: initial;
 }

--- a/src/styles/themes/blue.css
+++ b/src/styles/themes/blue.css
@@ -15,4 +15,6 @@
   --ec-theme-gray-color-level-6: 192.5, 10%, 88%;
   --ec-theme-gray-color-level-7: 192.5, 10%, 96%;
   --ec-theme-gray-color-level-8: 192.5, 10%, 100%;
+  --ec-theme-complementary-color-level-1: 184, 67%, 47%;
+  --ec-theme-complementary-color-level-2: 184, 67%, 57%;
 }

--- a/src/styles/themes/green.css
+++ b/src/styles/themes/green.css
@@ -15,4 +15,6 @@
   --ec-theme-gray-color-level-6: 164, 10%, 88%;
   --ec-theme-gray-color-level-7: 164, 10%, 96%;
   --ec-theme-gray-color-level-8: 164, 10%, 100%;
+  --ec-theme-complementary-color-level-1: initial;
+  --ec-theme-complementary-color-level-2: initial;
 }

--- a/src/styles/themes/hotpink.css
+++ b/src/styles/themes/hotpink.css
@@ -15,4 +15,6 @@
   --ec-theme-gray-color-level-6: 305, 10%, 88%;
   --ec-theme-gray-color-level-7: 305, 10%, 96%;
   --ec-theme-gray-color-level-8: 305, 10%, 100%;
+  --ec-theme-complementary-color-level-1: initial;
+  --ec-theme-complementary-color-level-2: initial;
 }

--- a/src/styles/themes/red.css
+++ b/src/styles/themes/red.css
@@ -15,4 +15,6 @@
   --ec-theme-gray-color-level-6: 1, 10%, 88%;
   --ec-theme-gray-color-level-7: 1, 10%, 96%;
   --ec-theme-gray-color-level-8: 1, 10%, 100%;
+  --ec-theme-complementary-color-level-1: initial;
+  --ec-theme-complementary-color-level-2: initial;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -48,6 +48,11 @@ module.exports = {
         8: 'hsl(var(--ec-gray-color-level-8))',
       },
 
+      complementary: {
+        1: 'hsl(var(--ec-complementary-color-level-1))',
+        2: 'hsl(var(--ec-complementary-color-level-2))',
+      },
+
       additional: {
         18: 'hsl(var(--ec-additional-color-level-18))',
         51: 'hsl(var(--ec-additional-color-level-51))',
@@ -127,6 +132,7 @@ module.exports = {
     backgroundColor: theme => theme('colors'),
     backgroundImage: {
       none: 'none',
+      'gradient-1': 'linear-gradient(132.46deg, theme(colors.complementary.2) 21.71%, theme(colors.key.4) 73.94%)',
       // 'gradient-to-t': 'linear-gradient(to top, var(--tw-gradient-stops))',
       // 'gradient-to-tr': 'linear-gradient(to top right, var(--tw-gradient-stops))',
       // 'gradient-to-r': 'linear-gradient(to right, var(--tw-gradient-stops))',
@@ -937,7 +943,7 @@ module.exports = {
     backgroundBlendMode: [ /* 'responsive' */ ],
     backgroundClip: [ /* 'responsive' */ ],
     backgroundColor: [ /* 'responsive', 'dark', 'group-hover', 'focus-within', */ 'hover', 'focus' ],
-    backgroundImage: [ /* 'responsive' */ ],
+    backgroundImage: [ 'responsive' ],
     backgroundOpacity: [ /* 'responsive', 'dark', 'group-hover', 'focus-within', 'hover', 'focus' */ ],
     backgroundPosition: [ /* 'responsive' */ ],
     backgroundRepeat: [ /* 'responsive' */ ],


### PR DESCRIPTION
The Figma spec has another colors theme called complementary colors, those are only to pair them with key colors to create gradients. We use a gradient like this in the legacy code (login page) and now there's a requirement for the modern code (Cards).

Complementary colors are brandable but only 7 brands (all based on Ebury's base color) are going to have them set. Rest of the brands will use key-color-4 and key-color-2 as a backup if complementary colors are not specified (that's what legacy does too).

There will be another PR in EBO to populate `--ec-theme-complementary-color-level-1` and `--ec-theme-complementary-color-level-2` from brand settings. The goal is to be able use a new class `tw-bg-gradient-1` to produce the same gradient as in Figma.

Design link: https://www.figma.com/file/E8q7GWDqRi6WG6pmmTURpG/01.-Chameleon-Library?node-id=0%3A1
Checkout the SB: https://chameleon-git-onl-6912-complementary-color-ebury.vercel.app/?path=/story/css-colors--all. You can change the theme via CSS Resources addon to see how it behaves for other themes which don't have these colors set.