### PR TITLE
[ONL-6699] Replaced clipboard-copy with useClipboard.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,9 +14,6 @@ updates:
   - "stavros-tomas"
   - "wolandec"
   ignore:
-  - dependency-name: clipboard-copy
-    versions:
-    - ">= 4"
   - dependency-name: cypress
     versions:
     - ">= 10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@vueuse/core": "10.2.1",
         "@vueuse/integrations": "10.2.1",
-        "clipboard-copy": "3.2.0",
         "flatpickr": "4.6.13",
         "floating-vue": "2.0.0-beta.16",
         "focus-trap": "6.9.4",
@@ -11011,25 +11010,6 @@
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
-    },
-    "node_modules/clipboard-copy": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/clipboard-copy/-/clipboard-copy-3.2.0.tgz",
-      "integrity": "sha512-vooFaGFL6ulEP1liiaWFBmmfuPm3cY3y7T9eB83ZTnYc/oFeAKsq3NcDrOkBC8XaauEE8zHQwI7k0+JSYiVQSQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
     },
     "node_modules/clone": {
       "version": "2.1.2",
@@ -35683,11 +35663,6 @@
           }
         }
       }
-    },
-    "clipboard-copy": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/clipboard-copy/-/clipboard-copy-3.2.0.tgz",
-      "integrity": "sha512-vooFaGFL6ulEP1liiaWFBmmfuPm3cY3y7T9eB83ZTnYc/oFeAKsq3NcDrOkBC8XaauEE8zHQwI7k0+JSYiVQSQ=="
     },
     "clone": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "dependencies": {
     "@vueuse/core": "10.2.1",
     "@vueuse/integrations": "10.2.1",
-    "clipboard-copy": "3.2.0",
     "flatpickr": "4.6.13",
     "floating-vue": "2.0.0-beta.16",
     "focus-trap": "6.9.4",

--- a/src/components/ec-icon/ec-icon.story.ts
+++ b/src/components/ec-icon/ec-icon.story.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryFn } from '@storybook/vue3';
-import copyToClipboard from 'clipboard-copy';
+import { useClipboard } from '@vueuse/core';
 import { computed, defineComponent, ref } from 'vue';
 
 import EcIcon from './ec-icon.vue';
@@ -25,9 +25,8 @@ const EcIconsGrid = defineComponent({
   // eslint-disable-next-line vue/require-prop-types
   props: ['icons', 'size', 'type', 'color', 'borderRadius'],
   setup() {
-    return {
-      copy: copyToClipboard,
-    };
+    const { copy } = useClipboard();
+    return { copy };
   },
   template: `
     <div class="tw-flex tw-flex-wrap" :style="{ fill: color }">

--- a/src/components/ec-inline-input-field/components/copy/copy.vue
+++ b/src/components/ec-inline-input-field/components/copy/copy.vue
@@ -17,6 +17,7 @@
     >
       <ec-icon
         v-ec-tooltip="{
+          delay: 0,
           placement: TooltipPlacement.LEFT,
           shown: isTooltipShown,
           triggers: [TooltipTrigger.MANUAL],
@@ -33,7 +34,7 @@
 </template>
 
 <script setup lang="ts">
-import clipboardCopy from 'clipboard-copy';
+import { useClipboard } from '@vueuse/core';
 import { computed, ref } from 'vue';
 
 import useConfig from '../../../../composables/use-ec-config';
@@ -61,6 +62,8 @@ const props = withDefaults(defineProps<InlineInputCopyProps>(), {
   errorMessage: '',
   isBtnRightAligned: false,
 });
+
+const { copy: clipboardCopy } = useClipboard({ legacy: true });
 
 const tooltipContent = computed(() => (isCopied.value ? props.tooltipTextSuccess : props.tooltipTextError));
 

--- a/tests/mocks/ec-tooltip.mock.ts
+++ b/tests/mocks/ec-tooltip.mock.ts
@@ -1,7 +1,7 @@
 import { vi } from 'vitest';
 import type { ObjectDirective } from 'vue';
 
-import type { TooltipOptions } from '../../src/directives/ec-tooltip/types';
+import type { TooltipOptions, TooltipPlacement, TooltipPopperClass } from '../../src/directives/ec-tooltip/types';
 
 function updateTooltipMock(el: HTMLElement, value: string | TooltipOptions) {
   const dataTest = el.getAttribute('data-test') || '';
@@ -9,16 +9,19 @@ function updateTooltipMock(el: HTMLElement, value: string | TooltipOptions) {
     el.setAttribute('data-test', `${dataTest} ec-mock ec-tooltip-mock`.trim());
   }
 
-  let content = null;
-  let placement = null;
-  let popperClass = null;
+  let content: string | boolean | undefined;
+  let placement: TooltipPlacement | undefined;
+  let popperClass: TooltipPopperClass[] | undefined;
+  let shown: boolean | undefined;
 
   if (typeof value === 'string') {
     content = value;
   }
 
   if (typeof value === 'object' && value) {
-    ({ placement, content, popperClass } = value);
+    ({
+      placement, content, popperClass, shown,
+    } = value);
   }
 
   if (content) {
@@ -38,6 +41,12 @@ function updateTooltipMock(el: HTMLElement, value: string | TooltipOptions) {
     el.removeAttribute('data-ec-tooltip-mock-placement');
     el.removeAttribute('data-ec-tooltip-mock-popper-class');
   }
+
+  if (shown) {
+    el.setAttribute('data-ec-tooltip-mock-popper-shown', '');
+  } else {
+    el.removeAttribute('data-ec-tooltip-mock-popper-shown');
+  }
 }
 
 export const EcTooltipDirectiveMock: ObjectDirective<HTMLElement, string | TooltipOptions> = {
@@ -53,6 +62,7 @@ export const EcTooltipDirectiveMock: ObjectDirective<HTMLElement, string | Toolt
     el.removeAttribute('data-ec-tooltip-mock-content');
     el.removeAttribute('data-ec-tooltip-mock-placement');
     el.removeAttribute('data-ec-tooltip-mock-popper-class');
+    el.removeAttribute('data-ec-tooltip-mock-popper-shown');
   },
 };
 


### PR DESCRIPTION
Replacing clipboard-copy library with implementation builtin in vueuse. There's no need to update EBO this time.