### PR TITLE
[ONL-7004] Expose stop-color as individual classes so they can be used inside SVGs.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "2.1.19",
+  "version": "2.1.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ebury/chameleon-components",
-      "version": "2.1.19",
+      "version": "2.1.20",
       "license": "MIT",
       "dependencies": {
         "@vueuse/core": "9.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "2.1.19",
+  "version": "2.1.20",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /* eslint-disable array-bracket-spacing */
 const plugin = require('tailwindcss/plugin');
+const flattenColorPalette = require('tailwindcss/lib/util/flattenColorPalette').default;
 
 // see https://github.com/tailwindcss/tailwindcss/blob/master/stubs/defaultConfig.stub.js
 // for reference config
@@ -1240,6 +1241,7 @@ module.exports = {
   plugins: [
     plugin(typographyPlugin),
     plugin(flexboxGridPlugin),
+    plugin(stopColorPlugin),
   ],
 };
 
@@ -1312,4 +1314,14 @@ function flexboxGridPlugin({ addUtilities, theme }) {
   };
 
   addUtilities(grid, ['responsive']);
+}
+
+function stopColorPlugin({ matchUtilities, theme }) {
+  matchUtilities({
+    stop: value => ({
+      'stop-color': value,
+    }),
+  }, {
+    values: flattenColorPalette(theme('colors')),
+  });
 }


### PR DESCRIPTION
An additional feature for gradients in chameleon, we need to be able to access gradient stop colors as individual classes (tw-stop-key-4) so they can be re-used in SVG gradients too.