### PR TITLE
ONL-7256 Fix vue-props-interface rule for ESLint

### DIFF
--- a/eslint/lib/rules/vue-props-interface.js
+++ b/eslint/lib/rules/vue-props-interface.js
@@ -18,9 +18,38 @@ module.exports = {
   },
 
   create(context) {
+    function getDiffProps(fileInterfaceStructure, vueInterface) {
+      const fileInterfaceProperties = fileInterfaceStructure.properties.map(property => property.name);
+      const vueInterfaceProperties = vueInterface?.body?.body?.map(property => property.key.name);
+
+      if (fileInterfaceProperties.length > vueInterfaceProperties.length) {
+        return fileInterfaceProperties.reduce((acc, fileInterfaceProperty) => {
+          if (!vueInterfaceProperties.includes(fileInterfaceProperty)) {
+            return {
+              ...acc,
+              [fileInterfaceProperty]: false,
+            };
+          }
+          return acc;
+        }, {});
+      }
+
+      return vueInterfaceProperties.reduce((acc, vueInterfaceProperty) => {
+        if (!fileInterfaceProperties.includes(vueInterfaceProperty)) {
+          return {
+            ...acc,
+            [vueInterfaceProperty]: false,
+          };
+        }
+        return acc;
+      }, {});
+    }
+
     function areInterfacesSame(fileInterface, vueInterface) {
       const fileInterfaceStructure = fileInterface.getStructure();
-      if (fileInterfaceStructure.properties.length !== vueInterface?.body?.body?.length) return false;
+      if (fileInterfaceStructure.properties.length !== vueInterface?.body?.body?.length) {
+        return getDiffProps(fileInterfaceStructure, vueInterface);
+      }
 
       const vueScriptSourceCode = context.getSourceCode().text;
 

--- a/eslint/tests/lib/rules/vue-props-interface.js
+++ b/eslint/tests/lib/rules/vue-props-interface.js
@@ -147,5 +147,30 @@ ruleTester.run('vue-props-interface', rule, {
       },
       errors: [{ message: 'Interface  RadioButtonProps must be defined in script setup', line: 4 }],
     },
+    {
+      filename: 'test.vue',
+      code: `
+      <script setup lang="ts">
+        interface RadioButtonProps {
+          value: string,
+          someExtraProp?: string,
+          modelValue?: string,
+          label?: string,
+          description?: string,
+          isDisabled?: boolean,
+          isTextInline?: boolean,
+          name?: string,
+          errorMessage?: string,
+          hasError?: boolean
+        }
+
+        const props = defineProps<RadioButtonProps>();
+      </script>`,
+      parser: require.resolve('vue-eslint-parser'),
+      parserOptions: {
+        parser: require.resolve('@typescript-eslint/parser'),
+      },
+      errors: [{ message: 'These properties of interface RadioButtonProps are different in test.vue and types.ts: someExtraProp', line: 16 }],
+    },
   ],
 });


### PR DESCRIPTION
If we have the same props in vue file and in the types.ts but one extra prop in one of them, then ESLint rule doesn’t proceed with this situation as an error. We should consider this as an error.