### PR TITLE
[ONL-7004] chore: Enabled gradient stop colors.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "2.1.17",
+  "version": "2.1.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ebury/chameleon-components",
-      "version": "2.1.17",
+      "version": "2.1.18",
       "license": "MIT",
       "dependencies": {
         "@vueuse/core": "9.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "2.1.18",
+  "version": "2.1.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ebury/chameleon-components",
-      "version": "2.1.18",
+      "version": "2.1.19",
       "license": "MIT",
       "dependencies": {
         "@vueuse/core": "9.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "2.1.18",
+  "version": "2.1.19",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -133,14 +133,14 @@ module.exports = {
     backgroundImage: {
       none: 'none',
       'gradient-1': 'linear-gradient(132.46deg, theme(colors.complementary.2) 21.71%, theme(colors.key.4) 73.94%)',
-      // 'gradient-to-t': 'linear-gradient(to top, var(--tw-gradient-stops))',
-      // 'gradient-to-tr': 'linear-gradient(to top right, var(--tw-gradient-stops))',
-      // 'gradient-to-r': 'linear-gradient(to right, var(--tw-gradient-stops))',
-      // 'gradient-to-br': 'linear-gradient(to bottom right, var(--tw-gradient-stops))',
-      // 'gradient-to-b': 'linear-gradient(to bottom, var(--tw-gradient-stops))',
-      // 'gradient-to-bl': 'linear-gradient(to bottom left, var(--tw-gradient-stops))',
-      // 'gradient-to-l': 'linear-gradient(to left, var(--tw-gradient-stops))',
-      // 'gradient-to-tl': 'linear-gradient(to top left, var(--tw-gradient-stops))',
+      'gradient-to-t': 'linear-gradient(to top, var(--tw-gradient-stops))',
+      'gradient-to-tr': 'linear-gradient(to top right, var(--tw-gradient-stops))',
+      'gradient-to-r': 'linear-gradient(to right, var(--tw-gradient-stops))',
+      'gradient-to-br': 'linear-gradient(to bottom right, var(--tw-gradient-stops))',
+      'gradient-to-b': 'linear-gradient(to bottom, var(--tw-gradient-stops))',
+      'gradient-to-bl': 'linear-gradient(to bottom left, var(--tw-gradient-stops))',
+      'gradient-to-l': 'linear-gradient(to left, var(--tw-gradient-stops))',
+      'gradient-to-tl': 'linear-gradient(to top left, var(--tw-gradient-stops))',
     },
     // backgroundOpacity: theme => theme('opacity'),
     // backgroundPosition: {
@@ -321,7 +321,7 @@ module.exports = {
     //   DEFAULT: '100%',
     // },
     // gap: (theme) => theme('spacing'),
-    // gradientColorStops: (theme) => theme('colors'),
+    gradientColorStops: theme => theme('colors'),
     // gridAutoColumns: {
     //   auto: 'auto',
     //   min: 'min-content',
@@ -985,7 +985,7 @@ module.exports = {
     fontVariantNumeric: [ /* 'responsive' */ ],
     fontWeight: [ /* 'responsive' */ ],
     gap: [ /* 'responsive' */ ],
-    gradientColorStops: [ /* 'responsive', 'dark', 'hover', 'focus' */ ],
+    gradientColorStops: [ /* 'responsive', 'dark', */ 'hover', 'focus' ],
     grayscale: [ /* 'responsive' */ ],
     gridAutoColumns: [ /* 'responsive' */ ],
     gridAutoFlow: [ /* 'responsive' */ ],
@@ -1161,7 +1161,7 @@ module.exports = {
     backgroundColor: true,
     backgroundOpacity: true,
     backgroundImage: true,
-    gradientColorStops: false, // very rarely used
+    gradientColorStops: true,
     boxDecorationBreak: true,
     backgroundSize: false, // very rarely used
     backgroundAttachment: false, // very rarely used


### PR DESCRIPTION
Allow constructing gradients using TW classes, e.g.

```html
<h1 class="tw-bg-gradient-to-r tw-from-key-3 tw-to-key-6 tw-text-key-7">Test</h1>
```

Produces:

![Screenshot from 2022-10-25 16-51-26](https://user-images.githubusercontent.com/5777410/197821767-5d27185b-5b84-4351-b540-3c73eb6f4f87.png)

and 
```
<h1 class="tw-bg-gradient-to-r tw-from-key-3 tw-to-key-6 tw-via-gray-4 tw-text-gray-7">Test</h1>
```

Produces:

![Screenshot from 2022-10-25 16-53-21](https://user-images.githubusercontent.com/5777410/197822201-367904ef-80ad-458f-a7ec-6f17a219da54.png)
