### PR TITLE
[SECENG-1371] Add GHA JIRA ref check in PR title

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -5,5 +5,14 @@ on:
 jobs:
   Jira-PR-Title:
     if: ${{ (github.actor != 'dependabot[bot]') && (github.actor != 'EburyCrowdin') }}
-    uses: Ebury/github-tools/.github/workflows/check-pr-title-reusable-workflow.yml@master
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Regex - Check PR Title follows the pattern "[XXXX-0000] (optional text)"
+        run: |
+          if [[ "${{ github.event.pull_request.title }}" =~ ^\[[A-Z]+-[0-9]+\] ]]; then
+            echo "OK"
+          else
+            echo "FAIL - PR title does not follow the pattern [XXXX-0000] (optional text)"
+            exit 1
+          fi
 

--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -1,0 +1,9 @@
+name: GitHub Actions - Check PR Title
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+jobs:
+  Jira-PR-Title:
+    if: ${{ (github.actor != 'dependabot[bot]') && (github.actor != 'EburyCrowdin') }}
+    uses: Ebury/github-tools/.github/workflows/check-pr-title-reusable-workflow.yml@master
+


### PR DESCRIPTION
As part of the audit report [Internal Audit: IT Development Governance](https://drive.google.com/file/d/1id4L4eziY-L_3mM-vJSRSmY8NDiStlOi/view) issued back in May 2023, and in particular recommendation 6.b, we are requested to ensure all GitHub pull requests (PRs) have a linked JIRA ticket to it.

For this reason, we are going to submit a PR to all Ebury repositories creating a GitHub Action that will check there is a JIRA ticket reference on the PR title following format `[JIRA_REF] Some additional text`. As an example: `[SECENG-1111] This is my PR`.
See [GHA source file](https://github.com/Ebury/github-tools/blob/master/.github/workflows/check-pr-title-reusable-workflow.yml) for reference.

**Note:** this means that current branch protections enforcing status checks to pass before merging will block new PRs not following the new formatcomms and ongoing discussion in Slack [here](https://eburydev.slack.com/archives/CFN6BCHGV/p1705486154025919).

This PR has been created by a bot owned by Security Engineering. See it [here](https://github.com/Ebury/seceng/tree/master/projects/github/pr-bot).

[SECENG-1111]: https://fxsolutions.atlassian.net/browse/SECENG-1111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ