### PR TITLE
[ONL-8121] Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,9 +8,11 @@ updates:
   open-pull-requests-limit: 10
   versioning-strategy: increase
   reviewers:
+  - "corinaper"
   - "jeger-at"
   - "mcibique"
   - "stavros-tomas"
+  - "wolandec"
   ignore:
   - dependency-name: clipboard-copy
     versions:
@@ -18,3 +20,21 @@ updates:
   - dependency-name: cypress
     versions:
     - ">= 10"
+  groups:
+    storybook:
+      patterns:
+        - "@storybook/*"
+        - "storybook*"
+    vueuse:
+      patterns:
+        - "@vueuse/*"
+    stylelint:
+      patterns:
+        - "stylelint*"
+    postcss:
+      patterns:
+        - "postcss*"
+        - "autoprefixer"
+    eslint:
+      patterns:
+        - "eslint*"


### PR DESCRIPTION
This new feature should prevent dependabot to create lots of disconnected PRs, especially when upgrading packages that are interconnected like `@vueuse` or `@storybook`.