### PR TITLE
[ONL-7030] chore: allow outside click

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "2.1.23",
+  "version": "2.1.24",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ebury/chameleon-components",
-      "version": "2.1.23",
+      "version": "2.1.24",
       "license": "MIT",
       "dependencies": {
         "@vueuse/core": "9.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "2.1.23",
+  "version": "2.1.24",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/components/ec-full-screen-overlay/ec-full-screen-overlay.vue
+++ b/src/components/ec-full-screen-overlay/ec-full-screen-overlay.vue
@@ -77,6 +77,7 @@ const { deactivate } = useFocusTrap(overlayContent, {
   escapeDeactivates: false,
   clickOutsideDeactivates: false,
   initialFocus: false,
+  allowOutsideClick: true,
 });
 
 onUnmounted(() => {


### PR DESCRIPTION
Currently when focus trap is enabled and we have an element like a dropdown inside the overlay, we won't be able to click on the items of the dropdown. 

Adding `allowOutsideClick: true` solves the issue.