### PR TITLE
[CHUX-661] Add prop to ec-letter-icon to control hover styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "2.8.9",
+  "version": "2.8.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ebury/chameleon-components",
-      "version": "2.8.9",
+      "version": "2.8.10",
       "license": "MIT",
       "dependencies": {
         "@vueuse/core": "10.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "2.8.9",
+  "version": "2.8.10",
   "main": "src/main.ts",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/components/ec-letter-icon/ec-letter-icon.spec.ts
+++ b/src/components/ec-letter-icon/ec-letter-icon.spec.ts
@@ -70,4 +70,14 @@ describe('EcLetterIcon', () => {
     expect(container.element.tagName).toContain('BUTTON');
     expect(container.classes()).toContain('ec-letter-icon--clickable');
   });
+
+  it('should add hover styles if "applyHoverStyles" prop is set', () => {
+    const wrapper = mountLetterIcon({
+      text: 'Test',
+      applyHoverStyles: true,
+    });
+
+    const container = wrapper.findByDataTest('ec-letter-icon');
+    expect(container.classes()).toContain('ec-letter-icon--hover-styles');
+  });
 });

--- a/src/components/ec-letter-icon/ec-letter-icon.spec.ts
+++ b/src/components/ec-letter-icon/ec-letter-icon.spec.ts
@@ -71,10 +71,10 @@ describe('EcLetterIcon', () => {
     expect(container.classes()).toContain('ec-letter-icon--clickable');
   });
 
-  it('should add hover styles if "applyHoverStyles" prop is set', () => {
+  it('should add hover styles if "isParentHovered" prop is set', () => {
     const wrapper = mountLetterIcon({
       text: 'Test',
-      applyHoverStyles: true,
+      isParentHovered: true,
     });
 
     const container = wrapper.findByDataTest('ec-letter-icon');

--- a/src/components/ec-letter-icon/ec-letter-icon.vue
+++ b/src/components/ec-letter-icon/ec-letter-icon.vue
@@ -6,6 +6,7 @@
     class="ec-letter-icon"
     :class="{
       'ec-letter-icon--clickable': isClickable,
+      'ec-letter-icon--hover-styles': applyHoverStyles,
       [`ec-letter-icon--${size}`]: true,
     }"
   >
@@ -26,6 +27,7 @@ import { type LetterIconProps, LetterIconSize } from './types';
 const props = withDefaults(defineProps<LetterIconProps>(), {
   size: LetterIconSize.SMALL,
   isClickable: false,
+  applyHoverStyles: false,
 });
 
 const firstLetter = computed(() => (props.text[0]?.toUpperCase()));
@@ -55,11 +57,15 @@ const firstLetter = computed(() => (props.text[0]?.toUpperCase()));
     @apply tw-cursor-pointer tw-border-0 tw-p-0;
 
     &:hover {
-      @apply tw-bg-gray-2;
+      @apply ec-letter-icon--hover-styles;
+    }
+  }
 
-      .ec-letter-icon__text {
-        @apply tw-text-gray-7;
-      }
+  &--hover-styles {
+    @apply tw-bg-gray-2;
+
+    .ec-letter-icon__text {
+      @apply tw-text-gray-7;
     }
   }
 }

--- a/src/components/ec-letter-icon/ec-letter-icon.vue
+++ b/src/components/ec-letter-icon/ec-letter-icon.vue
@@ -6,7 +6,7 @@
     class="ec-letter-icon"
     :class="{
       'ec-letter-icon--clickable': isClickable,
-      'ec-letter-icon--hover-styles': applyHoverStyles,
+      'ec-letter-icon--hover-styles': isParentHovered,
       [`ec-letter-icon--${size}`]: true,
     }"
   >
@@ -27,7 +27,7 @@ import { type LetterIconProps, LetterIconSize } from './types';
 const props = withDefaults(defineProps<LetterIconProps>(), {
   size: LetterIconSize.SMALL,
   isClickable: false,
-  applyHoverStyles: false,
+  isParentHovered: false,
 });
 
 const firstLetter = computed(() => (props.text[0]?.toUpperCase()));

--- a/src/components/ec-letter-icon/types.ts
+++ b/src/components/ec-letter-icon/types.ts
@@ -2,6 +2,7 @@ export interface LetterIconProps {
   text: string,
   size?: LetterIconSize,
   isClickable?: boolean,
+  applyHoverStyles?: boolean,
 }
 
 export enum LetterIconSize {

--- a/src/components/ec-letter-icon/types.ts
+++ b/src/components/ec-letter-icon/types.ts
@@ -2,7 +2,7 @@ export interface LetterIconProps {
   text: string,
   size?: LetterIconSize,
   isClickable?: boolean,
-  applyHoverStyles?: boolean,
+  isParentHovered?: boolean,
 }
 
 export enum LetterIconSize {

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,6 +49,8 @@ export { default as EcInlineInputField } from './components/ec-inline-input-fiel
 export * from './components/ec-inline-input-field/types';
 export { default as EcInputField } from './components/ec-input-field';
 export * from './components/ec-input-field/types';
+export { default as EcLetterIcon } from './components/ec-letter-icon';
+export * from './components/ec-letter-icon/types';
 export { default as EcLoading } from './components/ec-loading';
 export * from './components/ec-loading/types';
 export { default as EcLoadingIcon } from './components/ec-loading-icon';


### PR DESCRIPTION
This is needed if we want to keep using good CSS practices in EBO, as it can be done by modifying the styles of the Chameleon component on EBO, but this approach is against best practices.