### PR TITLE
[NBL-480]: Update table components to support multi selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "2.8.21",
+  "version": "2.8.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ebury/chameleon-components",
-      "version": "2.8.21",
+      "version": "2.8.22",
       "license": "MIT",
       "dependencies": {
         "@vueuse/core": "10.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "2.8.21",
+  "version": "2.8.22",
   "main": "src/main.ts",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",

--- a/src/components/ec-smart-table-heading/types.ts
+++ b/src/components/ec-smart-table-heading/types.ts
@@ -2,4 +2,5 @@ export interface SmartTableHeadingProps {
   title?: string,
   isResponsive?: boolean,
   hasStretchFilter?: boolean,
+  isSelect?: boolean,
 }

--- a/src/components/ec-smart-table/ec-smart-table.story.ts
+++ b/src/components/ec-smart-table/ec-smart-table.story.ts
@@ -149,6 +149,30 @@ const fakeData: string[][] = [
   ],
 ];
 
+const fakeMultiSelectData: string[][] = [
+  [
+    '1234',
+    'Lorem',
+    'ipsum',
+    'dolor',
+    'sit',
+  ],
+  [
+    '2345',
+    'foo',
+    'bar',
+    'baz',
+    'sit',
+  ],
+  [
+    '3456',
+    'foo',
+    'bar',
+    'baz',
+    'sit',
+  ],
+];
+
 const prefilters: Record<string, Record<string, unknown>> = {
   all: {},
   onlyOverdue: { paymentStatus: [{ text: 'Overdue', value: 'overdue' }], feeType: [{ text: 'Payment', value: 'payment' }] },
@@ -311,6 +335,8 @@ function useSmartTableSetup(args: EcSmartTableStoryProps) {
     }, args.loadingDelay);
   }
 
+  const multiSelectData = ref(fakeMultiSelectData);
+
   return {
     data,
     isFetching,
@@ -322,6 +348,7 @@ function useSmartTableSetup(args: EcSmartTableStoryProps) {
     stretchedFilters,
     selectedFilter,
     infiniteScrollMappedData,
+    multiSelectData,
     getInfiniteScrollMappedData,
     onSort: action('sort'),
     onAbort: action('abort'),
@@ -644,6 +671,83 @@ export const all: EcSmartTableStory = args => ({
             isFilteringEnabled: null,
             prefilter: null,
             isResponsive: false,
+          }"
+          v-on="{
+            fetch: onFetch,
+            sort: onSort,
+            abort: onAbort,
+            error: onError,
+          }">
+          <template #header-actions="{ total, items, error, loading }">
+            <a
+              href="#"
+              v-if="!error && !loading"
+              @click.prevent.stop="onDownload">Download all {{ total }} item(s)</a>
+            <a @click.prevent.stop="execute()" href="#">Reload</a>
+          </template>
+          <template #error="{ errorMessage }">
+            <div class="tw-text-center tw-text-error tw-py-48">
+              <div><ec-icon name="simple-error" :size="48" class="tw-fill-error" /></div>
+              {{ errorMessage }}
+            </div>
+          </template>
+          <template #empty="{ emptyMessage }">
+            <div class="tw-text-center tw-py-48">
+              <div><ec-icon name="simple-info" :size="48" /></div>
+              {{ emptyMessage }}
+            </div>
+          </template>
+          <template #footer><div class="tw-text-right">Custom footer info</div></template>
+          <template #pages="{ page, totalPages, total }">{{ page }}&nbsp;of&nbsp;{{ totalPages }} pages ({{ total }}&nbsp;ipsums)</template>
+        </ec-smart-table>
+      </div>
+    </div>
+    <h2 class="tw-m-24">With multiselect enabled</h2>
+    <div class="tw-flex tw-px-20">
+      <div class="tw-my-auto tw-mx-20 tw-w-full ec-card">
+        <ec-smart-table
+          v-bind="{
+            columns: [
+              {
+                isSelect: true,
+              },
+              {
+                name: 'request-details',
+                title: 'Request details',
+                sortable: true,
+              },
+              {
+                name: 'original-amount',
+                title: 'Original amount',
+                sortable: true,
+              },
+              {
+                name: 'repayment-date',
+                title: 'Repayment date',
+                sortable: true,
+              },
+              {
+                title: 'Status',
+                type: 'icon',
+              },
+            ],
+            data: multiSelectData,
+            totalRecords: data?.total ?? 0,
+            isFetching,
+            error,
+            sortCycle,
+            filters,
+            filter: selectedFilter,
+            loadingDelay: null,
+            failOnFetch: null,
+            fakeData: null,
+            fetchEmptyList: null,
+            isFilteringEnabled: null,
+            prefilter: null,
+            isCustomRowShown: false,
+            isPaginationEnabled: false,
+            isInfiniteScrollEnabled: false,
+            isMultiSelectEnabled: true,
           }"
           v-on="{
             fetch: onFetch,

--- a/src/components/ec-smart-table/ec-smart-table.vue
+++ b/src/components/ec-smart-table/ec-smart-table.vue
@@ -72,10 +72,16 @@
             stickyColumn,
             sorts,
             isCustomRowShown,
+            isMultiSelectEnabled,
+            selectedItems,
+            allItemsSelected,
+            isSelectableCheck,
           }"
           v-on="{
             sort: sortBy,
             rowClick: attrs.onRowClick,
+            selectItem: attrs.onSelectItem,
+            selectAllItems: attrs.onSelectAllItems,
           }"
         >
           <template #default="{ row }" v-if="canShowCustomRow">

--- a/src/components/ec-smart-table/types.ts
+++ b/src/components/ec-smart-table/types.ts
@@ -39,4 +39,8 @@ export interface SmartTableProps<TRow extends ReadonlyArray<unknown>, TAdditiona
   isTotalHidden?: boolean,
   isResponsive?: boolean,
   isInfiniteScrollEnabled?: boolean,
+  isMultiSelectEnabled?: boolean,
+  selectedItems?: string[],
+  allItemsSelected?: boolean,
+  isSelectableCheck?: (itemId: string) => boolean,
 }

--- a/src/components/ec-table-head/ec-table-head.spec.ts
+++ b/src/components/ec-table-head/ec-table-head.spec.ts
@@ -129,4 +129,59 @@ describe('EcTableHead', () => {
 
     expect(wrapper.element).toMatchSnapshot();
   });
+
+  describe('multiselect', () => {
+    const cols = [
+      {
+        isSelect: true,
+      },
+      {
+        name: 'lorem',
+        title: 'Lorem',
+      },
+      {
+        name: 'ipsum',
+        title: 'Ipsum',
+      },
+    ];
+    const onSelectAllItems = vi.fn();
+
+    const selectProps = {
+      columns: cols, isMultiSelectEnabled: true, allItemsSelected: false, hasAnySelectableRows: true,
+    };
+    const selectAttrs = { onSelectAllItems };
+
+    it('should render checkbox as unchecked when multi select is enabled and allItemsSelected is false', () => {
+      const wrapper = mountEcTableHead(selectProps, { attrs: selectAttrs });
+
+      const headerCheckbox = wrapper.findByDataTest('ec-table-head__select');
+      expect(headerCheckbox.exists()).toBe(true);
+      expect(headerCheckbox.findByDataTest('ec-checkbox__check-icon').exists()).toBe(false);
+    });
+
+    it('should render checkbox as checked when multi select is enabled and allItemsSelected is true', () => {
+      const wrapper = mountEcTableHead({ ...selectProps, allItemsSelected: true }, { attrs: selectAttrs });
+
+      const headerCheckbox = wrapper.findByDataTest('ec-table-head__select');
+      expect(headerCheckbox.exists()).toBe(true);
+      expect(headerCheckbox.findByDataTest('ec-checkbox__check-icon').exists()).toBe(true);
+    });
+
+    it('should render checkbox as disabled unchecked when multi select is enabled and hasAnySelectableRows is false', () => {
+      const wrapper = mountEcTableHead({ ...selectProps, hasAnySelectableRows: false }, { attrs: selectAttrs });
+
+      const headerCheckbox = wrapper.findByDataTest('ec-table-head__select');
+      expect(headerCheckbox.exists()).toBe(true);
+      expect(headerCheckbox.findByDataTest('ec-checkbox__check-icon').exists()).toBe(false);
+      expect(headerCheckbox.findByDataTest<HTMLInputElement>('ec-checkbox__input').element.disabled).toBe(true);
+    });
+
+    it('should call onSelectAllItems when toggling the checkbox', () => {
+      const wrapper = mountEcTableHead(selectProps, { attrs: selectAttrs });
+
+      const headerCheckbox = wrapper.findByDataTest('ec-table-head__select');
+      headerCheckbox.findByDataTest('ec-checkbox__input').setValue(true);
+      expect(onSelectAllItems).toHaveBeenCalledWith();
+    });
+  });
 });

--- a/src/components/ec-table-head/ec-table-head.vue
+++ b/src/components/ec-table-head/ec-table-head.vue
@@ -15,7 +15,15 @@
         :colspan="column.span"
         scope="col"
       >
+        <ec-checkbox
+          v-if="props.isMultiSelectEnabled && column.isSelect"
+          :disabled="!props.hasAnySelectableRows"
+          :model-value="props.allItemsSelected"
+          data-test="ec-table-head__select"
+          @update:model-value="onToggleSelectAll()"
+        />
         <span
+          v-else
           class="ec-table-head__cell-wrapper"
           :class="{
             'ec-table-head__cell-wrapper--is-type-icon': column.type === 'icon',
@@ -50,10 +58,11 @@
 </template>
 
 <script setup lang="ts">
-import type { StyleValue } from 'vue';
+import { type StyleValue, useAttrs } from 'vue';
 
 import vEcTooltip from '../../directives/ec-tooltip';
 import type { SortDirection } from '../../enums';
+import EcCheckbox from '../ec-checkbox';
 import EcIcon from '../ec-icon';
 import { IconName, IconType } from '../ec-icon/types';
 import EcTableSort from '../ec-table-sort';
@@ -61,8 +70,11 @@ import type {
   TableHeadColumn, TableHeadEvent, TableHeadEvents, TableHeadProps,
 } from './types';
 
+const attrs = useAttrs();
+
 const emit = defineEmits<{
   'sort': [value: TableHeadEvents[TableHeadEvent.SORT]],
+  'update:modelValue': [],
 }>();
 
 const props = withDefaults(defineProps<TableHeadProps>(), {
@@ -93,6 +105,12 @@ function getStickyColumnClass(colIndex: number): string | undefined {
     return 'ec-table-head__cell--sticky-right';
   }
   return undefined;
+}
+
+function onToggleSelectAll() {
+  if (attrs.onSelectAllItems && typeof attrs.onSelectAllItems === 'function') {
+    attrs.onSelectAllItems();
+  }
 }
 </script>
 

--- a/src/components/ec-table-head/types.ts
+++ b/src/components/ec-table-head/types.ts
@@ -10,7 +10,8 @@ export interface TableHeadColumn {
   tooltip?: string,
   type?: string,
   span?: number,
-  sortCycle?: SortDirectionCycle
+  sortCycle?: SortDirectionCycle,
+  isSelect?: boolean,
 }
 
 export interface TableHeadSort extends Sorting {}
@@ -24,6 +25,9 @@ export interface TableHeadProps {
   columns?: TableHeadColumn[],
   sorts?: TableHeadSort[],
   stickyColumn?: StickyColumnPosition,
+  isMultiSelectEnabled?: boolean,
+  allItemsSelected?: boolean,
+  hasAnySelectableRows?: boolean,
 }
 
 export enum TableHeadEvent {

--- a/src/components/ec-table/ec-table.story.ts
+++ b/src/components/ec-table/ec-table.story.ts
@@ -119,6 +119,8 @@ export const all: EcTableStory = args => ({
       args,
       onSort: action('sort'),
       onRowClick: action('rowClick'),
+      onSelectItem: action('selectItem'),
+      onSelectAllItems: action('selectAllItems'),
     };
   },
   template: `
@@ -205,6 +207,57 @@ export const all: EcTableStory = args => ({
         </ec-table>
       </div>
     </div>
+    <h2 class="tw-m-24">With multi select enabled</h2>
+    <div class="tw-my-auto tw-mx-20 ec-card" style="width: 90vw">
+      <ec-table
+        v-bind="args"
+        :is-multi-select-enabled="true"
+        :columns="[
+          {
+            isSelect: true
+          },
+          {
+            name: 'request-details',
+            title: 'Request details',
+            sortable: true,
+            minWidth: '200px',
+          },
+          {
+            title: 'Status',
+            type: 'icon',
+            tooltip: 'This is info test',
+          },
+          {
+            name: 'long-text',
+            title: 'Text too long to display',
+            maxWidth: '120px',
+          },
+        ]"
+        :data="[
+          [
+            '1',
+            'Lorem',
+            'dolor',
+            'sit amet, consectetur adipiscing elit. Vestibulum eget ultricies turpis',
+          ],
+          [
+            '2',
+            'foo',
+            'baz',
+            'qux',
+          ],
+          [
+            '3',
+            'baz',
+            'foo',
+            'qux',
+          ],
+        ]"
+        v-on="{ sort: onSort, rowClick: onRowClick, selectItem: onSelectItem, selectAllItems: onSelectAllItems }"
+      >
+      </ec-table>
+    </div>
+  </div>
   `,
 });
 

--- a/src/components/ec-table/types.ts
+++ b/src/components/ec-table/types.ts
@@ -13,5 +13,9 @@ export interface TableProps<TRow extends ReadonlyArray<unknown>> {
   stickyColumn?: StickyColumnPosition,
   title?: string,
   isCustomRowShown?: boolean,
-  isTableHeaderHidden?: boolean
+  isTableHeaderHidden?: boolean,
+  isMultiSelectEnabled?: boolean,
+  selectedItems?: string[],
+  allItemsSelected?: boolean,
+  isSelectableCheck?: (itemId: string) => boolean,
 }


### PR DESCRIPTION
Updating the smart-table, table and heading components to allow adding an optional column that contains checkboxes to select things in the table. We should also be able to pass an `isSelectableCheck` function so that we can filter which rows can be selectable. 
** changes to onRowClick behaviour - the `onRowClick` fn should only be called when clicking anywhere in the row besides the checkbox cell - we usually want to open up a details panel when clicking on the row and this makes sure that selecting a row won't also open up that panel.

Using the new props in the activity log table (new Neyes functionality) - without passing `isSelectableCheck`:
![image](https://github.com/user-attachments/assets/feb93e25-9ce8-4bb7-8d02-e4fb85e8da9c)



Using `isSelectableCheck` so only the changes in the table that have a status of 'pending your approval' can be selected:
![image](https://github.com/user-attachments/assets/9d4fdb38-acb9-4c33-908d-d2817682637c)


Check out this PR https://github.com/Ebury/eburyonline/pull/2440 for the full implementation.
