### PR TITLE
[ONL-7921] Fix ec-table migration

### DIFF
--- a/src/components/ec-smart-table/ec-smart-table.spec.js
+++ b/src/components/ec-smart-table/ec-smart-table.spec.js
@@ -110,7 +110,7 @@ describe('EcSmartTable', () => {
     expect(wrapper.findByDataTest('ec-table__row--0').element).toMatchSnapshot();
     await wrapper.findByDataTest('ec-table__row--0').trigger('click');
     expect(onRowClick).toHaveBeenCalledTimes(1);
-    expect(onRowClick).toHaveBeenCalledWith({ data: data.items[0] });
+    expect(onRowClick).toHaveBeenCalledWith({ data: data.items[0], rowIndex: 0 });
   });
 
   describe('#slots', () => {

--- a/src/components/ec-table/ec-table.spec.ts
+++ b/src/components/ec-table/ec-table.spec.ts
@@ -382,9 +382,9 @@ describe('EcTable', () => {
     });
 
     await wrapper.findByDataTest('ec-table__row--0').trigger('click');
-    expect(onRowClick.mock.calls[0]).toEqual([{ data: ['foo', 'bar'] }]);
+    expect(onRowClick.mock.calls[0]).toEqual([{ data: ['foo', 'bar'], rowIndex: 0 }]);
     await wrapper.findByDataTest('ec-table__row--1').trigger('click');
-    expect(onRowClick.mock.calls[1]).toEqual([{ data: ['widgets', 'doodads'] }]);
+    expect(onRowClick.mock.calls[1]).toEqual([{ data: ['widgets', 'doodads'], rowIndex: 1 }]);
   });
 
   it('should render the style with the min-width on each cell of the column that have the prop given', () => {

--- a/src/components/ec-table/ec-table.vue
+++ b/src/components/ec-table/ec-table.vue
@@ -26,7 +26,7 @@
             :key="rowIndex"
             :data-test="`ec-table__row ec-table__row--${rowIndex}`"
             :class="{ 'ec-table__row--is-clickable': !!attrs.onRowClick }"
-            @click="onRowClick({ data: row })"
+            @click="onRowClick({ data: row, rowIndex })"
           >
             <td
               v-if="canShowCustomRow"
@@ -119,7 +119,7 @@ function onSort(column: TableEvents[TableEvent.SORT]) {
   emit('sort', column);
 }
 
-function onRowClick(rowData: { data: unknown }) {
+function onRowClick(rowData: { data: unknown, rowIndex: number }) {
   if (attrs.onRowClick && typeof attrs.onRowClick === 'function') {
     attrs.onRowClick(rowData);
   }


### PR DESCRIPTION
During the migration to TS we removed `rowIndex`, but it shouldn't be removed as it is used to get bene ids on EBO