### PR TITLE
[ONL-7579] Refactor defineOptions and defineEmits

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -64,6 +64,7 @@ module.exports = {
     'vue/multiline-html-element-content-newline': 'off',
     'vue/no-restricted-syntax': 'off',
     'vue/one-component-per-file': 'off',
+    'vue/prefer-define-options': ['error'],
     'vue/require-default-prop': 'off',
     'vue/singleline-html-element-content-newline': 'off',
     // TODO: enable a11y rules

--- a/src/components/ec-alert/ec-alert.vue
+++ b/src/components/ec-alert/ec-alert.vue
@@ -67,9 +67,10 @@ import { IconName } from '../ec-icon/types';
 import type { AlertEvents } from './types';
 import { AlertEvent, AlertType } from './types';
 
-const emit = defineEmits<{ (e: 'update:open', value: AlertEvents[AlertEvent.UPDATE_OPEN]): void
-  (e: 'action'): void
-  (e: 'change', value: AlertEvents[AlertEvent.CHANGE]): void
+const emit = defineEmits<{
+  'update:open': [value: AlertEvents[AlertEvent.UPDATE_OPEN]],
+  'action': [],
+  'change': [value: AlertEvents[AlertEvent.CHANGE]],
 }>();
 
 interface AlertProps {

--- a/src/components/ec-amount-input/ec-amount-input.vue
+++ b/src/components/ec-amount-input/ec-amount-input.vue
@@ -16,6 +16,10 @@
 </template>
 
 <script setup>
+defineOptions({
+  inheritAttrs: false,
+});
+
 import { computed, ref, watch } from 'vue';
 
 import VEcAmount from '../../directives/ec-amount/ec-amount';
@@ -141,8 +145,3 @@ watch(() => props.isMasked, (newValue) => {
 });
 </script>
 
-<script>
-export default {
-  inheritAttrs: false,
-};
-</script>

--- a/src/components/ec-btn/ec-btn.vue
+++ b/src/components/ec-btn/ec-btn.vue
@@ -50,13 +50,11 @@
   </component>
 </template>
 
-<script lang="ts">
-export default {
-  inheritAttrs: false,
-};
-</script>
-
 <script setup lang="ts">
+defineOptions({
+  inheritAttrs: false,
+});
+
 import {
   computed,
   useAttrs,

--- a/src/components/ec-checkbox/ec-checkbox.vue
+++ b/src/components/ec-checkbox/ec-checkbox.vue
@@ -81,6 +81,10 @@
 </template>
 
 <script setup>
+defineOptions({
+  inheritAttrs: false,
+});
+
 import {
   computed,
   onMounted,
@@ -154,12 +158,6 @@ function updateIndeterminate(newValue) {
 onMounted(() => {
   updateIndeterminate(props.indeterminate);
 });
-</script>
-
-<script>
-export default {
-  inheritAttrs: false,
-};
 </script>
 
 <style>

--- a/src/components/ec-datepicker/ec-datepicker.vue
+++ b/src/components/ec-datepicker/ec-datepicker.vue
@@ -26,6 +26,10 @@
 </template>
 
 <script setup>
+defineOptions({
+  inheritAttrs: false,
+});
+
 import flatpickr from 'flatpickr';
 import {
   onBeforeUnmount, onMounted, ref, useAttrs, watch,
@@ -356,11 +360,6 @@ function datesAreEqual(date1, date2) {
 }
 </script>
 
-<script>
-export default {
-  inheritAttrs: false,
-};
-</script>
 <style>
 /* We purge the css as a result Flatpickr does not render correctly, because we cannot apply our own classes we need to whitelist the following file */
 

--- a/src/components/ec-dropdown-search/ec-dropdown-search.vue
+++ b/src/components/ec-dropdown-search/ec-dropdown-search.vue
@@ -145,6 +145,10 @@
 </template>
 
 <script setup>
+defineOptions({
+  inheritAttrs: false,
+});
+
 import { useFocusTrap } from '@vueuse/integrations/useFocusTrap';
 import {
   computed, nextTick, ref, toRaw, useSlots, watch,
@@ -579,12 +583,6 @@ function loseFocus() {
     ctaAreaElementFocusable.blur();
   }
 }
-</script>
-
-<script>
-export default {
-  inheritAttrs: false,
-};
 </script>
 
 <style>

--- a/src/components/ec-dropdown/ec-dropdown.vue
+++ b/src/components/ec-dropdown/ec-dropdown.vue
@@ -64,6 +64,10 @@
 </template>
 
 <script setup>
+defineOptions({
+  inheritAttrs: false,
+});
+
 import { computed, ref, useSlots } from 'vue';
 
 import EcDropdownSearch from '../ec-dropdown-search';
@@ -206,12 +210,6 @@ const slots = useSlots();
 function hasSlot(name) {
   return name in slots;
 }
-</script>
-
-<script>
-export default {
-  inheritAttrs: false,
-};
 </script>
 
 <style>

--- a/src/components/ec-input-field/ec-input-field.vue
+++ b/src/components/ec-input-field/ec-input-field.vue
@@ -81,6 +81,10 @@
 </template>
 
 <script setup lang="ts">
+defineOptions({
+  inheritAttrs: false,
+});
+
 import type { StyleValue } from 'vue';
 import {
   computed, ref, useAttrs, watchEffect,
@@ -195,12 +199,6 @@ watchEffect(() => {
 });
 
 defineExpose<InputFieldExpose>({ focus, inputRef });
-</script>
-
-<script lang="ts">
-export default {
-  inheritAttrs: false,
-};
 </script>
 
 <style>

--- a/src/components/ec-input-field/ec-input-field.vue
+++ b/src/components/ec-input-field/ec-input-field.vue
@@ -106,8 +106,9 @@ const config = useConfig();
 const attrs = useAttrs();
 const style = attrs.style as unknown as StyleValue;
 
-const emit = defineEmits<{ (e: 'update:modelValue', value: InputFieldEvents[InputFieldEvent.UPDATE_MODEL_VALUE]): void
-  (e: 'icon-click', value: InputFieldEvents[InputFieldEvent.ICON_CLICK]): void
+const emit = defineEmits<{
+  'update:modelValue': [value: InputFieldEvents[InputFieldEvent.UPDATE_MODEL_VALUE]],
+  'icon-click': [value: InputFieldEvents[InputFieldEvent.ICON_CLICK]],
 }>();
 
 interface InputFieldProps {

--- a/src/components/ec-metroline/ec-metroline.vue
+++ b/src/components/ec-metroline/ec-metroline.vue
@@ -13,8 +13,9 @@ import { provide, reactive, ref } from 'vue';
 import { METROLINE_PROVIDE_KEY, type MetrolineProviderContext } from './provide';
 import type { MetrolineEvent, MetrolineEvents } from './types';
 
-const emit = defineEmits<{ (e: 'change', value: MetrolineEvents[MetrolineEvent.CHANGE]): void
-  (e: 'complete'): void
+const emit = defineEmits<{
+  'change': [value: MetrolineEvents[MetrolineEvent.CHANGE]],
+  'complete': [],
 }>();
 
 const metroline = reactive<MetrolineProviderContext>({

--- a/src/components/ec-navigation-link/ec-navigation-link.vue
+++ b/src/components/ec-navigation-link/ec-navigation-link.vue
@@ -63,13 +63,11 @@
   </a>
 </template>
 
-<script>
-export default {
-  inheritAttrs: false,
-};
-</script>
-
 <script setup>
+defineOptions({
+  inheritAttrs: false,
+});
+
 import EcIcon from '../ec-icon/ec-icon.vue';
 
 defineProps({

--- a/src/components/ec-panel/ec-panel.vue
+++ b/src/components/ec-panel/ec-panel.vue
@@ -76,6 +76,10 @@
 </template>
 
 <script setup>
+defineOptions({
+  inheritAttrs: false,
+});
+
 import { computed, useAttrs, useSlots } from 'vue';
 
 import EcIcon from '../ec-icon';
@@ -110,12 +114,6 @@ function closePanel() {
   emit('update:show', false);
   emit('close');
 }
-</script>
-
-<script>
-export default {
-  inheritAttrs: false,
-};
 </script>
 
 <style>

--- a/src/components/ec-phone-number-input/ec-phone-number-input.vue
+++ b/src/components/ec-phone-number-input/ec-phone-number-input.vue
@@ -180,13 +180,14 @@ const supportedCountries = new Set(Object.keys(countries));
 
 const config = useConfig();
 
-const emit = defineEmits<{ (e: 'update:modelValue', value: PhoneNumberEvents[PhoneNumberEvent.UPDATE_MODEL_VALUE]): void
-  (e: 'change', value: PhoneNumberEvents[PhoneNumberEvent.CHANGE]): void
-  (e: 'focus'): void
-  (e: 'open'): void
-  (e: 'after-open'): void
-  (e: 'country-change', value: PhoneNumberEvents[PhoneNumberEvent.COUNTRY_CHANGE]): void
-  (e: 'phone-number-change', value: PhoneNumberEvents[PhoneNumberEvent.PHONE_NUMBER_CHANGE]): void
+const emit = defineEmits<{
+  'update:modelValue': [value: PhoneNumberEvents[PhoneNumberEvent.UPDATE_MODEL_VALUE]],
+  'change': [value: PhoneNumberEvents[PhoneNumberEvent.CHANGE]],
+  'focus': [],
+  'open': [],
+  'after-open': [],
+  'country-change': [value: PhoneNumberEvents[PhoneNumberEvent.COUNTRY_CHANGE]],
+  'phone-number-change': [value: PhoneNumberEvents[PhoneNumberEvent.PHONE_NUMBER_CHANGE]],
 }>();
 
 interface PhoneNumberProps {

--- a/src/components/ec-popover/ec-popover.vue
+++ b/src/components/ec-popover/ec-popover.vue
@@ -14,13 +14,11 @@
   </fv-dropdown>
 </template>
 
-<script>
-export default {
-  inheritAttrs: false,
-};
-</script>
-
 <script setup>
+defineOptions({
+  inheritAttrs: false,
+});
+
 import { Dropdown as FvDropdown } from 'floating-vue';
 import {
   inject, ref, toRefs, useAttrs,

--- a/src/components/ec-radio-btn-group/ec-radio-btn-group.vue
+++ b/src/components/ec-radio-btn-group/ec-radio-btn-group.vue
@@ -76,7 +76,8 @@ const isInvalid = computed(() => !!props.errorMessage);
 const hasErrorMessage = computed(() => (!!props.errorMessage || !!slots['error-message']));
 const hasLabel = computed(() => (!!props.label || !!slots.label));
 
-const emit = defineEmits<{ (e: 'update:modelValue', value: RadioButtonGroupEvents[RadioButtonGroupEvent.UPDATE_MODEL_VALUE]): void,
+const emit = defineEmits<{
+  'update:modelValue': [value: RadioButtonGroupEvents[RadioButtonGroupEvent.UPDATE_MODEL_VALUE]],
 }>();
 </script>
 

--- a/src/components/ec-radio-btn/ec-radio-btn.vue
+++ b/src/components/ec-radio-btn/ec-radio-btn.vue
@@ -138,7 +138,8 @@ const labelId = `${id}-label`;
 const descriptionId = `${id}-description`;
 const inputRadioRef = ref();
 
-const emit = defineEmits<{ (e: 'update:modelValue', value: RadioButtonEvents[RadioButtonEvent.UPDATE_MODEL_VALUE]): void,
+const emit = defineEmits<{
+  'update:modelValue': [value: RadioButtonEvents[RadioButtonEvent.UPDATE_MODEL_VALUE]],
 }>();
 
 const isChecked = computed(() => props.modelValue === props.value);

--- a/src/components/ec-table-filter/ec-table-filter.vue
+++ b/src/components/ec-table-filter/ec-table-filter.vue
@@ -30,13 +30,11 @@
   </section>
 </template>
 
-<script>
-export default {
-  inheritAttrs: false,
-};
-</script>
-
 <script setup>
+defineOptions({
+  inheritAttrs: false,
+});
+
 import { computed } from 'vue';
 
 const props = defineProps({

--- a/src/components/ec-table-pagination/ec-table-pagination.vue
+++ b/src/components/ec-table-pagination/ec-table-pagination.vue
@@ -98,6 +98,10 @@
 </template>
 
 <script setup>
+defineOptions({
+  inheritAttrs: false,
+});
+
 import { computed } from 'vue';
 
 import { DEFAULT_PAGE_SIZE, PAGE_SIZES } from '../../enums/pagination';
@@ -148,13 +152,6 @@ const pageSizeModel = computed({
 });
 const selectedPageSizeText = computed(() => pageSizeModel.value?.text);
 
-</script>
-
-<script>
-
-export default {
-  inheritAttrs: false,
-};
 </script>
 
 <style>

--- a/src/components/ec-textarea/ec-textarea.vue
+++ b/src/components/ec-textarea/ec-textarea.vue
@@ -66,6 +66,10 @@
 </template>
 
 <script setup>
+defineOptions({
+  inheritAttrs: false,
+});
+
 import { computed, ref } from 'vue';
 
 import useConfig from '../../composables/use-ec-config';
@@ -151,12 +155,6 @@ function focus() {
     textareaRef.value.focus();
   }
 }
-</script>
-
-<script>
-export default {
-  inheritAttrs: false,
-};
 </script>
 
 <style>


### PR DESCRIPTION
There is an issue with Storybook because they are still using Vue 3.2.47, so the new `defineEmits` syntax is not being recognized by the controls and therefore we can't modify emits there because the events section is not being displayed.