### PR TITLE
[ONL-7971] Adjust table min width when card component is included

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "2.2.52",
+  "version": "2.2.53",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ebury/chameleon-components",
-      "version": "2.2.52",
+      "version": "2.2.53",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "2.2.52",
+  "version": "2.2.53",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/components/ec-smart-table/__snapshots__/ec-smart-table.spec.js.snap
+++ b/src/components/ec-smart-table/__snapshots__/ec-smart-table.spec.js.snap
@@ -26,7 +26,7 @@ exports[`EcSmartTable #slots should only render custom row if "isCustomRowShown"
           data-test="ec-table-scroll-container"
         >
           <table
-            class="ec-table"
+            class="ec-table tw-table-fixed"
           >
             <!--v-if-->
             <tbody>
@@ -123,7 +123,7 @@ exports[`EcSmartTable #slots should render custom row if window width is lower t
           data-test="ec-table-scroll-container"
         >
           <table
-            class="ec-table"
+            class="ec-table tw-table-fixed"
           >
             <!--v-if-->
             <tbody>

--- a/src/components/ec-table/__snapshots__/ec-table.spec.ts.snap
+++ b/src/components/ec-table/__snapshots__/ec-table.spec.ts.snap
@@ -232,7 +232,7 @@ exports[`EcTable should only render custom row if "isCustomRowShown" is true 1`]
     data-test="ec-table-scroll-container"
   >
     <table
-      class="ec-table"
+      class="ec-table tw-table-fixed"
     >
       <!--v-if-->
       <tbody>
@@ -862,7 +862,7 @@ exports[`EcTable should render custom row if window width is lower than 768px 1`
     data-test="ec-table-scroll-container"
   >
     <table
-      class="ec-table"
+      class="ec-table tw-table-fixed"
     >
       <!--v-if-->
       <tbody>

--- a/src/components/ec-table/ec-table.vue
+++ b/src/components/ec-table/ec-table.vue
@@ -12,6 +12,7 @@
       <table
         :aria-label="title"
         class="ec-table"
+        :class="{ 'tw-table-fixed': canShowCustomRow }"
       >
         <ec-table-head
           v-if="canShowTableHeader"


### PR DESCRIPTION
Adding `table-layout: fixed;` to `ec-table` when custom rows are being shown

> **NOTE**
> In smart table preview there is a scroll caused by pagination. It will be solved when the new pagination responsive design is implemented