### PR TITLE
[ONL-7016] fix: Prevent purgecss purging generic CSS.

### DIFF
--- a/src/styles/elements/index.css
+++ b/src/styles/elements/index.css
@@ -1,2 +1,6 @@
+/* purgecss start ignore */
+
 @import 'elements';
 @import 'tables';
+
+/* purgecss end ignore */

--- a/src/styles/generic/index.css
+++ b/src/styles/generic/index.css
@@ -1,4 +1,8 @@
+/* purgecss start ignore */
+
 @import 'tailwindcss/base';
 @import 'css-reset';
 @import 'fonts';
 @import 'normalize';
+
+/* purgecss end ignore */

--- a/src/styles/settings/index.css
+++ b/src/styles/settings/index.css
@@ -1,2 +1,6 @@
+/* purgecss start ignore */
+
 @import 'colors';
 @import 'layout';
+
+/* purgecss end ignore */


### PR DESCRIPTION
While investigating the ec-modal, I noticed that the footer in ec-modal is broken in SB (https://chameleon-ebury.vercel.app/iframe.html?args=large:true&id=modal--basic&viewMode=story)

![Screenshot from 2022-10-31 14-46-35](https://user-images.githubusercontent.com/5777410/199036285-95a211ca-273d-48ed-89a9-55c0532e7fd6.png)

The buttons no longer have box-sizing set to border-box but to content-box. All elements in the chameleon should inherit box-sizing from the parent, html should set it to border-box (elements.css):

```
html {
  box-sizing: border-box;
}

*,
*:before,
*:after {
  box-sizing: inherit;
}
```

^^ But this is no longer included in the generated CSS. Other bits from the `elements.css` are included but not this one. It turned out it's purgecss removing the styles for `html` very likely due to a change from vue/cli to vite which uses PostCSS very different way.

The first 3 layers of ITCSS shouldn't be purged at all as they are essential base for every element on the page. I added comments for purgecss to leave them alone. The size of the bundle went up by 0.7kB, the missing bits are now presented in the generated CSS.