### PR TITLE
[ONL-8007] Fix ec-smart-table filter model reactivity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "2.2.53",
+  "version": "2.2.54",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ebury/chameleon-components",
-      "version": "2.2.53",
+      "version": "2.2.54",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "2.2.53",
+  "version": "2.2.54",
   "main": "src/main.js",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/components/ec-smart-table/__snapshots__/ec-smart-table.spec.js.snap
+++ b/src/components/ec-smart-table/__snapshots__/ec-smart-table.spec.js.snap
@@ -560,6 +560,58 @@ exports[`EcSmartTable #slots should render resolved data properly with the heade
 </div>
 `;
 
+exports[`EcSmartTable filtering should change filters when filter prop is changed 1`] = `
+<section
+  class="ec-table-filter"
+  data-test="ec-smart-table__filter ec-table-filter"
+>
+  
+  <div
+    class="ec-table-filter__filter-item tw-mr-8"
+    data-test="ec-table-filter__filter-item ec-table-filter__filter-item-0"
+  >
+    Test 1 (test-value-1)
+  </div>
+  <div
+    class="ec-table-filter__filter-item tw-mr-8"
+    data-test="ec-table-filter__filter-item ec-table-filter__filter-item-1"
+  >
+    Test 2 (N/A)
+  </div>
+  
+  <button
+    class="ec-table-filter__clear-filters-button"
+    data-test="ec-table-filter__clear-filters-button"
+    type="button"
+  >
+    Clear filters
+  </button>
+</section>
+`;
+
+exports[`EcSmartTable filtering should change filters when filter prop is changed 2`] = `
+<section
+  class="ec-table-filter"
+  data-test="ec-smart-table__filter ec-table-filter"
+>
+  
+  <div
+    class="ec-table-filter__filter-item tw-mr-8"
+    data-test="ec-table-filter__filter-item ec-table-filter__filter-item-0"
+  >
+    Test 1 (N/A)
+  </div>
+  <div
+    class="ec-table-filter__filter-item tw-mr-8"
+    data-test="ec-table-filter__filter-item ec-table-filter__filter-item-1"
+  >
+    Test 2 (N/A)
+  </div>
+  
+  <!--v-if-->
+</section>
+`;
+
 exports[`EcSmartTable filtering should handle changes in filters and reload the table data 1`] = `
 <section
   class="ec-table-filter"

--- a/src/components/ec-smart-table/ec-smart-table.spec.js
+++ b/src/components/ec-smart-table/ec-smart-table.spec.js
@@ -582,6 +582,20 @@ describe('EcSmartTable', () => {
       }]);
     });
 
+    it('should change filters when filter prop is changed', async () => {
+      const wrapper = mountEcSmartTable({
+        columns,
+        filters,
+        filter: prefilter,
+      });
+      const tableFiltersElement = wrapper.findByDataTest('ec-smart-table__filter').element;
+      expect(tableFiltersElement).toMatchSnapshot();
+      await wrapper.setProps({
+        filter: {},
+      });
+      expect(tableFiltersElement).toMatchSnapshot();
+    });
+
     it('should reset the page after changes in filters and reload the table data', async () => {
       const wrapper = mountEcSmartTableWithData(lotsOfData, {
         columns,

--- a/src/components/ec-smart-table/ec-smart-table.spec.js
+++ b/src/components/ec-smart-table/ec-smart-table.spec.js
@@ -547,6 +547,29 @@ describe('EcSmartTable', () => {
       }]);
     });
 
+    it('should trigger fetch when filter prop is changed', async () => {
+      const wrapper = mountEcSmartTable({
+        columns,
+        filters,
+        filter: prefilter,
+      });
+      expect(wrapper.emitted('fetch')[0]).toEqual([{
+        filter: prefilter,
+        numberOfItems: 10,
+        page: 1,
+        sorts: [],
+      }]);
+      await wrapper.setProps({
+        filter: {},
+      });
+      expect(wrapper.emitted('fetch')[1]).toEqual([{
+        filter: {},
+        numberOfItems: 10,
+        page: 1,
+        sorts: [],
+      }]);
+    });
+
     it('should handle changes in filters and reload the table data', async () => {
       const wrapper = mountEcSmartTableWithData(data, { columns, filters, filter: prefilter });
       await wrapper.findByDataTest('ec-table-filter__clear-filters-button').trigger('click');

--- a/src/components/ec-smart-table/ec-smart-table.vue
+++ b/src/components/ec-smart-table/ec-smart-table.vue
@@ -196,6 +196,10 @@ watch(() => props.pagination, () => paginate(props.pagination?.page, props.pagin
 const isFilteringEnabled = computed(() => props.filters?.length > 0);
 const filterModel = ref(unref(props.filter) ?? {});
 
+watch(() => props.filter, () => {
+  filterModel.value = props.filter;
+});
+
 function onFilterChanged(filters) {
   paginate(1);
   emit('update:filter', filters);

--- a/src/components/ec-smart-table/ec-smart-table.vue
+++ b/src/components/ec-smart-table/ec-smart-table.vue
@@ -197,7 +197,7 @@ const isFilteringEnabled = computed(() => props.filters?.length > 0);
 const filterModel = ref(unref(props.filter) ?? {});
 
 watch(() => props.filter, () => {
-  filterModel.value = props.filter;
+  filterModel.value = unref(props.filter);
 });
 
 function onFilterChanged(filters) {


### PR DESCRIPTION
It was not possible to update filters using the model from a parent component because it was not reacting to `filter` prop changes