### PR TITLE
SECENG-910 Add Aquasec Action

### DIFF
--- a/.github/workflows/aquasec.yaml
+++ b/.github/workflows/aquasec.yaml
@@ -1,0 +1,14 @@
+---
+name: Aquasec
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, reopened, edited]
+jobs:
+  Aquasec:
+    uses: Ebury/seceng/.github/workflows/aquasec-reusable-workflow.yaml@master
+    secrets:
+      AQUA_KEY: ${{ secrets.AQUA_KEY }}
+      AQUA_SECRET: ${{ secrets.AQUA_SECRET }}


### PR DESCRIPTION
This PR aims to include a GH action to integrate Aquasec with GitHub. In this way, security scans will be conducted automatically when a PR is changed, and before merging to master. This actions will not block the repository actions in any way. *NOTE*: You will see some warning messages in the PR. These are related to the lack of items to scan and it is the expected behaviour. Thanks for your understand.