### PR TITLE
[CHOPS-1072] Adding disableMobile property for flatpickr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "2.8.19",
+  "version": "2.8.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ebury/chameleon-components",
-      "version": "2.8.19",
+      "version": "2.8.20",
       "license": "MIT",
       "dependencies": {
         "@vueuse/core": "10.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "2.8.19",
+  "version": "2.8.20",
   "main": "src/main.ts",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/components/ec-datepicker/ec-datepicker.vue
+++ b/src/components/ec-datepicker/ec-datepicker.vue
@@ -201,6 +201,7 @@ function appendDatepickerHook(existingHook: flatpickr.Options.Hook | flatpickr.O
 function mergeWithDefaultOptions(options: flatpickr.Options.Options): flatpickr.Options.Options {
   const mergedOptions: flatpickr.Options.Options = {
     ...options,
+    disableMobile: true,
     // We need to update the time of "now" every time something changes otherwise flatpickr will only pick it once when imported.
     now: new Date(),
     allowInput: true,


### PR DESCRIPTION
There seems to be an issue with the Flatpickr datetime component. 
As mentioned on their website https://flatpickr.js.org/mobile-support/, this created an issue where the EBO web app on a mobile view displayed 2 datepicker components instead of 1. 

Disabling mobile allows the web app to use the datepicker without the additional native datepicker.