### PR TITLE
[CHOPS-2159] chore: prepare release v.2.8.24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "2.8.22",
+  "version": "2.8.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ebury/chameleon-components",
-      "version": "2.8.22",
+      "version": "2.8.24",
       "license": "MIT",
       "dependencies": {
         "@vueuse/core": "10.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ebury/chameleon-components",
-  "version": "2.8.22",
+  "version": "2.8.24",
   "main": "src/main.ts",
   "sideEffects": false,
   "author": "Ebury Team (http://labs.ebury.rocks/)",


### PR DESCRIPTION
This PR prepares for the release of `v2.8.24`