### PR TITLE
[ONL-6946] Fixed metroline using undefined as provide key.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "2.1.11",
+  "version": "2.1.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ebury/chameleon-components",
-      "version": "2.1.11",
+      "version": "2.1.12",
       "license": "MIT",
       "dependencies": {
         "@vueuse/core": "9.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "2.1.11",
+  "version": "2.1.12",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/components/ec-metroline/components/ec-metroline-item/ec-metroline-item.vue
+++ b/src/components/ec-metroline/components/ec-metroline-item/ec-metroline-item.vue
@@ -109,7 +109,7 @@ import {
 } from 'vue';
 
 import EcIcon from '../../../ec-icon';
-import METROLINE_PROVIDE_KEY from '../../ec-metroline-provide';
+import { METROLINE_PROVIDE_KEY } from '../../ec-metroline-provide';
 
 const METROLINE_ITEM_STATUS = {
   next: 'next',

--- a/src/components/ec-metroline/ec-metroline.vue
+++ b/src/components/ec-metroline/ec-metroline.vue
@@ -10,7 +10,7 @@
 <script setup>
 import { provide, reactive, ref } from 'vue';
 
-import METROLINE_PROVIDE_KEY from './ec-metroline-provide';
+import { METROLINE_PROVIDE_KEY } from './ec-metroline-provide';
 
 const emit = defineEmits(['change', 'complete']);
 

--- a/src/main.js
+++ b/src/main.js
@@ -39,6 +39,7 @@ export { default as EcMainContainer } from './components/ec-main-container';
 export { default as EcMenu } from './components/ec-menu';
 export { default as EcMetroline } from './components/ec-metroline';
 export { default as EcMetrolineItem } from './components/ec-metroline/components/ec-metroline-item';
+export { METROLINE_PROVIDE_KEY } from './components/ec-metroline/ec-metroline-provide';
 export { default as EcModal } from './components/ec-modal';
 export { default as EcMultipleValuesSelection } from './components/ec-multiple-values-selection';
 export { default as EcNavigation } from './components/ec-navigation';


### PR DESCRIPTION
Added METROLINE_PROVIDE_KEY to main exports because it's needed in EBO tests.