### PR TITLE
[ONL-8253] Fixed type-fest import

### DIFF
--- a/src/components/ec-full-screen-overlay/types.ts
+++ b/src/components/ec-full-screen-overlay/types.ts
@@ -1,4 +1,4 @@
-import { type IntRange } from 'type-fest';
+import type { IntRange } from 'type-fest';
 
 export interface FullScreenOverlayProps {
   title?: string,


### PR DESCRIPTION
A quick fix for import when using full-screen-overlay in webpack app. Not sure why but webpack can't recognise type-fest import if written as `import { type }` and complains about type-fest:

```
Module not found: Error: Can't resolve 'type-fest' in '/home/<user>/code/eburyonline/frontend/node_modules/@ebury/chameleon-components/src/components/ec-full-screen-overlay'
```

Declaring webpack resolve alias in vue.config doesn't help either. It could be that this is the only place where the new lib is used and it doesn't generate any output code so webpack throw it away prematurely and then can't find it???